### PR TITLE
Allow compatability with Addons containing multiple stylesheets such …

### DIFF
--- a/StyleMapping_Ribbon.py
+++ b/StyleMapping_Ribbon.py
@@ -93,7 +93,7 @@ def DarkMode():
     # Go through the sub-folders
     for root, dirs, files in os.walk(path):
         for name in dirs:
-            # if the current stylesheet matches a sub directory, try to geth the pacakgexml
+            # if the current stylesheet matches a sub directory, try to geth the packagexml
             if currentStyleSheet.replace(".qss", "").lower() in name.lower():
                 try:
                     packageXML = os.path.join(path, name, "package.xml")
@@ -114,8 +114,11 @@ def DarkMode():
                         if "dark" in element.text.lower():
                             IsDarkTheme = True
                             break
+
                 except Exception:
-                    continue
+                    if not os.path.isfile(packageXML):
+                        if "dark" in currentStyleSheet.lower():
+                            IsDarkTheme = True
 
     return IsDarkTheme
 


### PR DESCRIPTION
…as _[FreeCAD-themes](https://github.com/FreeCAD/FreeCAD-themes)_
Unfortunately when Addons with multiple stylesheets have the `package.xml` in the root and not alongside each of the qss files.