### PR TITLE
Update package.xml correct icon location

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -24,7 +24,7 @@
   <content>
     <workbench>
       <freecadmin>0.21.0</freecadmin>
-      <icon>Resources/Icons/FreecadNew.svg</icon>
+      <icon>Resources/icons/FreecadNew.svg</icon>
       <subdirectory>./</subdirectory>
       <!-- Optional install of 3rd-party SearchBar to streamline ability to Search and find commands -->
       <depend type="addon" optional="true">SearchBar</depend>


### PR DESCRIPTION
to stop warning from AddonManager:

`Request failed: PySide2.QtNetwork.QNetworkReply.NetworkError.ContentNotFoundError `