### PR TITLE
Release v1.9.0

### DIFF
--- a/FCBinding.py
+++ b/FCBinding.py
@@ -181,7 +181,9 @@ class ModernMenu(RibbonBar):
     # Create an offset for the panelheight
     PanelHeightOffset = 36
     # Create an offset for the whole ribbon height
-    RibbonOffset = 50 + QuickAccessButtonSize * 2  # Set to zero to hide the panel titles
+    RibbonOffset = (
+        50 + QuickAccessButtonSize * 2
+    )  # Set to zero to hide the panel titles
 
     # Set the minimum height for the ribbon
     RibbonMinimalHeight = QuickAccessButtonSize * 2 + 16
@@ -315,8 +317,13 @@ class ModernMenu(RibbonBar):
             ]
         else:
             try:
-                if "Views - Ribbon_newPanel" in self.ribbonStructure["newPanels"]["Global"]:
-                    del self.ribbonStructure["newPanels"]["Global"]["Views - Ribbon_newPanel"]
+                if (
+                    "Views - Ribbon_newPanel"
+                    in self.ribbonStructure["newPanels"]["Global"]
+                ):
+                    del self.ribbonStructure["newPanels"]["Global"][
+                        "Views - Ribbon_newPanel"
+                    ]
             except Exception:
                 pass
         # # Add a toolbar "tools"
@@ -326,11 +333,14 @@ class ModernMenu(RibbonBar):
         try:
             NeedsUpdating = False
             if "Tools_newPanel" in self.ribbonStructure["newPanels"]["Global"]:
-                for item in self.ribbonStructure["newPanels"]["Global"]["Tools_newPanel"]:
+                for item in self.ribbonStructure["newPanels"]["Global"][
+                    "Tools_newPanel"
+                ]:
                     if item[1] != "Standard":
                         NeedsUpdating = True
             if (
-                "Tools_newPanel" not in self.ribbonStructure["newPanels"]["Global"] and UseToolsPanel is True
+                "Tools_newPanel" not in self.ribbonStructure["newPanels"]["Global"]
+                and UseToolsPanel is True
             ) or NeedsUpdating is True:
                 StandardFunctions.add_keys_nested_dict(
                     self.ribbonStructure,
@@ -399,7 +409,9 @@ class ModernMenu(RibbonBar):
 
         # Get the address of the repository address
         PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
-        self.ReproAdress = StandardFunctions.ReturnXML_Value(PackageXML, "url", "type", "repository")
+        self.ReproAdress = StandardFunctions.ReturnXML_Value(
+            PackageXML, "url", "type", "repository"
+        )
         if self.ReproAdress != "" or self.ReproAdress is not None:
             print(translate("FreeCAD Ribbon", "FreeCAD Ribbon: ") + self.ReproAdress)
 
@@ -409,7 +421,9 @@ class ModernMenu(RibbonBar):
                 for WorkBenchName in self.ribbonStructure["newPanels"]:
                     for NewPanel in self.ribbonStructure["newPanels"][WorkBenchName]:
                         # Get the commands from the custom panel
-                        Commands = self.ribbonStructure["newPanels"][WorkBenchName][NewPanel]
+                        Commands = self.ribbonStructure["newPanels"][WorkBenchName][
+                            NewPanel
+                        ]
 
                         # Get the command and its original toolbar
                         for CommandItem in Commands:
@@ -431,9 +445,15 @@ class ModernMenu(RibbonBar):
         # Activate the workbenches used in the dropdown buttons otherwise the button stays empty
         try:
             if "dropdownButtons" in self.ribbonStructure:
-                for DropDownCommand, Commands in self.ribbonStructure["dropdownButtons"].items():
+                for DropDownCommand, Commands in self.ribbonStructure[
+                    "dropdownButtons"
+                ].items():
                     for CommandItem in Commands:
-                        if CommandItem[1] != "General" and CommandItem[1] != "Global" and CommandItem[1] != "Standard":
+                        if (
+                            CommandItem[1] != "General"
+                            and CommandItem[1] != "Global"
+                            and CommandItem[1] != "Standard"
+                        ):
                             # Activate the workbench if not loaded
                             Gui.activateWorkbench(CommandItem[1])
         except Exception as e:
@@ -452,11 +472,15 @@ class ModernMenu(RibbonBar):
             Branch = "main"
             File = "package.xml"
             ElementName = "version"
-            LatestVersion = StandardFunctions.ReturnXML_Value_Git(User, Repo, Branch, File, ElementName)
+            LatestVersion = StandardFunctions.ReturnXML_Value_Git(
+                User, Repo, Branch, File, ElementName
+            )
             if LatestVersion is not None:
                 # Get the current version
                 PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
-                CurrentVersion = StandardFunctions.ReturnXML_Value(PackageXML, "version")
+                CurrentVersion = StandardFunctions.ReturnXML_Value(
+                    PackageXML, "version"
+                )
                 # Check if you are on a developer version. If so set developer version
                 if CurrentVersion.lower().endswith("x"):
                     self.DeveloperVersion = CurrentVersion
@@ -489,15 +513,29 @@ class ModernMenu(RibbonBar):
         StyleSheet = Path(Parameters_Ribbon.STYLESHEET).read_text()
         # modify the stylesheet to set the border and background for a toolbar and menu
         hexColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
-        hexColorTab = StyleMapping_Ribbon.ReturnStyleItem("Background_Color", True, True)
-        if hexColor is not None and hexColor != "" and Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True:
+        hexColorTab = StyleMapping_Ribbon.ReturnStyleItem(
+            "Background_Color", True, True
+        )
+        if (
+            hexColor is not None
+            and hexColor != ""
+            and Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True
+        ):
             # Set the quickaccess toolbar background color. This fixes a transparant toolbar.
-            self.quickAccessToolBar().setStyleSheet("QToolBar {background: " + hexColor + ";}")
+            self.quickAccessToolBar().setStyleSheet(
+                "QToolBar {background: " + hexColor + ";}"
+            )
             self.tabBar().setStyleSheet("background: " + hexColorTab + ";")
             # Set the background color. This fixes transparant backgrounds when FreeCAD has no stylesheet
-            StyleSheet_Addition = "\n\nQToolButton {background: solid " + hexColor + ";}"
+            StyleSheet_Addition = (
+                "\n\nQToolButton {background: solid " + hexColor + ";}"
+            )
             StyleSheet_Addition_2 = (
-                "\n\nRibbonBar {border: none;background: solid " + hexColor + ";color: " + hexColor + ";}"
+                "\n\nRibbonBar {border: none;background: solid "
+                + hexColor
+                + ";color: "
+                + hexColor
+                + ";}"
             )
             StyleSheet = StyleSheet_Addition_2 + StyleSheet + StyleSheet_Addition
         self.setStyleSheet(StyleSheet)
@@ -507,9 +545,13 @@ class ModernMenu(RibbonBar):
             StyleSheet_Addition_3 = (
                 """QTabBar::tab {
                     background: """
-                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color_Hover", True, True)
+                + StyleMapping_Ribbon.ReturnStyleItem(
+                    "Background_Color_Hover", True, True
+                )
                 + """;color: """
-                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color_Hover", True, True)
+                + StyleMapping_Ribbon.ReturnStyleItem(
+                    "Background_Color_Hover", True, True
+                )
                 + """;min-width: """
                 + str(self.TabBar_Size)
                 + """px;
@@ -582,7 +624,9 @@ class ModernMenu(RibbonBar):
         self.tabBar().tabBarClicked.connect(self.onTabBarClicked)
 
         # override the default scroll behavior with a custom function
-        self.tabBar().wheelEvent = lambda event_tabBar: self.wheelEvent_TabBar(event_tabBar)
+        self.tabBar().wheelEvent = lambda event_tabBar: self.wheelEvent_TabBar(
+            event_tabBar
+        )
         self.wheelEvent = lambda event_CC: self.wheelEvent_CC(event_CC)
         self.tabBar().setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.currentCategory().setFocusPolicy(Qt.FocusPolicy.StrongFocus)
@@ -595,12 +639,20 @@ class ModernMenu(RibbonBar):
         ScrollLeftButton_Tab: QToolButton = self.tabBar().findChildren(QToolButton)[0]
         ScrollRightButton_Tab: QToolButton = self.tabBar().findChildren(QToolButton)[1]
         # get the icons
-        ScrollLeftButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab")
-        ScrollRightButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab")
+        ScrollLeftButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem(
+            "ScrollLeftButton_Tab"
+        )
+        ScrollRightButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem(
+            "ScrollRightButton_Tab"
+        )
         # Set the icons
         StyleSheet = "QToolButton {image: none;margin-top:6px;margin-bottom:6px;};QToolButton::arrow {image: none};"
         BackgroundColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
-        if int(App.Version()[0]) == 0 and int(App.Version()[1]) <= 21 and BackgroundColor is not None:
+        if (
+            int(App.Version()[0]) == 0
+            and int(App.Version()[1]) <= 21
+            and BackgroundColor is not None
+        ):
             StyleSheet = (
                 """QToolButton {image: none;background: """
                 + BackgroundColor
@@ -610,7 +662,9 @@ class ModernMenu(RibbonBar):
             ScrollLeftButton_Tab.setStyleSheet(StyleSheet)
             ScrollLeftButton_Tab.setIcon(ScrollLeftButton_Tab_Icon)
         else:
-            ScrollRightButton_Tab.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+            ScrollRightButton_Tab.setToolButtonStyle(
+                Qt.ToolButtonStyle.ToolButtonTextOnly
+            )
         if ScrollRightButton_Tab_Icon is not None:
             ScrollRightButton_Tab.setStyleSheet(StyleSheet)
             ScrollRightButton_Tab.setIcon(ScrollRightButton_Tab_Icon)
@@ -618,9 +672,13 @@ class ModernMenu(RibbonBar):
             ScrollRightButton_Tab.setArrowType(Qt.ArrowType.RightArrow)
 
         # Remove persistant toolbars
-        PersistentToolbars = App.ParamGet("User parameter:Tux/PersistentToolbars/User").GetGroups()
+        PersistentToolbars = App.ParamGet(
+            "User parameter:Tux/PersistentToolbars/User"
+        ).GetGroups()
         for Group in PersistentToolbars:
-            Parameter = App.ParamGet("User parameter:Tux/PersistentToolbars/User/" + Group)
+            Parameter = App.ParamGet(
+                "User parameter:Tux/PersistentToolbars/User/" + Group
+            )
             Parameter.SetString("Top", "")
             Parameter.SetString("Left", "")
             Parameter.SetString("Right", "")
@@ -631,7 +689,9 @@ class ModernMenu(RibbonBar):
         # Application menu
         ShortcutKey = "Alt+A"
         try:
-            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+            CustomShortCuts = App.ParamGet(
+                "User parameter:BaseApp/Preferences/Shortcut"
+            )
             if "Ribbon_Menu" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Menu")
         except Exception:
@@ -648,7 +708,10 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().enterEvent = lambda enter: self.leaveEvent(enter)
 
         # Rearrange the tabbar and toolbars
-        if Parameters_Ribbon.TOOLBAR_POSITION == 0 or Parameters_Ribbon.TOOLBAR_POSITION == 1:
+        if (
+            Parameters_Ribbon.TOOLBAR_POSITION == 0
+            or Parameters_Ribbon.TOOLBAR_POSITION == 1
+        ):
             # Get the widgets
             _quickAccessToolBarWidget = self.quickAccessToolBar()
             _titleLabel = self._titleWidget._titleLabel
@@ -666,24 +729,38 @@ class ModernMenu(RibbonBar):
                 _titleLabel.setAlignment(Qt.AlignmentFlag.AlignCenter)
                 _titleLabel.setFont(font)
                 # Set the label text to FreeCAD's version
-                text = f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
+                text = (
+                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
+                )
                 _titleLabel.setText(text)
                 # Create a spacer to set the tab
                 spacer = QWidget()
-                spacer.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
+                spacer.setSizePolicy(
+                    QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
+                )
                 spacer.setFixedWidth(3)
                 self._titleWidget._tabBarLayout.setContentsMargins(3, 3, 3, 0)
                 self._titleWidget._tabBarLayout.addWidget(
                     _quickAccessToolBarWidget, 0, 0, 1, 2, Qt.AlignmentFlag.AlignVCenter
                 )
-                self._titleWidget._tabBarLayout.addWidget(_titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter)
-                self._titleWidget._tabBarLayout.addWidget(_rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter)
-                self._titleWidget._tabBarLayout.addWidget(spacer, 1, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter)
-                self._titleWidget._tabBarLayout.addWidget(_tabBar, 1, 1, 1, 4, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(
+                    _titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter
+                )
+                self._titleWidget._tabBarLayout.addWidget(
+                    _rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter
+                )
+                self._titleWidget._tabBarLayout.addWidget(
+                    spacer, 1, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter
+                )
+                self._titleWidget._tabBarLayout.addWidget(
+                    _tabBar, 1, 1, 1, 4, Qt.AlignmentFlag.AlignVCenter
+                )
                 # Change the offsets
                 self.RibbonMinimalHeight = self.QuickAccessButtonSize * 2 + 20
                 self.RibbonOffset = 54 + self.QuickAccessButtonSize * 2
-                self._titleWidget._tabBarLayout.setRowMinimumHeight(0, self.QuickAccessButtonSize)
+                self._titleWidget._tabBarLayout.setRowMinimumHeight(
+                    0, self.QuickAccessButtonSize
+                )
                 self._titleWidget._tabBarLayout.setRowMinimumHeight(1, self.TabBar_Size)
                 # self.setTitle("FreeCAD")
             if Parameters_Ribbon.TOOLBAR_POSITION == 1:  # Toolbars inline with tabbar
@@ -691,13 +768,21 @@ class ModernMenu(RibbonBar):
                 self._titleWidget._tabBarLayout.addWidget(
                     _quickAccessToolBarWidget, 0, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter
                 )
-                self._titleWidget._tabBarLayout.addWidget(_tabBar, 0, 1, 1, 1, Qt.AlignmentFlag.AlignVCenter)
-                self._titleWidget._tabBarLayout.addWidget(_titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter)
-                self._titleWidget._tabBarLayout.addWidget(_rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(
+                    _tabBar, 0, 1, 1, 1, Qt.AlignmentFlag.AlignVCenter
+                )
+                self._titleWidget._tabBarLayout.addWidget(
+                    _titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter
+                )
+                self._titleWidget._tabBarLayout.addWidget(
+                    _rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter
+                )
                 # Change the offsets
                 self.RibbonMinimalHeight = self.QuickAccessButtonSize + 10
                 self.RibbonOffset = 46 + self.QuickAccessButtonSize
-                self._titleWidget._tabBarLayout.setRowMinimumHeight(0, self.QuickAccessButtonSize)
+                self._titleWidget._tabBarLayout.setRowMinimumHeight(
+                    0, self.QuickAccessButtonSize
+                )
 
         # Install an event filter to catch events from the main window and act on it.
         mw.installEventFilter(EventInspector(mw))
@@ -728,7 +813,10 @@ class ModernMenu(RibbonBar):
         TB.show()
         # In FreeCAD 1.0, Overlays are introduced. These have also an enterEvent which results in strange behavior
         # Therefore this function is only activated when FreeCAD's overlay function is disabled.
-        if Parameters_Ribbon.SHOW_ON_HOVER is True and Parameters_Ribbon.USE_FC_OVERLAY is False:
+        if (
+            Parameters_Ribbon.SHOW_ON_HOVER is True
+            and Parameters_Ribbon.USE_FC_OVERLAY is False
+        ):
             self.UnfoldRibbon()
             return
 
@@ -740,7 +828,9 @@ class ModernMenu(RibbonBar):
     # implementation to add actions to the Filemenu. Needed for the accessories menu
     def addAction(self, action: QAction):
         menu = self.findChild(RibbonMenu, "Ribbon")
-        StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+        StyleSheet_Menu = (
+            "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+        )
         menu.setStyleSheet(StyleSheet_Menu)
         if menu is None:
             menu = self.addFileMenu()
@@ -821,7 +911,9 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().setContentsMargins(0, 0, 9, 0)
         # Set the size of the menu button
         self.applicationOptionButton().setFixedSize(
-            self.QuickAccessButtonSize + FontMetrics.boundingRect(Text.text()).width() + 12,
+            self.QuickAccessButtonSize
+            + FontMetrics.boundingRect(Text.text()).width()
+            + 12,
             self.QuickAccessButtonSize,
         )
         # Set the icon
@@ -830,19 +922,24 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().setStyleSheet(
             StyleMapping_Ribbon.ReturnStyleSheet(
                 "applicationbutton",
-                padding_right=str(FontMetrics.horizontalAdvance(Text.text(), -1) + 12) + "px",
+                padding_right=str(FontMetrics.horizontalAdvance(Text.text(), -1) + 12)
+                + "px",
                 radius="4px",
             )
         )
         # Add the default tooltip
-        self.applicationOptionButton().setToolTip(translate("FreeCAD Ribbon", "FreeCAD Ribbon"))
+        self.applicationOptionButton().setToolTip(
+            translate("FreeCAD Ribbon", "FreeCAD Ribbon")
+        )
 
         # add the menus from the menubar to the application button
         self.ApplicationMenus()
 
         # add quick access buttons
         i = 1  # Start value for button count. Used for width of quickaccess toolbar
-        toolBarWidth = ((self.QuickAccessButtonSize * self.sizeFactor) * i) + self.applicationOptionButton().width()
+        toolBarWidth = (
+            (self.QuickAccessButtonSize * self.sizeFactor) * i
+        ) + self.applicationOptionButton().width()
         for commandName in self.ribbonStructure["quickAccessCommands"]:
             i = i + 1
             # Define a width
@@ -874,7 +971,11 @@ class ModernMenu(RibbonBar):
                         height = self.QuickAccessButtonSize
                         button.setFixedSize(width, height)
                         # Set the stylesheet
-                        button.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", f"{padding}px"))
+                        button.setStyleSheet(
+                            StyleMapping_Ribbon.ReturnStyleSheet(
+                                "toolbutton", "2px", f"{padding}px"
+                            )
+                        )
                     elif len(QuickAction) > 1:
                         # set the padding for a dropdown button
                         padding = self.PaddingRight
@@ -886,9 +987,15 @@ class ModernMenu(RibbonBar):
                         height = self.QuickAccessButtonSize
                         button.setFixedSize(width, height)
                         # Set the PopupMode
-                        button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+                        button.setPopupMode(
+                            QToolButton.ToolButtonPopupMode.InstantPopup
+                        )
                         # Set the stylesheet
-                        button.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", f"{padding}px"))
+                        button.setStyleSheet(
+                            StyleMapping_Ribbon.ReturnStyleSheet(
+                                "toolbutton", "2px", f"{padding}px"
+                            )
+                        )
 
                 # If it is a custom dropdown, add the actions one by one.
                 if commandName.endswith("_ddb") is True:
@@ -910,7 +1017,9 @@ class ModernMenu(RibbonBar):
 
                     # Set the stylesheet
                     button.setStyleSheet(
-                        StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", padding_right=f"{padding}px")
+                        StyleMapping_Ribbon.ReturnStyleSheet(
+                            "toolbutton", "2px", padding_right=f"{padding}px"
+                        )
                     )
 
                 # Set the height
@@ -922,7 +1031,9 @@ class ModernMenu(RibbonBar):
                 if len(button.actions()) > 0:
                     self.addQuickAccessButton(button)
                 else:
-                    StandardFunctions.Print(f"{commandName} did not contain any actions!", "Log")
+                    StandardFunctions.Print(
+                        f"{commandName} did not contain any actions!", "Log"
+                    )
 
                 toolBarWidth = toolBarWidth + width
             except Exception as e:
@@ -938,7 +1049,9 @@ class ModernMenu(RibbonBar):
         # Set the width of the quickaccess toolbar.
         self.quickAccessToolBar().setMinimumWidth(toolBarWidth)
         # Set the size policy
-        self.quickAccessToolBar().setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.MinimumExpanding)
+        self.quickAccessToolBar().setSizePolicy(
+            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.MinimumExpanding
+        )
         # needed for excluding from hiding toolbars
         self.quickAccessToolBar().setObjectName("quickAccessToolBar")
         self.quickAccessToolBar().setWindowTitle("quickAccessToolBar")
@@ -950,17 +1063,23 @@ class ModernMenu(RibbonBar):
         self.tabBar().setFont(font)
 
         self.tabBar().setIconSize(QSize(self.TabBar_Size - 6, self.TabBar_Size - 6))
-        self.tabBar().setStyleSheet("margin: 0px;padding: 0px;height: " + str(self.TabBar_Size) + ";")
+        self.tabBar().setStyleSheet(
+            "margin: 0px;padding: 0px;height: " + str(self.TabBar_Size) + ";"
+        )
 
         # Correct colors when no stylesheet is selected for FreeCAD.
         self.quickAccessToolBar().setStyleSheet("")
         if Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True:
-            FreeCAD_preferences = App.ParamGet("User parameter:BaseApp/Preferences/MainWindow")
+            FreeCAD_preferences = App.ParamGet(
+                "User parameter:BaseApp/Preferences/MainWindow"
+            )
             currentStyleSheet = FreeCAD_preferences.GetString("StyleSheet")
             if currentStyleSheet == "":
                 hexColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
                 # Set the quickaccess toolbar background color
-                self.quickAccessToolBar().setStyleSheet("background-color: " + hexColor + ";")
+                self.quickAccessToolBar().setStyleSheet(
+                    "background-color: " + hexColor + ";"
+                )
 
         # Get the order of workbenches from Parameters
         WorkbenchOrderedList: list = Parameters_Ribbon.TAB_ORDER.split(",")
@@ -976,7 +1095,10 @@ class ModernMenu(RibbonBar):
         # There is an issue with the internal assembly wb showing the wrong panel
         # when assembly4 wb is installed and positioned for the internal assembly wb
         for i in range(len(WorkbenchOrderedList)):
-            if WorkbenchOrderedList[i] == "Assembly4Workbench" or WorkbenchOrderedList[i] == "Assembly3Workbench":
+            if (
+                WorkbenchOrderedList[i] == "Assembly4Workbench"
+                or WorkbenchOrderedList[i] == "Assembly3Workbench"
+            ):
                 try:
                     index_1 = WorkbenchOrderedList.index(WorkbenchOrderedList[i])
                     index_2 = WorkbenchOrderedList.index("AssemblyWorkbench")
@@ -1016,10 +1138,14 @@ class ModernMenu(RibbonBar):
                             icon: QIcon = self.ReturnWorkbenchIcon(workbenchName)
                             self.tabBar().setTabIcon(len(self.categories()) - 1, icon)
                         if Parameters_Ribbon.TABBAR_STYLE == 2:
-                            self.tabBar().setTabIcon(len(self.categories()) - 1, QIcon())
+                            self.tabBar().setTabIcon(
+                                len(self.categories()) - 1, QIcon()
+                            )
 
                         # Set the tab data
-                        self.tabBar().setTabData(len(self.categories()) - 1, workbenchName)
+                        self.tabBar().setTabData(
+                            len(self.categories()) - 1, workbenchName
+                        )
 
                         # Set the tooltip
                         MenuText = workbench.MenuText
@@ -1028,14 +1154,20 @@ class ModernMenu(RibbonBar):
                             ToolTipText.lower() != MenuText.lower() + " workbench"
                             and MenuText.lower() != ToolTipText.lower()
                         ):
-                            MenuText = f"<b>{workbench.MenuText}</b><br>{workbench.ToolTip}"
+                            MenuText = (
+                                f"<b>{workbench.MenuText}</b><br>{workbench.ToolTip}"
+                            )
                         else:
                             MenuText = f"<b>{MenuText}<b>"
 
-                        self.tabBar().setTabToolTip(len(self.categories()) - 1, MenuText)
+                        self.tabBar().setTabToolTip(
+                            len(self.categories()) - 1, MenuText
+                        )
 
         # Set the size of the collapseRibbonButton
-        self.collapseRibbonButton().setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
+        self.collapseRibbonButton().setFixedSize(
+            self.RightToolBarButtonSize, self.RightToolBarButtonSize
+        )
 
         # add the searchbar if available
         SearchBarWidth = self.AddSearchBar()
@@ -1053,10 +1185,18 @@ class ModernMenu(RibbonBar):
         if self.OverlayMenu is not None:
             OverlayMenu = QToolButton()
             OverlayMenu.setIcon(QIcon(os.path.join(pathIcons, "Draft_Layer.svg")))
-            OverlayMenu.setToolTip(translate("FreeCAD Ribbon", "Overlay functions") + "...")
+            OverlayMenu.setToolTip(
+                translate("FreeCAD Ribbon", "Overlay functions") + "..."
+            )
             OverlayMenu.setMenu(self.OverlayMenu)
-            OverlayMenu.setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
-            OverlayMenu.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px"))
+            OverlayMenu.setFixedSize(
+                self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
+            )
+            OverlayMenu.setStyleSheet(
+                StyleMapping_Ribbon.ReturnStyleSheet(
+                    control="toolbutton", padding_right="12px"
+                )
+            )
             OverlayMenu.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
             Font = OverlayMenu.font()
             Font.setPixelSize(Parameters_Ribbon.FONTSIZE_MENUS)
@@ -1094,31 +1234,47 @@ class ModernMenu(RibbonBar):
         SettingsMenu.addAction(self.RibbonMenu.menuAction())
         SettingsMenu.setIcon(Gui.getIcon("Std_DlgParameter.svg"))
         SettingsMenu.setToolTip(translate("FreeCAD Ribbon", "Preferences") + "...")
-        SettingsMenu.setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
-        SettingsMenu.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px"))
+        SettingsMenu.setFixedSize(
+            self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
+        )
+        SettingsMenu.setStyleSheet(
+            StyleMapping_Ribbon.ReturnStyleSheet(
+                control="toolbutton", padding_right="12px"
+            )
+        )
         SettingsMenu.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         # add the settingsmenu to the right toolbar
         self.rightToolBar().addWidget(SettingsMenu)
 
         # Set the helpbutton
         self.helpRibbonButton().setEnabled(True)
-        self.helpRibbonButton().setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self.helpRibbonButton().setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
         self.helpRibbonButton().setToolTip(translate("FreeCAD Ribbon", "Help") + "...")
         # Get the default help action from FreeCAD
         helpMenu = mw.findChildren(QMenu, "&Help")[0]
         helpAction = helpMenu.actions()[0]
         self.helpRibbonButton().setIcon(helpAction.icon())
         self.helpRibbonButton().setMenu(self.HelpMenu)
-        self.helpRibbonButton().setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
-        self.helpRibbonButton().setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px")
+        self.helpRibbonButton().setFixedSize(
+            self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
         )
-        self.helpRibbonButton().setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+        self.helpRibbonButton().setStyleSheet(
+            StyleMapping_Ribbon.ReturnStyleSheet(
+                control="toolbutton", padding_right="12px"
+            )
+        )
+        self.helpRibbonButton().setPopupMode(
+            QToolButton.ToolButtonPopupMode.InstantPopup
+        )
 
         # Add a button the enable or disable AutoHide
         pinButton = QToolButton()
         pinButton.setCheckable(True)
-        pinButton.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        pinButton.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
         pinButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
         # Set the correct icon
         if Parameters_Ribbon.AUTOHIDE_RIBBON is True:
@@ -1136,10 +1292,14 @@ class ModernMenu(RibbonBar):
             pinButton.setChecked(False)
         if Parameters_Ribbon.AUTOHIDE_RIBBON is False:
             pinButton.setChecked(True)
-        pinButton.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px"))
+        pinButton.setStyleSheet(
+            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px")
+        )
         ShortcutKey = "Alt+T"
         try:
-            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+            CustomShortCuts = App.ParamGet(
+                "User parameter:BaseApp/Preferences/Shortcut"
+            )
             if "Ribbon_Pin" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Pin")
             if ShortcutKey != "" and ShortcutKey is not None:
@@ -1147,13 +1307,16 @@ class ModernMenu(RibbonBar):
         except Exception:
             pass
         # Set the tooltip
-        ToolTip = translate("FreeCAD Ribbon", "Click to toggle the autohide function on or off")
+        ToolTip = translate(
+            "FreeCAD Ribbon", "Click to toggle the autohide function on or off"
+        )
         if ShortcutKey != "none":
             ToolTip = ToolTip + f"<br></br><i>{ShortcutKey}</i>"
         pinButton.setToolTip(
             translate(
                 "FreeCAD Ribbon",
-                "Click to toggle the autohide function on or off" + f"<br></br><i>{ShortcutKey}</i>",
+                "Click to toggle the autohide function on or off"
+                + f"<br></br><i>{ShortcutKey}</i>",
             )
         )
 
@@ -1187,9 +1350,13 @@ class ModernMenu(RibbonBar):
                     padding_right="3px",
                 )
             )
-            MinimzeButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[3])
+            MinimzeButton.setIcon(
+                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[3]
+            )
             MinimzeButton.clicked.connect(self.MinimizeFreeCAD)
-            MinimzeButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
+            MinimzeButton.setFixedSize(
+                self.RightToolBarButtonSize, self.RightToolBarButtonSize
+            )
             self.rightToolBar().addWidget(MinimzeButton)
             # Restore button
             RestoreButton = QToolButton()
@@ -1204,9 +1371,13 @@ class ModernMenu(RibbonBar):
                     padding_right="3px",
                 )
             )
-            RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2])
+            RestoreButton.setIcon(
+                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2]
+            )
             RestoreButton.clicked.connect(self.RestoreFreeCAD)
-            RestoreButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
+            RestoreButton.setFixedSize(
+                self.RightToolBarButtonSize, self.RightToolBarButtonSize
+            )
             self.rightToolBar().addWidget(RestoreButton)
             # Close button
             CloseButton = QToolButton()
@@ -1221,19 +1392,29 @@ class ModernMenu(RibbonBar):
                     HoverColor="#e62424",
                 )
             )
-            CloseButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[0])
+            CloseButton.setIcon(
+                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[0]
+            )
             CloseButton.clicked.connect(self.CloseFreeCAD)
-            CloseButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
+            CloseButton.setFixedSize(
+                self.RightToolBarButtonSize, self.RightToolBarButtonSize
+            )
             self.rightToolBar().addWidget(CloseButton)
 
         # Set the width of the right toolbar
-        RightToolbarWidth = SearchBarWidth + 3 * (self.RightToolBarButtonSize + 16) + self.RightToolBarButtonSize
+        RightToolbarWidth = (
+            SearchBarWidth
+            + 3 * (self.RightToolBarButtonSize + 16)
+            + self.RightToolBarButtonSize
+        )
         if Parameters_Ribbon.USE_FC_OVERLAY is True:
             RightToolbarWidth = SearchBarWidth + 2 * (self.RightToolBarButtonSize + 16)
         self.rightToolBar().setMinimumWidth(RightToolbarWidth)
         self.setRightToolBarHeight(self.RibbonMinimalHeight)
         # Set the size policy
-        self.rightToolBar().setSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding)
+        self.rightToolBar().setSizePolicy(
+            QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding
+        )
         self.rightToolBar().setSizeIncrement(1, 1)
         # Set the objectName for the right toolbar. needed for excluding from hiding.
         self.rightToolBar().setObjectName("rightToolBar")
@@ -1251,11 +1432,17 @@ class ModernMenu(RibbonBar):
 
                 sea = SearchBoxLight.SearchBoxLight(
                     getItemGroups=lambda: __import__("GetItemGroups").getItemGroups(),
-                    getToolTip=lambda groupId, setParent: __import__("GetItemGroups").getToolTip(groupId, setParent),
-                    getItemDelegate=lambda: __import__("IndentedItemDelegate").IndentedItemDelegate(),
+                    getToolTip=lambda groupId, setParent: __import__(
+                        "GetItemGroups"
+                    ).getToolTip(groupId, setParent),
+                    getItemDelegate=lambda: __import__(
+                        "IndentedItemDelegate"
+                    ).IndentedItemDelegate(),
                 )
                 sea.resultSelected.connect(
-                    lambda index, groupId: __import__("GetItemGroups").onResultSelected(index, groupId)
+                    lambda index, groupId: __import__("GetItemGroups").onResultSelected(
+                        index, groupId
+                    )
                 )
                 sea.setFixedSize(width, self.RightToolBarButtonSize)
                 BeforeAction = self.rightToolBar().actions()[1]
@@ -1273,13 +1460,18 @@ class ModernMenu(RibbonBar):
         MenuBar = mw.menuBar()
 
         # Set a stylesheet specific for the menubar. Otherwise the fontsize of the menus will not be applied
-        StyleSheet_MenuBar = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+        StyleSheet_MenuBar = (
+            "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+        )
         MenuBar.setStyleSheet(StyleSheet_MenuBar)
         # # Add the actions of the menubar to the application menu
         for child in MenuBar.actions():
             if child.objectName() != "&Help" and child.objectName != "AccessoriesMenu":
                 ApplictionMenu.addAction(child)
-            if child.objectName == "AccessoriesMenu" and self.AccessoriesMenu is not None:
+            if (
+                child.objectName == "AccessoriesMenu"
+                and self.AccessoriesMenu is not None
+            ):
                 ApplictionMenu.addMenu(self.AccessoriesMenu)
 
         # if you on macOS, add the ribbon menus to the menubar
@@ -1308,7 +1500,9 @@ class ModernMenu(RibbonBar):
             color = StyleMapping_Ribbon.ReturnStyleItem("DevelopColor")
             Label = QLabel()
             Label.setText("Development version")
-            Label.setStyleSheet(f"color: {color};border: 1px solid {color};border-radius: 2px;")
+            Label.setStyleSheet(
+                f"color: {color};border: 1px solid {color};border-radius: 2px;"
+            )
             ApplictionMenu.addWidget(Label)
         # if there is an update, add a button that opens the addon manager
         if self.UpdateVersion != "" and self.DeveloperVersion == "":
@@ -1347,12 +1541,17 @@ class ModernMenu(RibbonBar):
                 self.AccessoriesMenu.addActions(subMenus)
 
         # Create the overlay menu when the native overlay function is not used
-        if Parameters_Ribbon.USE_FC_OVERLAY is False and Parameters_Ribbon.USE_OVERLAY is True:
+        if (
+            Parameters_Ribbon.USE_FC_OVERLAY is False
+            and Parameters_Ribbon.USE_OVERLAY is True
+        ):
             OverlayMenu = QMenu(translate("FreeCAD Ribbon", "Overlay") + "...", self)
             OverlayMenu.setToolTipsVisible(True)
 
             # Toggle overlay for all -----------------------------------------------------
-            OverlayButton_All = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle overlay for all"))
+            OverlayButton_All = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle overlay for all")
+            )
             OverlayButton_All.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1363,7 +1562,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "F4"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayAll" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayAll")
             except Exception as e:
@@ -1373,7 +1574,9 @@ class ModernMenu(RibbonBar):
             OverlayButton_All.setShortcut(ShortcutKey)
 
             # Toggle transparancy for all -----------------------------------------------------
-            TransparancyButton_All = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle transparancy"))
+            TransparancyButton_All = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle transparancy")
+            )
             TransparancyButton_All.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1384,9 +1587,13 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Shift+F4"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayTransparentAll" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayTransparentAll")
+                    ShortcutKey = CustomShortCuts.GetString(
+                        "Std_DockOverlayTransparentAll"
+                    )
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1395,7 +1602,9 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle overlay for active panel-----------------------------------------------------
-            OverlayButton_Active = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle overlay"))
+            OverlayButton_Active = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle overlay")
+            )
             OverlayButton_Active.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1406,7 +1615,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "F3"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayToggle" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggle")
             except Exception as e:
@@ -1416,7 +1627,9 @@ class ModernMenu(RibbonBar):
             OverlayButton_Active.setShortcut(ShortcutKey)
 
             # Toggle transparancy for active panel-----------------------------------------------------
-            TransparancyButton = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle transparant mode"))
+            TransparancyButton = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle transparant mode")
+            )
             TransparancyButton.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1427,9 +1640,13 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Shift+F3"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayToggleTransparent" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleTransparent")
+                    ShortcutKey = CustomShortCuts.GetString(
+                        "Std_DockOverlayToggleTransparent"
+                    )
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1438,15 +1655,25 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle mouse bypass-----------------------------------------------------
-            ToggleMouseByPass = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Bypass mouse events"))
-            ToggleMouseByPass.setToolTip(translate("FreeCAD Ribbon", "Bypass mouse events in docked overlay windows"))
+            ToggleMouseByPass = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Bypass mouse events")
+            )
+            ToggleMouseByPass.setToolTip(
+                translate(
+                    "FreeCAD Ribbon", "Bypass mouse events in docked overlay windows"
+                )
+            )
             ToggleMouseByPass.triggered.connect(self.ToggleMouseByPass)
             # Get the shortcut from the original command
             ShortcutKey = "T,T"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayMouseTransparent" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayMouseTransparent")
+                    ShortcutKey = CustomShortCuts.GetString(
+                        "Std_DockOverlayMouseTransparent"
+                    )
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1455,7 +1682,9 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle overlay for left panels-----------------------------------------------------
-            OverlayButton_Left = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle left"))
+            OverlayButton_Left = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle left")
+            )
             OverlayButton_Left.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1466,7 +1695,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+left"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayToggleLeft" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleLeft")
             except Exception as e:
@@ -1475,7 +1706,9 @@ class ModernMenu(RibbonBar):
                 ShortcutKey = "Ctrl+left"
             OverlayButton_Left.setShortcut(ShortcutKey)
             # Toggle overlay for right panels-----------------------------------------------------
-            OverlayButton_Right = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle right"))
+            OverlayButton_Right = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle right")
+            )
             OverlayButton_Right.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1486,16 +1719,22 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+right"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayToggleRight" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleRight")
+                    ShortcutKey = CustomShortCuts.GetString(
+                        "Std_DockOverlayToggleRight"
+                    )
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
                 ShortcutKey = "Ctrl+right"
             OverlayButton_Right.setShortcut(ShortcutKey)
             # Toggle overlay for Bottom panels-----------------------------------------------------
-            OverlayButton_Bottom = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle bottom"))
+            OverlayButton_Bottom = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle bottom")
+            )
             OverlayButton_Bottom.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1506,9 +1745,13 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+down"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayToggleBottom" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleBottom")
+                    ShortcutKey = CustomShortCuts.GetString(
+                        "Std_DockOverlayToggleBottom"
+                    )
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1519,15 +1762,23 @@ class ModernMenu(RibbonBar):
             self.OverlayMenu = OverlayMenu
 
         # Create a ribbon menu
-        RibbonMenu = QMenu(translate("FreeCAD Ribbon", "Ribbon UI preferences") + " ...", self)
+        RibbonMenu = QMenu(
+            translate("FreeCAD Ribbon", "Ribbon UI preferences") + " ...", self
+        )
         RibbonMenu.setToolTipsVisible(True)
         # Add the ribbon design button
-        DesignButton = RibbonMenu.addAction(translate("FreeCAD Ribbon", "Ribbon layout"))
-        DesignButton.setToolTip(translate("FreeCAD Ribbon", "Design the ribbon to your preference"))
+        DesignButton = RibbonMenu.addAction(
+            translate("FreeCAD Ribbon", "Ribbon layout")
+        )
+        DesignButton.setToolTip(
+            translate("FreeCAD Ribbon", "Design the ribbon to your preference")
+        )
         DesignButton.triggered.connect(self.loadDesignMenu)
         ShortcutKey = "Alt+L"
         try:
-            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+            CustomShortCuts = App.ParamGet(
+                "User parameter:BaseApp/Preferences/Shortcut"
+            )
             if "Ribbon_Layout" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Layout")
         except Exception:
@@ -1536,13 +1787,19 @@ class ModernMenu(RibbonBar):
             DesignButton.setShortcut(ShortcutKey)
             self.LayoutMenuShortCut = ShortcutKey
         # Add the preference button
-        PreferenceButton = RibbonMenu.addAction(translate("FreeCAD Ribbon", "Preferences"))
-        PreferenceButton.setToolTip(translate("FreeCAD Ribbon", "Set preferences for the Ribbon UI"))
+        PreferenceButton = RibbonMenu.addAction(
+            translate("FreeCAD Ribbon", "Preferences")
+        )
+        PreferenceButton.setToolTip(
+            translate("FreeCAD Ribbon", "Set preferences for the Ribbon UI")
+        )
         PreferenceButton.setMenuRole(QAction.MenuRole.NoRole)
         PreferenceButton.triggered.connect(self.loadSettingsMenu)
         ShortcutKey = "Alt+P"
         try:
-            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+            CustomShortCuts = App.ParamGet(
+                "User parameter:BaseApp/Preferences/Shortcut"
+            )
             if "Ribbon_Preferences" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Preferences")
         except Exception:
@@ -1554,8 +1811,12 @@ class ModernMenu(RibbonBar):
         if os.path.exists(ScriptDir) is True:
             ListScripts = os.listdir(ScriptDir)
             if len(ListScripts) > 0:
-                ScriptButtonMenu = RibbonMenu.addMenu(translate("FreeCAD Ribbon", "Scripts"))
-                ScriptButtonMenu.setToolTip(translate("FreeCAD Ribbon", "Scripts to help setup the ribbon."))
+                ScriptButtonMenu = RibbonMenu.addMenu(
+                    translate("FreeCAD Ribbon", "Scripts")
+                )
+                ScriptButtonMenu.setToolTip(
+                    translate("FreeCAD Ribbon", "Scripts to help setup the ribbon.")
+                )
                 for i in range(len(ListScripts)):
                     ScriptButtonMenu.addAction(
                         ListScripts[i],
@@ -1587,7 +1848,11 @@ class ModernMenu(RibbonBar):
 
         # Add the ribbon helpbutton under the FreeCAD
         RibbonHelpButton = QAction(translate("FreeCAD Ribbon", "Ribbon UI help"))
-        RibbonHelpButton.setToolTip(translate("FreeCAD Ribbon", "Open the help page for the Ribbon UI in your browser"))
+        RibbonHelpButton.setToolTip(
+            translate(
+                "FreeCAD Ribbon", "Open the help page for the Ribbon UI in your browser"
+            )
+        )
         RibbonHelpButton.setIcon(HelpIcon)
         RibbonHelpButton.triggered.connect(self.on_RibbonHelpButton_clicked)
         HelpMenu.insertAction(actions[1], RibbonHelpButton)
@@ -1610,11 +1875,15 @@ class ModernMenu(RibbonBar):
         PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
         version = StandardFunctions.ReturnXML_Value(PackageXML, "version")
         # Create the ribbon about button
-        AboutButton_Ribbon = AboutMenu.addAction(translate("FreeCAD Ribbon", "About Ribbon UI ") + version)
+        AboutButton_Ribbon = AboutMenu.addAction(
+            translate("FreeCAD Ribbon", "About Ribbon UI ") + version
+        )
         AboutButton_Ribbon.setIcon(AboutIcon)
         AboutButton_Ribbon.triggered.connect(self.on_AboutButton_clicked)
         # Create the what's new button
-        WhatsNewButton_Ribbon = AboutMenu.addAction(translate("FreeCAD Ribbon", "What's new?"))
+        WhatsNewButton_Ribbon = AboutMenu.addAction(
+            translate("FreeCAD Ribbon", "What's new?")
+        )
         WhatsNewButton_Ribbon.triggered.connect(self.on_WhatsNewButton_clicked)
         # add the aboutmenu to the help menu
         HelpMenu.addMenu(AboutMenu)
@@ -1661,7 +1930,9 @@ class ModernMenu(RibbonBar):
             Parameters_Ribbon.Settings.SetBoolSetting("AutoHideRibbon", True)
             Parameters_Ribbon.AUTOHIDE_RIBBON = True
 
-            pinButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "Pin Ribbon")[0]
+            pinButton: QToolButton = self.rightToolBar().findChildren(
+                QToolButton, "Pin Ribbon"
+            )[0]
             pinButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed"))
 
             # Make sure that the ribbon remains visible
@@ -1673,7 +1944,9 @@ class ModernMenu(RibbonBar):
             Parameters_Ribbon.Settings.SetBoolSetting("AutoHideRibbon", False)
             Parameters_Ribbon.AUTOHIDE_RIBBON = False
 
-            pinButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "Pin Ribbon")[0]
+            pinButton: QToolButton = self.rightToolBar().findChildren(
+                QToolButton, "Pin Ribbon"
+            )[0]
             pinButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_open"))
 
             # Make sure that the ribbon remains visible
@@ -1718,7 +1991,9 @@ class ModernMenu(RibbonBar):
         # Set the text color depending in tabstyle
         if Parameters_Ribbon.TABBAR_STYLE != 1:
             self.tabBar().setStyleSheet(
-                "QTabBar::tab {color: " + StyleMapping_Ribbon.ReturnStyleItem("FontColor") + ";}"
+                "QTabBar::tab {color: "
+                + StyleMapping_Ribbon.ReturnStyleItem("FontColor")
+                + ";}"
             )
         if Parameters_Ribbon.TABBAR_STYLE == 1:
             self.tabBar().setStyleSheet(
@@ -1799,16 +2074,20 @@ class ModernMenu(RibbonBar):
         # Get the custom panels and add them to the list of toolbars
         try:
             if workbenchName in self.ribbonStructure["customToolbars"]:
-                for CustomPanel in self.ribbonStructure["customToolbars"][workbenchName]:
+                for CustomPanel in self.ribbonStructure["customToolbars"][
+                    workbenchName
+                ]:
                     ListToolbars.append(CustomPanel)
 
                     # remove the original toolbars from the list
-                    Commands = self.ribbonStructure["customToolbars"][workbenchName][CustomPanel]["commands"]
+                    Commands = self.ribbonStructure["customToolbars"][workbenchName][
+                        CustomPanel
+                    ]["commands"]
                     for Command in Commands:
                         try:
-                            OriginalToolbar = self.ribbonStructure["customToolbars"][workbenchName][CustomPanel][
-                                "commands"
-                            ][Command]
+                            OriginalToolbar = self.ribbonStructure["customToolbars"][
+                                workbenchName
+                            ][CustomPanel]["commands"][Command]
                             ListToolbars.remove(OriginalToolbar)
                         except Exception:
                             continue
@@ -1828,7 +2107,9 @@ class ModernMenu(RibbonBar):
 
         try:
             # Get the order of toolbars
-            ToolbarOrder: list = self.ribbonStructure["workbenches"][workbenchName]["toolbars"]["order"]
+            ToolbarOrder: list = self.ribbonStructure["workbenches"][workbenchName][
+                "toolbars"
+            ]["order"]
 
             # Sort the list of toolbars according the toolbar order
             def SortToolbars(toolbar):
@@ -1892,30 +2173,51 @@ class ModernMenu(RibbonBar):
 
             # add separators to the command list.
             if workbenchName in self.ribbonStructure["workbenches"]:
-                if toolbar != "" and toolbar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]:
-                    if "order" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]:
+                if (
+                    toolbar != ""
+                    and toolbar
+                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
+                ):
+                    if (
+                        "order"
+                        in self.ribbonStructure["workbenches"][workbenchName][
+                            "toolbars"
+                        ][toolbar]
+                    ):
                         for j in range(
-                            len(self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"])
+                            len(
+                                self.ribbonStructure["workbenches"][workbenchName][
+                                    "toolbars"
+                                ][toolbar]["order"]
+                            )
                         ):
                             if (
                                 "separator"
-                                in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"][
-                                    j
-                                ].lower()
+                                in self.ribbonStructure["workbenches"][workbenchName][
+                                    "toolbars"
+                                ][toolbar]["order"][j].lower()
                             ):
                                 separator = QToolButton()
                                 separator.setText(
-                                    self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"][j]
+                                    self.ribbonStructure["workbenches"][workbenchName][
+                                        "toolbars"
+                                    ][toolbar]["order"][j]
                                 )
                                 allButtons.insert(j, separator)
 
             if workbenchName in self.ribbonStructure["workbenches"]:
                 # order buttons like defined in ribbonStructure
                 if (
-                    toolbar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
-                    and "order" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]
+                    toolbar
+                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
+                    and "order"
+                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][
+                        toolbar
+                    ]
                 ):
-                    OrderList: list = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"]
+                    OrderList: list = self.ribbonStructure["workbenches"][
+                        workbenchName
+                    ]["toolbars"][toolbar]["order"]
 
                     # XXX check that positionsList consists of strings only
                     def sortButtons(button: QToolButton):
@@ -1924,7 +2226,9 @@ class ModernMenu(RibbonBar):
                         # Get the menu text
                         if len(button.actions()) > 0:
                             action = button.actions()[0]
-                            Text = StandardFunctions.CommandInfoCorrections(action.data())["menuText"]
+                            Text = StandardFunctions.CommandInfoCorrections(
+                                action.data()
+                            )["menuText"]
 
                         if Text == "":
                             return -1
@@ -1944,12 +2248,8 @@ class ModernMenu(RibbonBar):
                 []
             )  # if buttons are used in multiple workbenches, they can show up double. (Sketcher_NewSketch)
             # for button in allButtons:
-            NoSmallButtons_spacer = (
-                0  # needed to count the number of small buttons in a column. (bug fix with adding separators)
-            )
-            NoMediumButtons_spacer = (
-                0  # needed to count the number of medium buttons in a column. (bug fix with adding separators)
-            )
+            NoSmallButtons_spacer = 0  # needed to count the number of small buttons in a column. (bug fix with adding separators)
+            NoMediumButtons_spacer = 0  # needed to count the number of medium buttons in a column. (bug fix with adding separators)
 
             # Define number of rows used per button size
             LargeButtonRows = 3
@@ -1972,9 +2272,9 @@ class ModernMenu(RibbonBar):
                 buttonSize = "small"
                 try:
                     action = button.defaultAction()
-                    buttonSize = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["commands"][
-                        action.data()
-                    ]["size"]
+                    buttonSize = self.ribbonStructure["workbenches"][workbenchName][
+                        "toolbars"
+                    ][toolbar]["commands"][action.data()]["size"]
                     if buttonSize == "small":
                         NoSmallButtons_spacer += 1
                     if buttonSize == "medium":
@@ -2065,22 +2365,28 @@ class ModernMenu(RibbonBar):
                             try:
                                 # If the text is not from a hardcoded dropdown:
                                 if len(action.data().split(", ")) <= 1:
-                                    text = StandardFunctions.CommandInfoCorrections(action.data())["ActionText"]
+                                    text = StandardFunctions.CommandInfoCorrections(
+                                        action.data()
+                                    )["ActionText"]
                             except Exception:
                                 pass
 
                             # try to get alternative text from ribbonStructure
                             try:
-                                textJSON = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                    "commands"
-                                ][action.data()]["text"]
+                                textJSON = self.ribbonStructure["workbenches"][
+                                    workbenchName
+                                ]["toolbars"][toolbar]["commands"][action.data()][
+                                    "text"
+                                ]
 
                                 # There is a bug in freecad with the comp-sketch menu hase the wrong text
                                 if (
                                     action.data() == "PartDesign_CompSketches"
-                                    and self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                        "commands"
-                                    ][action.data()]["text"]
+                                    and self.ribbonStructure["workbenches"][
+                                        workbenchName
+                                    ]["toolbars"][toolbar]["commands"][action.data()][
+                                        "text"
+                                    ]
                                     == "Create datum"
                                 ):
                                     textJSON = "Create sketch"
@@ -2091,13 +2397,19 @@ class ModernMenu(RibbonBar):
                                     # if it is a normal command:
                                     if len(action.data().split(", ")) <= 1:
                                         Command = Gui.Command.get(CommandName)
-                                        MenuName = CommandInfoCorrections(CommandName)["menuText"].replace("&", "")
+                                        MenuName = CommandInfoCorrections(CommandName)[
+                                            "menuText"
+                                        ].replace("&", "")
                                         if CommandName == action.data():
                                             if (
                                                 MenuName
-                                                != self.ribbonStructure["workbenches"][workbenchName]["toolbars"][
-                                                    toolbar
-                                                ]["commands"][action.data()]["text"]
+                                                != self.ribbonStructure["workbenches"][
+                                                    workbenchName
+                                                ]["toolbars"][toolbar]["commands"][
+                                                    action.data()
+                                                ][
+                                                    "text"
+                                                ]
                                                 and MenuName != ""
                                                 and textJSON != ""
                                             ):
@@ -2107,9 +2419,13 @@ class ModernMenu(RibbonBar):
                                         MenuName = action.text()
                                         if (
                                             MenuName
-                                            != self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                                "commands"
-                                            ][action.data()]["text"]
+                                            != self.ribbonStructure["workbenches"][
+                                                workbenchName
+                                            ]["toolbars"][toolbar]["commands"][
+                                                action.data()
+                                            ][
+                                                "text"
+                                            ]
                                             and MenuName != ""
                                             and textJSON != ""
                                         ):
@@ -2134,9 +2450,9 @@ class ModernMenu(RibbonBar):
                                 CommandName = button.text()
 
                             try:
-                                pixmap = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                    "commands"
-                                ][CommandName]["icon"]
+                                pixmap = self.ribbonStructure["workbenches"][
+                                    workbenchName
+                                ]["toolbars"][toolbar]["commands"][CommandName]["icon"]
                             except Exception:
                                 pass
                             actionIcon = self.ReturnCommandIcon(action.data(), pixmap)
@@ -2145,18 +2461,24 @@ class ModernMenu(RibbonBar):
 
                             # try to get alternative icon from ribbonStructure
                             try:
-                                icon_Json = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                    "commands"
-                                ][CommandName]["icon"]
+                                icon_Json = self.ribbonStructure["workbenches"][
+                                    workbenchName
+                                ]["toolbars"][toolbar]["commands"][CommandName]["icon"]
                                 if icon_Json != "":
                                     action.setIcon(Gui.getIcon(icon_Json))
                             except KeyError:
                                 pass
 
                             # If the icon is still none, try to retrieve it from the data file
-                            if action.icon() is None or (action.icon() is not None and action.icon().isNull()):
-                                StandardFunctions.Print(f"An icon retrieved from data file for '{CommandName}'")
-                                DataFile = os.path.join(os.path.dirname(__file__), "RibbonDataFile.dat")
+                            if action.icon() is None or (
+                                action.icon() is not None and action.icon().isNull()
+                            ):
+                                StandardFunctions.Print(
+                                    f"An icon retrieved from data file for '{CommandName}'"
+                                )
+                                DataFile = os.path.join(
+                                    os.path.dirname(__file__), "RibbonDataFile.dat"
+                                )
 
                                 if os.path.exists(DataFile) is True:
                                     Data = {}
@@ -2170,7 +2492,11 @@ class ModernMenu(RibbonBar):
                                             # This works only for FreeCAD Commands
                                             CommandName_Icon = action.data()
                                             if CommandName_Icon == IconItem[0]:
-                                                Icon: QIcon = Serialize_Ribbon.deserializeIcon(IconItem[1])
+                                                Icon: QIcon = (
+                                                    Serialize_Ribbon.deserializeIcon(
+                                                        IconItem[1]
+                                                    )
+                                                )
                                                 action.setIcon(Icon)
                                     except Exception as e:
                                         if Parameters_Ribbon.DEBUG_MODE is True:
@@ -2182,9 +2508,9 @@ class ModernMenu(RibbonBar):
 
                             # get button size from ribbonStructure
                             try:
-                                buttonSize = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                    "commands"
-                                ][CommandName]["size"]
+                                buttonSize = self.ribbonStructure["workbenches"][
+                                    workbenchName
+                                ]["toolbars"][toolbar]["commands"][CommandName]["size"]
                                 if buttonSize == "":
                                     buttonSize = "small"
                             except KeyError:
@@ -2201,7 +2527,10 @@ class ModernMenu(RibbonBar):
                             action.setText(action.text().replace("&", ""))
                             if buttonSize == "small":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_SMALL
-                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
+                                if (
+                                    IconOnly is True
+                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
+                                ):
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2240,7 +2569,10 @@ class ModernMenu(RibbonBar):
 
                             elif buttonSize == "medium":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_MEDIUM
-                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
+                                if (
+                                    IconOnly is True
+                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
+                                ):
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2277,7 +2609,10 @@ class ModernMenu(RibbonBar):
                                 )  # Set fixedheight to false. This is set in the custom widgets
                             elif buttonSize == "large":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_LARGE
-                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
+                                if (
+                                    IconOnly is True
+                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
+                                ):
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2315,17 +2650,23 @@ class ModernMenu(RibbonBar):
                             else:
                                 if Parameters_Ribbon.DEBUG_MODE is True:
                                     if buttonSize != "none":
-                                        print(f"{action.text()} is ignored. Its size was: {buttonSize}")
+                                        print(
+                                            f"{action.text()} is ignored. Its size was: {buttonSize}"
+                                        )
                                 pass
 
                             if btn.menu() is not None:
-                                btn.popupMode(QToolButton.ToolButtonPopupMode.MenuButtonPopup)
+                                btn.popupMode(
+                                    QToolButton.ToolButtonPopupMode.MenuButtonPopup
+                                )
 
                             # Set the background always to background color.
                             # Styling is managed in the custom button class
                             StyleSheet_Addition_Button = (
                                 "QToolButton, QToolButton:hover {background-color: "
-                                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
+                                + StyleMapping_Ribbon.ReturnStyleItem(
+                                    "Background_Color"
+                                )
                                 + ";border: none"
                                 + ";}"
                             )
@@ -2340,7 +2681,10 @@ class ModernMenu(RibbonBar):
                             continue
 
             # Change the name of the view panels to "View"
-            if panel.title() in "Views - Ribbon_newPanel" or panel.title() in "Individual views":
+            if (
+                panel.title() in "Views - Ribbon_newPanel"
+                or panel.title() in "Individual views"
+            ):
                 panel.setTitle(" Views ")
             else:
                 # Remove possible workbench names from the titles
@@ -2380,7 +2724,9 @@ class ModernMenu(RibbonBar):
             actionList = []
             for i in range(len(ButtonList)):
                 button = ButtonList[i]
-                StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+                StyleSheet_Menu = (
+                    "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+                )
                 button.setStyleSheet(StyleSheet_Menu)
                 if len(button.actions()) == 1:
                     actionList.append(button.actions()[0])
@@ -2388,14 +2734,20 @@ class ModernMenu(RibbonBar):
                     actionList.append(button.actions())
             OptionButton = panel.panelOptionButton()
             if len(actionList) > 0:
-                Menu = CustomControls.CustomOptionMenu(OptionButton.menu(), actionList, self)
+                Menu = CustomControls.CustomOptionMenu(
+                    OptionButton.menu(), actionList, self
+                )
                 OptionButton.setMenu(Menu)
-                StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+                StyleSheet_Menu = (
+                    "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+                )
                 Menu.setStyleSheet(StyleSheet_Menu)
                 # Set the behavior of the option button
                 OptionButton.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
                 # Remove the image to avoid double arrows
-                OptionButton.setStyleSheet("RibbonPanelOptionButton::menu-indicator {image: none;}")
+                OptionButton.setStyleSheet(
+                    "RibbonPanelOptionButton::menu-indicator {image: none;}"
+                )
                 Menu = OptionButton.menu()
 
                 # Set the icon
@@ -2404,7 +2756,9 @@ class ModernMenu(RibbonBar):
                     OptionButton.setIcon(OptionButton_Icon)
                 else:
                     OptionButton.setArrowType(Qt.ArrowType.DownArrow)
-                    OptionButton.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
+                    OptionButton.setToolButtonStyle(
+                        Qt.ToolButtonStyle.ToolButtonTextBesideIcon
+                    )
                     OptionButton.setText("more...")
             if len(actionList) == 0:
                 panel.panelOptionButton().hide()
@@ -2413,13 +2767,21 @@ class ModernMenu(RibbonBar):
 
         # Set the previous/next buttons
         category = self.currentCategory()
-        ScrollLeftButton_Category: RibbonCategoryLayoutButton = category.findChildren(RibbonCategoryLayoutButton)[0]
-        ScrollRightButton_Category: RibbonCategoryLayoutButton = category.findChildren(RibbonCategoryLayoutButton)[1]
+        ScrollLeftButton_Category: RibbonCategoryLayoutButton = category.findChildren(
+            RibbonCategoryLayoutButton
+        )[0]
+        ScrollRightButton_Category: RibbonCategoryLayoutButton = category.findChildren(
+            RibbonCategoryLayoutButton
+        )[1]
         ScrollLeftButton_Category.setMinimumWidth(self.iconSize * 0.5)
         ScrollRightButton_Category.setMinimumWidth(self.iconSize * 0.5)
         # get the icons
-        ScrollLeftButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category")
-        ScrollRightButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category")
+        ScrollLeftButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem(
+            "ScrollLeftButton_Category"
+        )
+        ScrollRightButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem(
+            "ScrollRightButton_Category"
+        )
         # Set the icons
         if ScrollLeftButton_Category_Icon is not None:
             ScrollLeftButton_Category.setIcon(ScrollLeftButton_Category_Icon)
@@ -2433,23 +2795,37 @@ class ModernMenu(RibbonBar):
         ScrollLeftButton_Category.setFixedHeight(Parameters_Ribbon.ICON_SIZE_SMALL * 3)
         ScrollRightButton_Category.setFixedHeight(Parameters_Ribbon.ICON_SIZE_SMALL * 3)
         # Set the stylesheet
-        ScrollLeftButton_Category.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton"))
-        ScrollRightButton_Category.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton"))
-        # Connect the custom click event
-        ScrollLeftButton_Category.mousePressEvent = lambda clickLeft: self.on_ScrollButton_Category_clicked(
-            clickLeft, ScrollLeftButton_Category
+        ScrollLeftButton_Category.setStyleSheet(
+            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton")
         )
-        ScrollRightButton_Category.mousePressEvent = lambda clickRight: self.on_ScrollButton_Category_clicked(
-            clickRight, ScrollRightButton_Category
+        ScrollRightButton_Category.setStyleSheet(
+            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton")
+        )
+        # Connect the custom click event
+        ScrollLeftButton_Category.mousePressEvent = (
+            lambda clickLeft: self.on_ScrollButton_Category_clicked(
+                clickLeft, ScrollLeftButton_Category
+            )
+        )
+        ScrollRightButton_Category.mousePressEvent = (
+            lambda clickRight: self.on_ScrollButton_Category_clicked(
+                clickRight, ScrollRightButton_Category
+            )
         )
 
         # Set the maximum height to a high value to prevent from the ribbon to be clipped off
-        self.currentCategory().setMinimumHeight(self.RibbonHeight - self.RibbonMinimalHeight - 3)
-        self.currentCategory().setMaximumHeight(self.RibbonHeight - self.RibbonMinimalHeight - 3)
+        self.currentCategory().setMinimumHeight(
+            self.RibbonHeight - self.RibbonMinimalHeight - 3
+        )
+        self.currentCategory().setMaximumHeight(
+            self.RibbonHeight - self.RibbonMinimalHeight - 3
+        )
         self.setRibbonHeight(self.RibbonHeight)
         return
 
-    def on_ScrollButton_Category_clicked(self, event, ScrollButton: RibbonCategoryLayoutButton):
+    def on_ScrollButton_Category_clicked(
+        self, event, ScrollButton: RibbonCategoryLayoutButton
+    ):
         for i in range(Parameters_Ribbon.RIBBON_CLICKSPEED):
             ScrollButton.click()
         return
@@ -2470,7 +2846,10 @@ class ModernMenu(RibbonBar):
             parentWidget = toolbar.parentWidget()
             toolbar.setHidden(True)
             # hide toolbars that are not in the statusBar and show toolbars that are in the statusbar.
-            if parentWidget.objectName() == "statusBar" or parentWidget.objectName() == "StatusBarArea":
+            if (
+                parentWidget.objectName() == "statusBar"
+                or parentWidget.objectName() == "StatusBarArea"
+            ):
                 toolbar.setEnabled(True)
                 toolbar.setVisible(True)
             # # # Show specific toolbars and go to the next
@@ -2494,7 +2873,11 @@ class ModernMenu(RibbonBar):
         return
 
     def FoldRibbon(self, Ignore=False):
-        if Parameters_Ribbon.AUTOHIDE_RIBBON is True and self.isLoaded is True and Ignore is False:
+        if (
+            Parameters_Ribbon.AUTOHIDE_RIBBON is True
+            and self.isLoaded is True
+            and Ignore is False
+        ):
             if len(mw.findChildren(QDockWidget, "Ribbon")) > 0:
                 TB: QDockWidget = mw.findChildren(QDockWidget, "Ribbon")[0]
                 TB.setMinimumHeight(self.RibbonMinimalHeight)
@@ -2514,7 +2897,10 @@ class ModernMenu(RibbonBar):
 
                     for Group in CustomToolbars:
                         Parameter = App.ParamGet(
-                            "User parameter:BaseApp/Workbench/" + WorkBenchName + "/Toolbar/" + Group
+                            "User parameter:BaseApp/Workbench/"
+                            + WorkBenchName
+                            + "/Toolbar/"
+                            + Group
                         )
                         Name = Parameter.GetString("Name")
                         Toolbars.append([Name, WorkBenchName])
@@ -2523,10 +2909,14 @@ class ModernMenu(RibbonBar):
 
     def List_ReturnCustomToolbars_Global(self):
         Toolbars = []
-        CustomToolbars: list = App.ParamGet("User parameter:BaseApp/Workbench/Global/Toolbar").GetGroups()
+        CustomToolbars: list = App.ParamGet(
+            "User parameter:BaseApp/Workbench/Global/Toolbar"
+        ).GetGroups()
 
         for Group in CustomToolbars:
-            Parameter = App.ParamGet("User parameter:BaseApp/Workbench/Global/Toolbar/" + Group)
+            Parameter = App.ParamGet(
+                "User parameter:BaseApp/Workbench/Global/Toolbar/" + Group
+            )
             Name = Parameter.GetString("Name")
             Toolbars.append([Name, "Global"])
 
@@ -2537,7 +2927,9 @@ class ModernMenu(RibbonBar):
 
         try:
             # Get the commands from the custom panel
-            Commands = self.ribbonStructure["customToolbars"][WorkBenchName][CustomToolbar]["commands"]
+            Commands = self.ribbonStructure["customToolbars"][WorkBenchName][
+                CustomToolbar
+            ]["commands"]
 
             # Get the command and its original toolbar
             for key, value in list(Commands.items()):
@@ -2546,7 +2938,9 @@ class ModernMenu(RibbonBar):
                     # Get the english menutext
                     MenuName = CommandInfoCorrections(CommandName)["menuText"]
                     # Get the translated menutext
-                    MenuNameTtranslated = CommandInfoCorrections(CommandName)["ActionText"]
+                    MenuNameTtranslated = CommandInfoCorrections(CommandName)[
+                        "ActionText"
+                    ]
 
                     if MenuName == key:
                         try:
@@ -2561,11 +2955,16 @@ class ModernMenu(RibbonBar):
                                     if Toolbutton.text() == Child.text():
                                         IsInList = True
 
-                                if Child.text() == MenuNameTtranslated and IsInList is False:
+                                if (
+                                    Child.text() == MenuNameTtranslated
+                                    and IsInList is False
+                                ):
                                     ButtonList.append(Child)
                         except Exception as e:
                             if Parameters_Ribbon.DEBUG_MODE is True:
-                                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}, 3", "Warning")
+                                StandardFunctions.Print(
+                                    f"{e.with_traceback(e.__traceback__)}, 3", "Warning"
+                                )
                             continue
         except Exception:
             pass
@@ -2579,7 +2978,9 @@ class ModernMenu(RibbonBar):
             if WorkBenchName in self.ribbonStructure["newPanels"]:
                 if NewPanel in self.ribbonStructure["newPanels"][WorkBenchName]:
                     # Get the commands from the custom panel
-                    Commands = self.ribbonStructure["newPanels"][WorkBenchName][NewPanel]
+                    Commands = self.ribbonStructure["newPanels"][WorkBenchName][
+                        NewPanel
+                    ]
 
                     # Get the command and its original toolbar
                     for CommandItem in Commands:
@@ -2598,7 +2999,9 @@ class ModernMenu(RibbonBar):
                                     CommandActionList = Command.getAction()
                                 if Command is None:
                                     if Parameters_Ribbon.DEBUG_MODE is True:
-                                        StandardFunctions.Print(f"{CommandName} was None", "Warning")
+                                        StandardFunctions.Print(
+                                            f"{CommandName} was None", "Warning"
+                                        )
                             # If the commandname can be splitted, it is a FreeCAD dropdown
                             if len(CommandName.split(", ")) > 1:
                                 CommandActionList = self.LoadDropDownAction(CommandName)
@@ -2609,10 +3012,14 @@ class ModernMenu(RibbonBar):
                                 # if there is only one action, add it directly
                                 if len(CommandActionList) == 1:
                                     NewToolbutton.addAction(CommandActionList[0])
-                                    NewToolbutton.setDefaultAction(NewToolbutton.actions()[0])
+                                    NewToolbutton.setDefaultAction(
+                                        NewToolbutton.actions()[0]
+                                    )
                                     # If the commandname is from a FreeCAD dropdown, set the commandname as text
                                     if len(CommandName.split(", ")) > 1:
-                                        NewToolbutton.setText(NewToolbutton.actions()[0].text())
+                                        NewToolbutton.setText(
+                                            NewToolbutton.actions()[0].text()
+                                        )
                                 # if there are more actions, create a menu
                                 elif len(CommandActionList) > 1:
                                     menu = QMenu()
@@ -2630,7 +3037,9 @@ class ModernMenu(RibbonBar):
                                 # Set the text for the toolbutton
                                 if len(CommandName.split(", ")) <= 1:
                                     NewToolbutton.setText(
-                                        CommandInfoCorrections(CommandName)["menuText"].replace("&", "")
+                                        CommandInfoCorrections(CommandName)[
+                                            "menuText"
+                                        ].replace("&", "")
                                     )
                                 # # If the commandname is from a FreeCAD dropdown, set the commandname as text
                                 # if len(CommandName.split(", ")) > 1:
@@ -2647,7 +3056,9 @@ class ModernMenu(RibbonBar):
                                 # if there is only one action, add it directly
                                 if len(CommandActionList) == 1:
                                     NewToolbutton.addAction(CommandActionList[0])
-                                    NewToolbutton.setDefaultAction(NewToolbutton.actions()[0])
+                                    NewToolbutton.setDefaultAction(
+                                        NewToolbutton.actions()[0]
+                                    )
                                 # if there are more actions, create a menu
                                 if len(CommandActionList) > 1:
                                     menu = QMenu()
@@ -2670,7 +3081,9 @@ class ModernMenu(RibbonBar):
 
         except Exception as e:
             if Parameters_Ribbon.DEBUG_MODE is True:
-                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}, 4", "Warning")
+                StandardFunctions.Print(
+                    f"{e.with_traceback(e.__traceback__)}, 4", "Warning"
+                )
             pass
         return ButtonList
 
@@ -2711,12 +3124,14 @@ class ModernMenu(RibbonBar):
         # Check whichs is has the most height: 3 small buttons, 2 medium buttons or 1 large button
         # and set the height accordingly
         if (
-            Parameters_Ribbon.ICON_SIZE_SMALL * 3 >= Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
+            Parameters_Ribbon.ICON_SIZE_SMALL * 3
+            >= Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
             and Parameters_Ribbon.ICON_SIZE_SMALL * 3 >= LargeButtonHeight
         ):
             ribbonHeight = ribbonHeight + Parameters_Ribbon.ICON_SIZE_SMALL * 3 + 6
         elif (
-            Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 >= Parameters_Ribbon.ICON_SIZE_SMALL * 3
+            Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
+            >= Parameters_Ribbon.ICON_SIZE_SMALL * 3
             and Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 >= LargeButtonHeight
         ):
             ribbonHeight = ribbonHeight + Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 + 4
@@ -2829,10 +3244,18 @@ class ModernMenu(RibbonBar):
             Enable = False
 
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
-        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
-        OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
+        OverlayParam_Left = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
+        )
+        OverlayParam_Right = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
+        )
+        OverlayParam_Top = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayTop"
+        )
+        OverlayParam_Bottom = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
+        )
 
         # If overlay is enabled, go here
         PanelsLeft = []
@@ -2915,10 +3338,16 @@ class ModernMenu(RibbonBar):
         OverlayParam_Right = None
         OverlayParam_Bottom = None
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
-        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
+        OverlayParam_Left = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
+        )
+        OverlayParam_Right = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
+        )
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
+        OverlayParam_Bottom = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
+        )
 
         # Ge the focused dockwidget
         FocusWidget = mw.focusWidget().parent().objectName()
@@ -2964,22 +3393,32 @@ class ModernMenu(RibbonBar):
             RightPanels = OverlayParam_Right.GetString("Widgets")
             if FocusWidget in RightPanels:
                 RightPanels = OverlayParam_Left.GetString("Widgets")
-                RightPanels = RightPanels.replace(f"{FocusWidget}", "").replace(",,", ",")
+                RightPanels = RightPanels.replace(f"{FocusWidget}", "").replace(
+                    ",,", ","
+                )
                 OverlayParam_Right.SetString("Widgets", f"{RightPanels}")
                 return
             BottomPanels = OverlayParam_Bottom.GetString("Widgets")
             if FocusWidget in BottomPanels:
                 BottomPanels = OverlayParam_Bottom.GetString("Widgets")
-                BottomPanels = BottomPanels.replace(f"{FocusWidget}", "").replace(",,", ",")
+                BottomPanels = BottomPanels.replace(f"{FocusWidget}", "").replace(
+                    ",,", ","
+                )
                 OverlayParam_Bottom.SetString("Widgets", f"{BottomPanels}")
                 return
         return
 
     def CustomTransparancy(self):
-        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
-        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
+        OverlayParam_Left = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
+        )
+        OverlayParam_Right = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
+        )
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
+        OverlayParam_Bottom = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
+        )
 
         Enable = None
         if OverlayParam_Left.GetBool("Transparent") is False:
@@ -3001,10 +3440,16 @@ class ModernMenu(RibbonBar):
         OverlayParam_Right = None
         OverlayParam_Bottom = None
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
-        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
+        OverlayParam_Left = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
+        )
+        OverlayParam_Right = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
+        )
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
+        OverlayParam_Bottom = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
+        )
 
         # Ge the focused dockwidget
         FocusWidget = mw.focusWidget().parent().objectName()
@@ -3030,15 +3475,21 @@ class ModernMenu(RibbonBar):
         if position == "":
             LeftPanels = OverlayParam_Left.GetString("Widgets")
             if FocusWidget in LeftPanels:
-                OverlayParam_Left.SetBool("Transparent", not OverlayParam_Left.GetBool("Transparent"))
+                OverlayParam_Left.SetBool(
+                    "Transparent", not OverlayParam_Left.GetBool("Transparent")
+                )
                 return
             RightPanels = OverlayParam_Right.GetString("Widgets")
             if FocusWidget in RightPanels:
-                OverlayParam_Right.SetBool("Transparent", not OverlayParam_Right.GetBool("Transparent"))
+                OverlayParam_Right.SetBool(
+                    "Transparent", not OverlayParam_Right.GetBool("Transparent")
+                )
                 return
             BottomPanels = OverlayParam_Bottom.GetString("Widgets")
             if FocusWidget in BottomPanels:
-                OverlayParam_Bottom.SetBool("Transparent", not OverlayParam_Bottom.GetBool("Transparent"))
+                OverlayParam_Bottom.SetBool(
+                    "Transparent", not OverlayParam_Bottom.GetBool("Transparent")
+                )
                 return
         return
 
@@ -3046,7 +3497,9 @@ class ModernMenu(RibbonBar):
         actionList = []
 
         try:
-            for DropDownCommand, Commands in self.ribbonStructure["dropdownButtons"].items():
+            for DropDownCommand, Commands in self.ribbonStructure[
+                "dropdownButtons"
+            ].items():
                 if CommandName == DropDownCommand:
                     for CommandItem in Commands:
                         Command = Gui.Command.get(CommandItem[0])
@@ -3057,7 +3510,9 @@ class ModernMenu(RibbonBar):
             return actionList
         except Exception as e:
             if Parameters_Ribbon.DEBUG_MODE is True:
-                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}", "Warning")
+                StandardFunctions.Print(
+                    f"{e.with_traceback(e.__traceback__)}", "Warning"
+                )
             return
 
     def CloseFreeCAD(self):
@@ -3073,7 +3528,9 @@ class ModernMenu(RibbonBar):
         # if self.isLoaded:
         StatusBarState = mw.findChild(QStatusBar, "statusBar").isVisible()
         # Get the style and restore button
-        RestoreButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
+        RestoreButton: QToolButton = self.rightToolBar().findChildren(
+            QToolButton, "RestoreButton"
+        )[0]
         # If the mainwindow is maximized, set the mainwindow to normal, set a size and icon
         if mw.isMaximized() is True:
             try:
@@ -3161,18 +3618,27 @@ class ModernMenu(RibbonBar):
 
     def CheckLanguage(self):
         FreeCAD_preferences = App.ParamGet("User parameter:BaseApp/Preferences/General")
-        if self.ribbonStructure["language"] != FreeCAD_preferences.GetString("Language"):
+        if self.ribbonStructure["language"] != FreeCAD_preferences.GetString(
+            "Language"
+        ):
             if "workbenches" in self.ribbonStructure:
                 for workbenchName in self.ribbonStructure["workbenches"]:
                     if "toolbars" in self.ribbonStructure["workbenches"][workbenchName]:
-                        for ToolBar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]:
-                            if "commands" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar]:
-                                for Command in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar][
-                                    "commands"
-                                ]:
-                                    self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar]["commands"][
-                                        Command
-                                    ]["text"] = ""
+                        for ToolBar in self.ribbonStructure["workbenches"][
+                            workbenchName
+                        ]["toolbars"]:
+                            if (
+                                "commands"
+                                in self.ribbonStructure["workbenches"][workbenchName][
+                                    "toolbars"
+                                ][ToolBar]
+                            ):
+                                for Command in self.ribbonStructure["workbenches"][
+                                    workbenchName
+                                ]["toolbars"][ToolBar]["commands"]:
+                                    self.ribbonStructure["workbenches"][workbenchName][
+                                        "toolbars"
+                                    ][ToolBar]["commands"][Command]["text"] = ""
 
             print("Ribbon UI: Custom text are reset because the language was changed")
         return
@@ -3190,27 +3656,36 @@ class EventInspector(QObject):
             mw.showMaximal()
             Style = mw.style()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
-            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
+            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(
+                QToolButton, "RestoreButton"
+            )[0]
             try:
-                RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton))
+                RestoreButton.setIcon(
+                    Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton)
+                )
             except Exception:
                 pass
             return QObject.eventFilter(self, obj, event)
         # This is a workaround for windows
         # If the window stat changes and the titlebar is hidden, catch the event
         if (
-            event.type() == QEvent.Type.WindowStateChange or event.type() == QEvent.Type.DragMove
+            event.type() == QEvent.Type.WindowStateChange
+            or event.type() == QEvent.Type.DragMove
         ) and Parameters_Ribbon.HIDE_TITLEBAR_FC is True:
             # Get the main window, its style, the ribbon and the restore button
             mw = Gui.getMainWindow()
             Style = mw.style()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
-            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
+            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(
+                QToolButton, "RestoreButton"
+            )[0]
             # If the mainwindow is maximized, set the window state to maximize and set the correct icon
             if mw.isMaximized():
                 try:
                     # RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton))
-                    RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2])
+                    RestoreButton.setIcon(
+                        StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2]
+                    )
                 except Exception:
                     pass
                 return QObject.eventFilter(self, obj, event)
@@ -3218,13 +3693,18 @@ class EventInspector(QObject):
             if mw.isMaximized() is False:
                 try:
                     # RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarMaxButton))
-                    RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1])
+                    RestoreButton.setIcon(
+                        StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1]
+                    )
                 except Exception:
                     pass
                 return QObject.eventFilter(self, obj, event)
         # If the event is a modfied event, update the title
         # This is done when switching from one part to another
-        if event.type() == QEvent.Type.ModifiedChange and Parameters_Ribbon.TOOLBAR_POSITION == 0:
+        if (
+            event.type() == QEvent.Type.ModifiedChange
+            and Parameters_Ribbon.TOOLBAR_POSITION == 0
+        ):
             # Get the mainwindow, the ribbon and the title
             mw = Gui.getMainWindow()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
@@ -3232,7 +3712,9 @@ class EventInspector(QObject):
             # If there is an active document, continue here
             if App.ActiveDocument is not None:
                 # Define the standard title as a prefix
-                Prefix = f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
+                Prefix = (
+                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
+                )
                 # if the title is not equal to the prefix with the active document label,
                 # Get the text from the active tab from the viewport and combine it with the prefix
                 # Set it as the new title
@@ -3243,7 +3725,9 @@ class EventInspector(QObject):
                     RibbonBar.setTitle(Prefix + " - " + CurrentText)
             # If there is no active document, set just the standard title
             if App.ActiveDocument is None:
-                RibbonBar.setTitle(f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}")
+                RibbonBar.setTitle(
+                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
+                )
             return QObject.eventFilter(self, obj, event)
         return False
 

--- a/FCBinding.py
+++ b/FCBinding.py
@@ -181,7 +181,9 @@ class ModernMenu(RibbonBar):
     # Create an offset for the panelheight
     PanelHeightOffset = 36
     # Create an offset for the whole ribbon height
-    RibbonOffset = 50 + QuickAccessButtonSize * 2  # Set to zero to hide the panel titles
+    RibbonOffset = (
+        50 + QuickAccessButtonSize * 2
+    )  # Set to zero to hide the panel titles
 
     # Set the minimum height for the ribbon
     RibbonMinimalHeight = QuickAccessButtonSize * 2 + 16
@@ -315,8 +317,13 @@ class ModernMenu(RibbonBar):
             ]
         else:
             try:
-                if "Views - Ribbon_newPanel" in self.ribbonStructure["newPanels"]["Global"]:
-                    del self.ribbonStructure["newPanels"]["Global"]["Views - Ribbon_newPanel"]
+                if (
+                    "Views - Ribbon_newPanel"
+                    in self.ribbonStructure["newPanels"]["Global"]
+                ):
+                    del self.ribbonStructure["newPanels"]["Global"][
+                        "Views - Ribbon_newPanel"
+                    ]
             except Exception:
                 pass
         # # Add a toolbar "tools"
@@ -326,11 +333,14 @@ class ModernMenu(RibbonBar):
         try:
             NeedsUpdating = False
             if "Tools_newPanel" in self.ribbonStructure["newPanels"]["Global"]:
-                for item in self.ribbonStructure["newPanels"]["Global"]["Tools_newPanel"]:
+                for item in self.ribbonStructure["newPanels"]["Global"][
+                    "Tools_newPanel"
+                ]:
                     if item[1] != "Standard":
                         NeedsUpdating = True
             if (
-                "Tools_newPanel" not in self.ribbonStructure["newPanels"]["Global"] and UseToolsPanel is True
+                "Tools_newPanel" not in self.ribbonStructure["newPanels"]["Global"]
+                and UseToolsPanel is True
             ) or NeedsUpdating is True:
                 StandardFunctions.add_keys_nested_dict(
                     self.ribbonStructure,
@@ -399,7 +409,9 @@ class ModernMenu(RibbonBar):
 
         # Get the address of the repository address
         PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
-        self.ReproAdress = StandardFunctions.ReturnXML_Value(PackageXML, "url", "type", "repository")
+        self.ReproAdress = StandardFunctions.ReturnXML_Value(
+            PackageXML, "url", "type", "repository"
+        )
         if self.ReproAdress != "" or self.ReproAdress is not None:
             print(translate("FreeCAD Ribbon", "FreeCAD Ribbon: ") + self.ReproAdress)
 
@@ -409,7 +421,9 @@ class ModernMenu(RibbonBar):
                 for WorkBenchName in self.ribbonStructure["newPanels"]:
                     for NewPanel in self.ribbonStructure["newPanels"][WorkBenchName]:
                         # Get the commands from the custom panel
-                        Commands = self.ribbonStructure["newPanels"][WorkBenchName][NewPanel]
+                        Commands = self.ribbonStructure["newPanels"][WorkBenchName][
+                            NewPanel
+                        ]
 
                         # Get the command and its original toolbar
                         for CommandItem in Commands:
@@ -431,9 +445,15 @@ class ModernMenu(RibbonBar):
         # Activate the workbenches used in the dropdown buttons otherwise the button stays empty
         try:
             if "dropdownButtons" in self.ribbonStructure:
-                for DropDownCommand, Commands in self.ribbonStructure["dropdownButtons"].items():
+                for DropDownCommand, Commands in self.ribbonStructure[
+                    "dropdownButtons"
+                ].items():
                     for CommandItem in Commands:
-                        if CommandItem[1] != "General" and CommandItem[1] != "Global" and CommandItem[1] != "Standard":
+                        if (
+                            CommandItem[1] != "General"
+                            and CommandItem[1] != "Global"
+                            and CommandItem[1] != "Standard"
+                        ):
                             # Activate the workbench if not loaded
                             Gui.activateWorkbench(CommandItem[1])
         except Exception as e:
@@ -452,11 +472,15 @@ class ModernMenu(RibbonBar):
             Branch = "main"
             File = "package.xml"
             ElementName = "version"
-            LatestVersion = StandardFunctions.ReturnXML_Value_Git(User, Repo, Branch, File, ElementName)
+            LatestVersion = StandardFunctions.ReturnXML_Value_Git(
+                User, Repo, Branch, File, ElementName
+            )
             if LatestVersion is not None:
                 # Get the current version
                 PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
-                CurrentVersion = StandardFunctions.ReturnXML_Value(PackageXML, "version")
+                CurrentVersion = StandardFunctions.ReturnXML_Value(
+                    PackageXML, "version"
+                )
                 # Check if you are on a developer version. If so set developer version
                 if CurrentVersion.lower().endswith("x"):
                     self.DeveloperVersion = CurrentVersion
@@ -489,15 +513,29 @@ class ModernMenu(RibbonBar):
         StyleSheet = Path(Parameters_Ribbon.STYLESHEET).read_text()
         # modify the stylesheet to set the border and background for a toolbar and menu
         hexColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
-        hexColorTab = StyleMapping_Ribbon.ReturnStyleItem("Background_Color", True, True)
-        if hexColor is not None and hexColor != "" and Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True:
+        hexColorTab = StyleMapping_Ribbon.ReturnStyleItem(
+            "Background_Color", True, True
+        )
+        if (
+            hexColor is not None
+            and hexColor != ""
+            and Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True
+        ):
             # Set the quickaccess toolbar background color. This fixes a transparant toolbar.
-            self.quickAccessToolBar().setStyleSheet("QToolBar {background: " + hexColor + ";}")
+            self.quickAccessToolBar().setStyleSheet(
+                "QToolBar {background: " + hexColor + ";}"
+            )
             self.tabBar().setStyleSheet("background: " + hexColorTab + ";")
             # Set the background color. This fixes transparant backgrounds when FreeCAD has no stylesheet
-            StyleSheet_Addition = "\n\nQToolButton {background: solid " + hexColor + ";}"
+            StyleSheet_Addition = (
+                "\n\nQToolButton {background: solid " + hexColor + ";}"
+            )
             StyleSheet_Addition_2 = (
-                "\n\nRibbonBar {border: none;background: solid " + hexColor + ";color: " + hexColor + ";}"
+                "\n\nRibbonBar {border: none;background: solid "
+                + hexColor
+                + ";color: "
+                + hexColor
+                + ";}"
             )
             StyleSheet = StyleSheet_Addition_2 + StyleSheet + StyleSheet_Addition
         self.setStyleSheet(StyleSheet)
@@ -507,9 +545,13 @@ class ModernMenu(RibbonBar):
             StyleSheet_Addition_3 = (
                 """QTabBar::tab {
                     background: """
-                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color_Hover", True, True)
+                + StyleMapping_Ribbon.ReturnStyleItem(
+                    "Background_Color_Hover", True, True
+                )
                 + """;color: """
-                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color_Hover", True, True)
+                + StyleMapping_Ribbon.ReturnStyleItem(
+                    "Background_Color_Hover", True, True
+                )
                 + """;min-width: """
                 + str(self.TabBar_Size)
                 + """px;
@@ -582,7 +624,9 @@ class ModernMenu(RibbonBar):
         self.tabBar().tabBarClicked.connect(self.onTabBarClicked)
 
         # override the default scroll behavior with a custom function
-        self.tabBar().wheelEvent = lambda event_tabBar: self.wheelEvent_TabBar(event_tabBar)
+        self.tabBar().wheelEvent = lambda event_tabBar: self.wheelEvent_TabBar(
+            event_tabBar
+        )
         self.wheelEvent = lambda event_CC: self.wheelEvent_CC(event_CC)
         self.tabBar().setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.currentCategory().setFocusPolicy(Qt.FocusPolicy.StrongFocus)
@@ -595,12 +639,20 @@ class ModernMenu(RibbonBar):
         ScrollLeftButton_Tab: QToolButton = self.tabBar().findChildren(QToolButton)[0]
         ScrollRightButton_Tab: QToolButton = self.tabBar().findChildren(QToolButton)[1]
         # get the icons
-        ScrollLeftButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab")
-        ScrollRightButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab")
+        ScrollLeftButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem(
+            "ScrollLeftButton_Tab"
+        )
+        ScrollRightButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem(
+            "ScrollRightButton_Tab"
+        )
         # Set the icons
         StyleSheet = "QToolButton {image: none;margin-top:6px;margin-bottom:6px;};QToolButton::arrow {image: none};"
         BackgroundColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
-        if int(App.Version()[0]) == 0 and int(App.Version()[1]) <= 21 and BackgroundColor is not None:
+        if (
+            int(App.Version()[0]) == 0
+            and int(App.Version()[1]) <= 21
+            and BackgroundColor is not None
+        ):
             StyleSheet = (
                 """QToolButton {image: none;background: """
                 + BackgroundColor
@@ -610,7 +662,9 @@ class ModernMenu(RibbonBar):
             ScrollLeftButton_Tab.setStyleSheet(StyleSheet)
             ScrollLeftButton_Tab.setIcon(ScrollLeftButton_Tab_Icon)
         else:
-            ScrollRightButton_Tab.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+            ScrollRightButton_Tab.setToolButtonStyle(
+                Qt.ToolButtonStyle.ToolButtonTextOnly
+            )
         if ScrollRightButton_Tab_Icon is not None:
             ScrollRightButton_Tab.setStyleSheet(StyleSheet)
             ScrollRightButton_Tab.setIcon(ScrollRightButton_Tab_Icon)
@@ -618,9 +672,13 @@ class ModernMenu(RibbonBar):
             ScrollRightButton_Tab.setArrowType(Qt.ArrowType.RightArrow)
 
         # Remove persistant toolbars
-        PersistentToolbars = App.ParamGet("User parameter:Tux/PersistentToolbars/User").GetGroups()
+        PersistentToolbars = App.ParamGet(
+            "User parameter:Tux/PersistentToolbars/User"
+        ).GetGroups()
         for Group in PersistentToolbars:
-            Parameter = App.ParamGet("User parameter:Tux/PersistentToolbars/User/" + Group)
+            Parameter = App.ParamGet(
+                "User parameter:Tux/PersistentToolbars/User/" + Group
+            )
             Parameter.SetString("Top", "")
             Parameter.SetString("Left", "")
             Parameter.SetString("Right", "")
@@ -631,7 +689,9 @@ class ModernMenu(RibbonBar):
         # Application menu
         ShortcutKey = "Alt+A"
         try:
-            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+            CustomShortCuts = App.ParamGet(
+                "User parameter:BaseApp/Preferences/Shortcut"
+            )
             if "Ribbon_Menu" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Menu")
         except Exception:
@@ -648,7 +708,10 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().enterEvent = lambda enter: self.leaveEvent(enter)
 
         # Rearrange the tabbar and toolbars
-        if Parameters_Ribbon.TOOLBAR_POSITION == 0 or Parameters_Ribbon.TOOLBAR_POSITION == 1:
+        if (
+            Parameters_Ribbon.TOOLBAR_POSITION == 0
+            or Parameters_Ribbon.TOOLBAR_POSITION == 1
+        ):
             # Get the widgets
             _quickAccessToolBarWidget = self.quickAccessToolBar()
             _titleLabel = self._titleWidget._titleLabel
@@ -666,24 +729,38 @@ class ModernMenu(RibbonBar):
                 _titleLabel.setAlignment(Qt.AlignmentFlag.AlignCenter)
                 _titleLabel.setFont(font)
                 # Set the label text to FreeCAD's version
-                text = f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
+                text = (
+                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
+                )
                 _titleLabel.setText(text)
                 # Create a spacer to set the tab
                 spacer = QWidget()
-                spacer.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
+                spacer.setSizePolicy(
+                    QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
+                )
                 spacer.setFixedWidth(3)
                 self._titleWidget._tabBarLayout.setContentsMargins(3, 3, 3, 0)
                 self._titleWidget._tabBarLayout.addWidget(
                     _quickAccessToolBarWidget, 0, 0, 1, 2, Qt.AlignmentFlag.AlignVCenter
                 )
-                self._titleWidget._tabBarLayout.addWidget(_titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter)
-                self._titleWidget._tabBarLayout.addWidget(_rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter)
-                self._titleWidget._tabBarLayout.addWidget(spacer, 1, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter)
-                self._titleWidget._tabBarLayout.addWidget(_tabBar, 1, 1, 1, 4, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(
+                    _titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter
+                )
+                self._titleWidget._tabBarLayout.addWidget(
+                    _rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter
+                )
+                self._titleWidget._tabBarLayout.addWidget(
+                    spacer, 1, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter
+                )
+                self._titleWidget._tabBarLayout.addWidget(
+                    _tabBar, 1, 1, 1, 4, Qt.AlignmentFlag.AlignVCenter
+                )
                 # Change the offsets
                 self.RibbonMinimalHeight = self.QuickAccessButtonSize * 2 + 20
                 self.RibbonOffset = 54 + self.QuickAccessButtonSize * 2
-                self._titleWidget._tabBarLayout.setRowMinimumHeight(0, self.QuickAccessButtonSize)
+                self._titleWidget._tabBarLayout.setRowMinimumHeight(
+                    0, self.QuickAccessButtonSize
+                )
                 self._titleWidget._tabBarLayout.setRowMinimumHeight(1, self.TabBar_Size)
                 # self.setTitle("FreeCAD")
             if Parameters_Ribbon.TOOLBAR_POSITION == 1:  # Toolbars inline with tabbar
@@ -691,13 +768,21 @@ class ModernMenu(RibbonBar):
                 self._titleWidget._tabBarLayout.addWidget(
                     _quickAccessToolBarWidget, 0, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter
                 )
-                self._titleWidget._tabBarLayout.addWidget(_tabBar, 0, 1, 1, 1, Qt.AlignmentFlag.AlignVCenter)
-                self._titleWidget._tabBarLayout.addWidget(_titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter)
-                self._titleWidget._tabBarLayout.addWidget(_rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(
+                    _tabBar, 0, 1, 1, 1, Qt.AlignmentFlag.AlignVCenter
+                )
+                self._titleWidget._tabBarLayout.addWidget(
+                    _titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter
+                )
+                self._titleWidget._tabBarLayout.addWidget(
+                    _rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter
+                )
                 # Change the offsets
                 self.RibbonMinimalHeight = self.QuickAccessButtonSize + 10
                 self.RibbonOffset = 46 + self.QuickAccessButtonSize
-                self._titleWidget._tabBarLayout.setRowMinimumHeight(0, self.QuickAccessButtonSize)
+                self._titleWidget._tabBarLayout.setRowMinimumHeight(
+                    0, self.QuickAccessButtonSize
+                )
 
         # Install an event filter to catch events from the main window and act on it.
         mw.installEventFilter(EventInspector(mw))
@@ -728,7 +813,10 @@ class ModernMenu(RibbonBar):
         TB.show()
         # In FreeCAD 1.0, Overlays are introduced. These have also an enterEvent which results in strange behavior
         # Therefore this function is only activated when FreeCAD's overlay function is disabled.
-        if Parameters_Ribbon.SHOW_ON_HOVER is True and Parameters_Ribbon.USE_FC_OVERLAY is False:
+        if (
+            Parameters_Ribbon.SHOW_ON_HOVER is True
+            and Parameters_Ribbon.USE_FC_OVERLAY is False
+        ):
             self.UnfoldRibbon()
             return
 
@@ -740,7 +828,9 @@ class ModernMenu(RibbonBar):
     # implementation to add actions to the Filemenu. Needed for the accessories menu
     def addAction(self, action: QAction):
         menu = self.findChild(RibbonMenu, "Ribbon")
-        StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+        StyleSheet_Menu = (
+            "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+        )
         menu.setStyleSheet(StyleSheet_Menu)
         if menu is None:
             menu = self.addFileMenu()
@@ -821,7 +911,9 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().setContentsMargins(0, 0, 9, 0)
         # Set the size of the menu button
         self.applicationOptionButton().setFixedSize(
-            self.QuickAccessButtonSize + FontMetrics.boundingRect(Text.text()).width() + 12,
+            self.QuickAccessButtonSize
+            + FontMetrics.boundingRect(Text.text()).width()
+            + 12,
             self.QuickAccessButtonSize,
         )
         # Set the icon
@@ -830,19 +922,24 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().setStyleSheet(
             StyleMapping_Ribbon.ReturnStyleSheet(
                 "applicationbutton",
-                padding_right=str(FontMetrics.horizontalAdvance(Text.text(), -1) + 12) + "px",
+                padding_right=str(FontMetrics.horizontalAdvance(Text.text(), -1) + 12)
+                + "px",
                 radius="4px",
             )
         )
         # Add the default tooltip
-        self.applicationOptionButton().setToolTip(translate("FreeCAD Ribbon", "FreeCAD Ribbon"))
+        self.applicationOptionButton().setToolTip(
+            translate("FreeCAD Ribbon", "FreeCAD Ribbon")
+        )
 
         # add the menus from the menubar to the application button
         self.ApplicationMenus()
 
         # add quick access buttons
         i = 1  # Start value for button count. Used for width of quickaccess toolbar
-        toolBarWidth = ((self.QuickAccessButtonSize * self.sizeFactor) * i) + self.applicationOptionButton().width()
+        toolBarWidth = (
+            (self.QuickAccessButtonSize * self.sizeFactor) * i
+        ) + self.applicationOptionButton().width()
         for commandName in self.ribbonStructure["quickAccessCommands"]:
             i = i + 1
             # Define a width
@@ -874,7 +971,11 @@ class ModernMenu(RibbonBar):
                         height = self.QuickAccessButtonSize
                         button.setFixedSize(width, height)
                         # Set the stylesheet
-                        button.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", f"{padding}px"))
+                        button.setStyleSheet(
+                            StyleMapping_Ribbon.ReturnStyleSheet(
+                                "toolbutton", "2px", f"{padding}px"
+                            )
+                        )
                     elif len(QuickAction) > 1:
                         # set the padding for a dropdown button
                         padding = self.PaddingRight
@@ -886,9 +987,15 @@ class ModernMenu(RibbonBar):
                         height = self.QuickAccessButtonSize
                         button.setFixedSize(width, height)
                         # Set the PopupMode
-                        button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+                        button.setPopupMode(
+                            QToolButton.ToolButtonPopupMode.InstantPopup
+                        )
                         # Set the stylesheet
-                        button.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", f"{padding}px"))
+                        button.setStyleSheet(
+                            StyleMapping_Ribbon.ReturnStyleSheet(
+                                "toolbutton", "2px", f"{padding}px"
+                            )
+                        )
 
                 # If it is a custom dropdown, add the actions one by one.
                 if commandName.endswith("_ddb") is True:
@@ -910,7 +1017,9 @@ class ModernMenu(RibbonBar):
 
                     # Set the stylesheet
                     button.setStyleSheet(
-                        StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", padding_right=f"{padding}px")
+                        StyleMapping_Ribbon.ReturnStyleSheet(
+                            "toolbutton", "2px", padding_right=f"{padding}px"
+                        )
                     )
 
                 # Set the height
@@ -922,7 +1031,9 @@ class ModernMenu(RibbonBar):
                 if len(button.actions()) > 0:
                     self.addQuickAccessButton(button)
                 else:
-                    StandardFunctions.Print(f"{commandName} did not contain any actions!", "Log")
+                    StandardFunctions.Print(
+                        f"{commandName} did not contain any actions!", "Log"
+                    )
 
                 toolBarWidth = toolBarWidth + width
             except Exception as e:
@@ -938,7 +1049,9 @@ class ModernMenu(RibbonBar):
         # Set the width of the quickaccess toolbar.
         self.quickAccessToolBar().setMinimumWidth(toolBarWidth)
         # Set the size policy
-        self.quickAccessToolBar().setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.MinimumExpanding)
+        self.quickAccessToolBar().setSizePolicy(
+            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.MinimumExpanding
+        )
         # needed for excluding from hiding toolbars
         self.quickAccessToolBar().setObjectName("quickAccessToolBar")
         self.quickAccessToolBar().setWindowTitle("quickAccessToolBar")
@@ -950,17 +1063,23 @@ class ModernMenu(RibbonBar):
         self.tabBar().setFont(font)
 
         self.tabBar().setIconSize(QSize(self.TabBar_Size - 6, self.TabBar_Size - 6))
-        self.tabBar().setStyleSheet("margin: 0px;padding: 0px;height: " + str(self.TabBar_Size) + ";")
+        self.tabBar().setStyleSheet(
+            "margin: 0px;padding: 0px;height: " + str(self.TabBar_Size) + ";"
+        )
 
         # Correct colors when no stylesheet is selected for FreeCAD.
         self.quickAccessToolBar().setStyleSheet("")
         if Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True:
-            FreeCAD_preferences = App.ParamGet("User parameter:BaseApp/Preferences/MainWindow")
+            FreeCAD_preferences = App.ParamGet(
+                "User parameter:BaseApp/Preferences/MainWindow"
+            )
             currentStyleSheet = FreeCAD_preferences.GetString("StyleSheet")
             if currentStyleSheet == "":
                 hexColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
                 # Set the quickaccess toolbar background color
-                self.quickAccessToolBar().setStyleSheet("background-color: " + hexColor + ";")
+                self.quickAccessToolBar().setStyleSheet(
+                    "background-color: " + hexColor + ";"
+                )
 
         # Get the order of workbenches from Parameters
         WorkbenchOrderedList: list = Parameters_Ribbon.TAB_ORDER.split(",")
@@ -976,7 +1095,10 @@ class ModernMenu(RibbonBar):
         # There is an issue with the internal assembly wb showing the wrong panel
         # when assembly4 wb is installed and positioned for the internal assembly wb
         for i in range(len(WorkbenchOrderedList)):
-            if WorkbenchOrderedList[i] == "Assembly4Workbench" or WorkbenchOrderedList[i] == "Assembly3Workbench":
+            if (
+                WorkbenchOrderedList[i] == "Assembly4Workbench"
+                or WorkbenchOrderedList[i] == "Assembly3Workbench"
+            ):
                 try:
                     index_1 = WorkbenchOrderedList.index(WorkbenchOrderedList[i])
                     index_2 = WorkbenchOrderedList.index("AssemblyWorkbench")
@@ -1016,10 +1138,14 @@ class ModernMenu(RibbonBar):
                             icon: QIcon = self.ReturnWorkbenchIcon(workbenchName)
                             self.tabBar().setTabIcon(len(self.categories()) - 1, icon)
                         if Parameters_Ribbon.TABBAR_STYLE == 2:
-                            self.tabBar().setTabIcon(len(self.categories()) - 1, QIcon())
+                            self.tabBar().setTabIcon(
+                                len(self.categories()) - 1, QIcon()
+                            )
 
                         # Set the tab data
-                        self.tabBar().setTabData(len(self.categories()) - 1, workbenchName)
+                        self.tabBar().setTabData(
+                            len(self.categories()) - 1, workbenchName
+                        )
 
                         # Set the tooltip
                         MenuText = workbench.MenuText
@@ -1028,14 +1154,20 @@ class ModernMenu(RibbonBar):
                             ToolTipText.lower() != MenuText.lower() + " workbench"
                             and MenuText.lower() != ToolTipText.lower()
                         ):
-                            MenuText = f"<b>{workbench.MenuText}</b><br>{workbench.ToolTip}"
+                            MenuText = (
+                                f"<b>{workbench.MenuText}</b><br>{workbench.ToolTip}"
+                            )
                         else:
                             MenuText = f"<b>{MenuText}<b>"
 
-                        self.tabBar().setTabToolTip(len(self.categories()) - 1, MenuText)
+                        self.tabBar().setTabToolTip(
+                            len(self.categories()) - 1, MenuText
+                        )
 
         # Set the size of the collapseRibbonButton
-        self.collapseRibbonButton().setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
+        self.collapseRibbonButton().setFixedSize(
+            self.RightToolBarButtonSize, self.RightToolBarButtonSize
+        )
 
         # add the searchbar if available
         SearchBarWidth = self.AddSearchBar()
@@ -1053,10 +1185,18 @@ class ModernMenu(RibbonBar):
         if self.OverlayMenu is not None:
             OverlayMenu = QToolButton()
             OverlayMenu.setIcon(QIcon(os.path.join(pathIcons, "Draft_Layer.svg")))
-            OverlayMenu.setToolTip(translate("FreeCAD Ribbon", "Overlay functions") + "...")
+            OverlayMenu.setToolTip(
+                translate("FreeCAD Ribbon", "Overlay functions") + "..."
+            )
             OverlayMenu.setMenu(self.OverlayMenu)
-            OverlayMenu.setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
-            OverlayMenu.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px"))
+            OverlayMenu.setFixedSize(
+                self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
+            )
+            OverlayMenu.setStyleSheet(
+                StyleMapping_Ribbon.ReturnStyleSheet(
+                    control="toolbutton", padding_right="12px"
+                )
+            )
             OverlayMenu.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
             Font = OverlayMenu.font()
             Font.setPixelSize(Parameters_Ribbon.FONTSIZE_MENUS)
@@ -1084,31 +1224,47 @@ class ModernMenu(RibbonBar):
         SettingsMenu.addAction(self.RibbonMenu.menuAction())
         SettingsMenu.setIcon(Gui.getIcon("Std_DlgParameter.svg"))
         SettingsMenu.setToolTip(translate("FreeCAD Ribbon", "Preferences") + "...")
-        SettingsMenu.setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
-        SettingsMenu.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px"))
+        SettingsMenu.setFixedSize(
+            self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
+        )
+        SettingsMenu.setStyleSheet(
+            StyleMapping_Ribbon.ReturnStyleSheet(
+                control="toolbutton", padding_right="12px"
+            )
+        )
         SettingsMenu.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         # add the settingsmenu to the right toolbar
         self.rightToolBar().addWidget(SettingsMenu)
 
         # Set the helpbutton
         self.helpRibbonButton().setEnabled(True)
-        self.helpRibbonButton().setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self.helpRibbonButton().setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
         self.helpRibbonButton().setToolTip(translate("FreeCAD Ribbon", "Help") + "...")
         # Get the default help action from FreeCAD
         helpMenu = mw.findChildren(QMenu, "&Help")[0]
         helpAction = helpMenu.actions()[0]
         self.helpRibbonButton().setIcon(helpAction.icon())
         self.helpRibbonButton().setMenu(self.HelpMenu)
-        self.helpRibbonButton().setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
-        self.helpRibbonButton().setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px")
+        self.helpRibbonButton().setFixedSize(
+            self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
         )
-        self.helpRibbonButton().setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+        self.helpRibbonButton().setStyleSheet(
+            StyleMapping_Ribbon.ReturnStyleSheet(
+                control="toolbutton", padding_right="12px"
+            )
+        )
+        self.helpRibbonButton().setPopupMode(
+            QToolButton.ToolButtonPopupMode.InstantPopup
+        )
 
         # Add a button the enable or disable AutoHide
         pinButton = QToolButton()
         pinButton.setCheckable(True)
-        pinButton.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        pinButton.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
         pinButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
         # Set the correct icon
         if Parameters_Ribbon.AUTOHIDE_RIBBON is True:
@@ -1126,10 +1282,14 @@ class ModernMenu(RibbonBar):
             pinButton.setChecked(False)
         if Parameters_Ribbon.AUTOHIDE_RIBBON is False:
             pinButton.setChecked(True)
-        pinButton.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px"))
+        pinButton.setStyleSheet(
+            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px")
+        )
         ShortcutKey = "Alt+T"
         try:
-            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+            CustomShortCuts = App.ParamGet(
+                "User parameter:BaseApp/Preferences/Shortcut"
+            )
             if "Ribbon_Pin" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Pin")
             if ShortcutKey != "" and ShortcutKey is not None:
@@ -1137,13 +1297,16 @@ class ModernMenu(RibbonBar):
         except Exception:
             pass
         # Set the tooltip
-        ToolTip = translate("FreeCAD Ribbon", "Click to toggle the autohide function on or off")
+        ToolTip = translate(
+            "FreeCAD Ribbon", "Click to toggle the autohide function on or off"
+        )
         if ShortcutKey != "none":
             ToolTip = ToolTip + f"<br></br><i>{ShortcutKey}</i>"
         pinButton.setToolTip(
             translate(
                 "FreeCAD Ribbon",
-                "Click to toggle the autohide function on or off" + f"<br></br><i>{ShortcutKey}</i>",
+                "Click to toggle the autohide function on or off"
+                + f"<br></br><i>{ShortcutKey}</i>",
             )
         )
 
@@ -1177,9 +1340,13 @@ class ModernMenu(RibbonBar):
                     padding_right="3px",
                 )
             )
-            MinimzeButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[3])
+            MinimzeButton.setIcon(
+                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[3]
+            )
             MinimzeButton.clicked.connect(self.MinimizeFreeCAD)
-            MinimzeButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
+            MinimzeButton.setFixedSize(
+                self.RightToolBarButtonSize, self.RightToolBarButtonSize
+            )
             self.rightToolBar().addWidget(MinimzeButton)
             # Restore button
             RestoreButton = QToolButton()
@@ -1194,9 +1361,13 @@ class ModernMenu(RibbonBar):
                     padding_right="3px",
                 )
             )
-            RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2])
+            RestoreButton.setIcon(
+                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2]
+            )
             RestoreButton.clicked.connect(self.RestoreFreeCAD)
-            RestoreButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
+            RestoreButton.setFixedSize(
+                self.RightToolBarButtonSize, self.RightToolBarButtonSize
+            )
             self.rightToolBar().addWidget(RestoreButton)
             # Close button
             CloseButton = QToolButton()
@@ -1211,19 +1382,29 @@ class ModernMenu(RibbonBar):
                     HoverColor="#e62424",
                 )
             )
-            CloseButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[0])
+            CloseButton.setIcon(
+                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[0]
+            )
             CloseButton.clicked.connect(self.CloseFreeCAD)
-            CloseButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
+            CloseButton.setFixedSize(
+                self.RightToolBarButtonSize, self.RightToolBarButtonSize
+            )
             self.rightToolBar().addWidget(CloseButton)
 
         # Set the width of the right toolbar
-        RightToolbarWidth = SearchBarWidth + 3 * (self.RightToolBarButtonSize + 16) + self.RightToolBarButtonSize
+        RightToolbarWidth = (
+            SearchBarWidth
+            + 3 * (self.RightToolBarButtonSize + 16)
+            + self.RightToolBarButtonSize
+        )
         if Parameters_Ribbon.USE_FC_OVERLAY is True:
             RightToolbarWidth = SearchBarWidth + 2 * (self.RightToolBarButtonSize + 16)
         self.rightToolBar().setMinimumWidth(RightToolbarWidth)
         self.setRightToolBarHeight(self.RibbonMinimalHeight)
         # Set the size policy
-        self.rightToolBar().setSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding)
+        self.rightToolBar().setSizePolicy(
+            QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding
+        )
         self.rightToolBar().setSizeIncrement(1, 1)
         # Set the objectName for the right toolbar. needed for excluding from hiding.
         self.rightToolBar().setObjectName("rightToolBar")
@@ -1241,11 +1422,17 @@ class ModernMenu(RibbonBar):
 
                 sea = SearchBoxLight.SearchBoxLight(
                     getItemGroups=lambda: __import__("GetItemGroups").getItemGroups(),
-                    getToolTip=lambda groupId, setParent: __import__("GetItemGroups").getToolTip(groupId, setParent),
-                    getItemDelegate=lambda: __import__("IndentedItemDelegate").IndentedItemDelegate(),
+                    getToolTip=lambda groupId, setParent: __import__(
+                        "GetItemGroups"
+                    ).getToolTip(groupId, setParent),
+                    getItemDelegate=lambda: __import__(
+                        "IndentedItemDelegate"
+                    ).IndentedItemDelegate(),
                 )
                 sea.resultSelected.connect(
-                    lambda index, groupId: __import__("GetItemGroups").onResultSelected(index, groupId)
+                    lambda index, groupId: __import__("GetItemGroups").onResultSelected(
+                        index, groupId
+                    )
                 )
                 sea.setFixedSize(width, self.RightToolBarButtonSize)
                 BeforeAction = self.rightToolBar().actions()[1]
@@ -1263,13 +1450,18 @@ class ModernMenu(RibbonBar):
         MenuBar = mw.menuBar()
 
         # Set a stylesheet specific for the menubar. Otherwise the fontsize of the menus will not be applied
-        StyleSheet_MenuBar = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+        StyleSheet_MenuBar = (
+            "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+        )
         MenuBar.setStyleSheet(StyleSheet_MenuBar)
         # # Add the actions of the menubar to the application menu
         for child in MenuBar.actions():
             if child.objectName() != "&Help" and child.objectName != "AccessoriesMenu":
                 ApplictionMenu.addAction(child)
-            if child.objectName == "AccessoriesMenu" and self.AccessoriesMenu is not None:
+            if (
+                child.objectName == "AccessoriesMenu"
+                and self.AccessoriesMenu is not None
+            ):
                 ApplictionMenu.addMenu(self.AccessoriesMenu)
 
         # if you on macOS, add the ribbon menus to the menubar
@@ -1298,7 +1490,9 @@ class ModernMenu(RibbonBar):
             color = StyleMapping_Ribbon.ReturnStyleItem("DevelopColor")
             Label = QLabel()
             Label.setText("Development version")
-            Label.setStyleSheet(f"color: {color};border: 1px solid {color};border-radius: 2px;")
+            Label.setStyleSheet(
+                f"color: {color};border: 1px solid {color};border-radius: 2px;"
+            )
             ApplictionMenu.addWidget(Label)
         # if there is an update, add a button that opens the addon manager
         if self.UpdateVersion != "" and self.DeveloperVersion == "":
@@ -1337,12 +1531,17 @@ class ModernMenu(RibbonBar):
                 self.AccessoriesMenu.addActions(subMenus)
 
         # Create the overlay menu when the native overlay function is not used
-        if Parameters_Ribbon.USE_FC_OVERLAY is False and Parameters_Ribbon.USE_OVERLAY is True:
+        if (
+            Parameters_Ribbon.USE_FC_OVERLAY is False
+            and Parameters_Ribbon.USE_OVERLAY is True
+        ):
             OverlayMenu = QMenu(translate("FreeCAD Ribbon", "Overlay") + "...", self)
             OverlayMenu.setToolTipsVisible(True)
 
             # Toggle overlay for all -----------------------------------------------------
-            OverlayButton_All = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle overlay for all"))
+            OverlayButton_All = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle overlay for all")
+            )
             OverlayButton_All.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1353,7 +1552,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "F4"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayAll" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayAll")
             except Exception as e:
@@ -1363,7 +1564,9 @@ class ModernMenu(RibbonBar):
             OverlayButton_All.setShortcut(ShortcutKey)
 
             # Toggle transparancy for all -----------------------------------------------------
-            TransparancyButton_All = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle transparancy"))
+            TransparancyButton_All = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle transparancy")
+            )
             TransparancyButton_All.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1374,9 +1577,13 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Shift+F4"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayTransparentAll" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayTransparentAll")
+                    ShortcutKey = CustomShortCuts.GetString(
+                        "Std_DockOverlayTransparentAll"
+                    )
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1385,7 +1592,9 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle overlay for active panel-----------------------------------------------------
-            OverlayButton_Active = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle overlay"))
+            OverlayButton_Active = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle overlay")
+            )
             OverlayButton_Active.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1396,7 +1605,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "F3"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayToggle" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggle")
             except Exception as e:
@@ -1406,7 +1617,9 @@ class ModernMenu(RibbonBar):
             OverlayButton_Active.setShortcut(ShortcutKey)
 
             # Toggle transparancy for active panel-----------------------------------------------------
-            TransparancyButton = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle transparant mode"))
+            TransparancyButton = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle transparant mode")
+            )
             TransparancyButton.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1417,9 +1630,13 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Shift+F3"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayToggleTransparent" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleTransparent")
+                    ShortcutKey = CustomShortCuts.GetString(
+                        "Std_DockOverlayToggleTransparent"
+                    )
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1428,15 +1645,25 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle mouse bypass-----------------------------------------------------
-            ToggleMouseByPass = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Bypass mouse events"))
-            ToggleMouseByPass.setToolTip(translate("FreeCAD Ribbon", "Bypass mouse events in docked overlay windows"))
+            ToggleMouseByPass = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Bypass mouse events")
+            )
+            ToggleMouseByPass.setToolTip(
+                translate(
+                    "FreeCAD Ribbon", "Bypass mouse events in docked overlay windows"
+                )
+            )
             ToggleMouseByPass.triggered.connect(self.ToggleMouseByPass)
             # Get the shortcut from the original command
             ShortcutKey = "T,T"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayMouseTransparent" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayMouseTransparent")
+                    ShortcutKey = CustomShortCuts.GetString(
+                        "Std_DockOverlayMouseTransparent"
+                    )
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1445,7 +1672,9 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle overlay for left panels-----------------------------------------------------
-            OverlayButton_Left = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle left"))
+            OverlayButton_Left = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle left")
+            )
             OverlayButton_Left.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1456,7 +1685,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+left"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayToggleLeft" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleLeft")
             except Exception as e:
@@ -1465,7 +1696,9 @@ class ModernMenu(RibbonBar):
                 ShortcutKey = "Ctrl+left"
             OverlayButton_Left.setShortcut(ShortcutKey)
             # Toggle overlay for right panels-----------------------------------------------------
-            OverlayButton_Right = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle right"))
+            OverlayButton_Right = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle right")
+            )
             OverlayButton_Right.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1476,16 +1709,22 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+right"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayToggleRight" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleRight")
+                    ShortcutKey = CustomShortCuts.GetString(
+                        "Std_DockOverlayToggleRight"
+                    )
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
                 ShortcutKey = "Ctrl+right"
             OverlayButton_Right.setShortcut(ShortcutKey)
             # Toggle overlay for Bottom panels-----------------------------------------------------
-            OverlayButton_Bottom = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle bottom"))
+            OverlayButton_Bottom = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle bottom")
+            )
             OverlayButton_Bottom.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1496,9 +1735,13 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+down"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayToggleBottom" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleBottom")
+                    ShortcutKey = CustomShortCuts.GetString(
+                        "Std_DockOverlayToggleBottom"
+                    )
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1509,15 +1752,23 @@ class ModernMenu(RibbonBar):
             self.OverlayMenu = OverlayMenu
 
         # Create a ribbon menu
-        RibbonMenu = QMenu(translate("FreeCAD Ribbon", "Ribbon UI preferences") + " ...", self)
+        RibbonMenu = QMenu(
+            translate("FreeCAD Ribbon", "Ribbon UI preferences") + " ...", self
+        )
         RibbonMenu.setToolTipsVisible(True)
         # Add the ribbon design button
-        DesignButton = RibbonMenu.addAction(translate("FreeCAD Ribbon", "Ribbon layout"))
-        DesignButton.setToolTip(translate("FreeCAD Ribbon", "Design the ribbon to your preference"))
+        DesignButton = RibbonMenu.addAction(
+            translate("FreeCAD Ribbon", "Ribbon layout")
+        )
+        DesignButton.setToolTip(
+            translate("FreeCAD Ribbon", "Design the ribbon to your preference")
+        )
         DesignButton.triggered.connect(self.loadDesignMenu)
         ShortcutKey = "Alt+L"
         try:
-            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+            CustomShortCuts = App.ParamGet(
+                "User parameter:BaseApp/Preferences/Shortcut"
+            )
             if "Ribbon_Layout" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Layout")
         except Exception:
@@ -1526,13 +1777,19 @@ class ModernMenu(RibbonBar):
             DesignButton.setShortcut(ShortcutKey)
             self.LayoutMenuShortCut = ShortcutKey
         # Add the preference button
-        PreferenceButton = RibbonMenu.addAction(translate("FreeCAD Ribbon", "Preferences"))
-        PreferenceButton.setToolTip(translate("FreeCAD Ribbon", "Set preferences for the Ribbon UI"))
+        PreferenceButton = RibbonMenu.addAction(
+            translate("FreeCAD Ribbon", "Preferences")
+        )
+        PreferenceButton.setToolTip(
+            translate("FreeCAD Ribbon", "Set preferences for the Ribbon UI")
+        )
         PreferenceButton.setMenuRole(QAction.MenuRole.NoRole)
         PreferenceButton.triggered.connect(self.loadSettingsMenu)
         ShortcutKey = "Alt+P"
         try:
-            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+            CustomShortCuts = App.ParamGet(
+                "User parameter:BaseApp/Preferences/Shortcut"
+            )
             if "Ribbon_Preferences" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Preferences")
         except Exception:
@@ -1544,8 +1801,12 @@ class ModernMenu(RibbonBar):
         if os.path.exists(ScriptDir) is True:
             ListScripts = os.listdir(ScriptDir)
             if len(ListScripts) > 0:
-                ScriptButtonMenu = RibbonMenu.addMenu(translate("FreeCAD Ribbon", "Scripts"))
-                ScriptButtonMenu.setToolTip(translate("FreeCAD Ribbon", "Scripts to help setup the ribbon."))
+                ScriptButtonMenu = RibbonMenu.addMenu(
+                    translate("FreeCAD Ribbon", "Scripts")
+                )
+                ScriptButtonMenu.setToolTip(
+                    translate("FreeCAD Ribbon", "Scripts to help setup the ribbon.")
+                )
                 for i in range(len(ListScripts)):
                     ScriptButtonMenu.addAction(
                         ListScripts[i],
@@ -1577,7 +1838,11 @@ class ModernMenu(RibbonBar):
 
         # Add the ribbon helpbutton under the FreeCAD
         RibbonHelpButton = QAction(translate("FreeCAD Ribbon", "Ribbon UI help"))
-        RibbonHelpButton.setToolTip(translate("FreeCAD Ribbon", "Open the help page for the Ribbon UI in your browser"))
+        RibbonHelpButton.setToolTip(
+            translate(
+                "FreeCAD Ribbon", "Open the help page for the Ribbon UI in your browser"
+            )
+        )
         RibbonHelpButton.setIcon(HelpIcon)
         RibbonHelpButton.triggered.connect(self.on_RibbonHelpButton_clicked)
         HelpMenu.insertAction(actions[1], RibbonHelpButton)
@@ -1600,11 +1865,15 @@ class ModernMenu(RibbonBar):
         PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
         version = StandardFunctions.ReturnXML_Value(PackageXML, "version")
         # Create the ribbon about button
-        AboutButton_Ribbon = AboutMenu.addAction(translate("FreeCAD Ribbon", "About Ribbon UI ") + version)
+        AboutButton_Ribbon = AboutMenu.addAction(
+            translate("FreeCAD Ribbon", "About Ribbon UI ") + version
+        )
         AboutButton_Ribbon.setIcon(AboutIcon)
         AboutButton_Ribbon.triggered.connect(self.on_AboutButton_clicked)
         # Create the what's new button
-        WhatsNewButton_Ribbon = AboutMenu.addAction(translate("FreeCAD Ribbon", "What's new?"))
+        WhatsNewButton_Ribbon = AboutMenu.addAction(
+            translate("FreeCAD Ribbon", "What's new?")
+        )
         WhatsNewButton_Ribbon.triggered.connect(self.on_WhatsNewButton_clicked)
         # add the aboutmenu to the help menu
         HelpMenu.addMenu(AboutMenu)
@@ -1651,7 +1920,9 @@ class ModernMenu(RibbonBar):
             Parameters_Ribbon.Settings.SetBoolSetting("AutoHideRibbon", True)
             Parameters_Ribbon.AUTOHIDE_RIBBON = True
 
-            pinButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "Pin Ribbon")[0]
+            pinButton: QToolButton = self.rightToolBar().findChildren(
+                QToolButton, "Pin Ribbon"
+            )[0]
             pinButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed"))
 
             # Make sure that the ribbon remains visible
@@ -1663,7 +1934,9 @@ class ModernMenu(RibbonBar):
             Parameters_Ribbon.Settings.SetBoolSetting("AutoHideRibbon", False)
             Parameters_Ribbon.AUTOHIDE_RIBBON = False
 
-            pinButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "Pin Ribbon")[0]
+            pinButton: QToolButton = self.rightToolBar().findChildren(
+                QToolButton, "Pin Ribbon"
+            )[0]
             pinButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_open"))
 
             # Make sure that the ribbon remains visible
@@ -1708,7 +1981,9 @@ class ModernMenu(RibbonBar):
         # Set the text color depending in tabstyle
         if Parameters_Ribbon.TABBAR_STYLE != 1:
             self.tabBar().setStyleSheet(
-                "QTabBar::tab {color: " + StyleMapping_Ribbon.ReturnStyleItem("FontColor") + ";}"
+                "QTabBar::tab {color: "
+                + StyleMapping_Ribbon.ReturnStyleItem("FontColor")
+                + ";}"
             )
         if Parameters_Ribbon.TABBAR_STYLE == 1:
             self.tabBar().setStyleSheet(
@@ -1789,16 +2064,20 @@ class ModernMenu(RibbonBar):
         # Get the custom panels and add them to the list of toolbars
         try:
             if workbenchName in self.ribbonStructure["customToolbars"]:
-                for CustomPanel in self.ribbonStructure["customToolbars"][workbenchName]:
+                for CustomPanel in self.ribbonStructure["customToolbars"][
+                    workbenchName
+                ]:
                     ListToolbars.append(CustomPanel)
 
                     # remove the original toolbars from the list
-                    Commands = self.ribbonStructure["customToolbars"][workbenchName][CustomPanel]["commands"]
+                    Commands = self.ribbonStructure["customToolbars"][workbenchName][
+                        CustomPanel
+                    ]["commands"]
                     for Command in Commands:
                         try:
-                            OriginalToolbar = self.ribbonStructure["customToolbars"][workbenchName][CustomPanel][
-                                "commands"
-                            ][Command]
+                            OriginalToolbar = self.ribbonStructure["customToolbars"][
+                                workbenchName
+                            ][CustomPanel]["commands"][Command]
                             ListToolbars.remove(OriginalToolbar)
                         except Exception:
                             continue
@@ -1818,7 +2097,9 @@ class ModernMenu(RibbonBar):
 
         try:
             # Get the order of toolbars
-            ToolbarOrder: list = self.ribbonStructure["workbenches"][workbenchName]["toolbars"]["order"]
+            ToolbarOrder: list = self.ribbonStructure["workbenches"][workbenchName][
+                "toolbars"
+            ]["order"]
 
             # Sort the list of toolbars according the toolbar order
             def SortToolbars(toolbar):
@@ -1882,30 +2163,51 @@ class ModernMenu(RibbonBar):
 
             # add separators to the command list.
             if workbenchName in self.ribbonStructure["workbenches"]:
-                if toolbar != "" and toolbar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]:
-                    if "order" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]:
+                if (
+                    toolbar != ""
+                    and toolbar
+                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
+                ):
+                    if (
+                        "order"
+                        in self.ribbonStructure["workbenches"][workbenchName][
+                            "toolbars"
+                        ][toolbar]
+                    ):
                         for j in range(
-                            len(self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"])
+                            len(
+                                self.ribbonStructure["workbenches"][workbenchName][
+                                    "toolbars"
+                                ][toolbar]["order"]
+                            )
                         ):
                             if (
                                 "separator"
-                                in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"][
-                                    j
-                                ].lower()
+                                in self.ribbonStructure["workbenches"][workbenchName][
+                                    "toolbars"
+                                ][toolbar]["order"][j].lower()
                             ):
                                 separator = QToolButton()
                                 separator.setText(
-                                    self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"][j]
+                                    self.ribbonStructure["workbenches"][workbenchName][
+                                        "toolbars"
+                                    ][toolbar]["order"][j]
                                 )
                                 allButtons.insert(j, separator)
 
             if workbenchName in self.ribbonStructure["workbenches"]:
                 # order buttons like defined in ribbonStructure
                 if (
-                    toolbar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
-                    and "order" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]
+                    toolbar
+                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
+                    and "order"
+                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][
+                        toolbar
+                    ]
                 ):
-                    OrderList: list = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"]
+                    OrderList: list = self.ribbonStructure["workbenches"][
+                        workbenchName
+                    ]["toolbars"][toolbar]["order"]
 
                     # XXX check that positionsList consists of strings only
                     def sortButtons(button: QToolButton):
@@ -1914,7 +2216,9 @@ class ModernMenu(RibbonBar):
                         # Get the menu text
                         if len(button.actions()) > 0:
                             action = button.actions()[0]
-                            Text = StandardFunctions.CommandInfoCorrections(action.data())["menuText"]
+                            Text = StandardFunctions.CommandInfoCorrections(
+                                action.data()
+                            )["menuText"]
 
                         if Text == "":
                             return -1
@@ -1934,12 +2238,8 @@ class ModernMenu(RibbonBar):
                 []
             )  # if buttons are used in multiple workbenches, they can show up double. (Sketcher_NewSketch)
             # for button in allButtons:
-            NoSmallButtons_spacer = (
-                0  # needed to count the number of small buttons in a column. (bug fix with adding separators)
-            )
-            NoMediumButtons_spacer = (
-                0  # needed to count the number of medium buttons in a column. (bug fix with adding separators)
-            )
+            NoSmallButtons_spacer = 0  # needed to count the number of small buttons in a column. (bug fix with adding separators)
+            NoMediumButtons_spacer = 0  # needed to count the number of medium buttons in a column. (bug fix with adding separators)
 
             # Define number of rows used per button size
             LargeButtonRows = 3
@@ -1962,9 +2262,9 @@ class ModernMenu(RibbonBar):
                 buttonSize = "small"
                 try:
                     action = button.defaultAction()
-                    buttonSize = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["commands"][
-                        action.data()
-                    ]["size"]
+                    buttonSize = self.ribbonStructure["workbenches"][workbenchName][
+                        "toolbars"
+                    ][toolbar]["commands"][action.data()]["size"]
                     if buttonSize == "small":
                         NoSmallButtons_spacer += 1
                     if buttonSize == "medium":
@@ -2055,22 +2355,28 @@ class ModernMenu(RibbonBar):
                             try:
                                 # If the text is not from a hardcoded dropdown:
                                 if len(action.data().split(", ")) <= 1:
-                                    text = StandardFunctions.CommandInfoCorrections(action.data())["ActionText"]
+                                    text = StandardFunctions.CommandInfoCorrections(
+                                        action.data()
+                                    )["ActionText"]
                             except Exception:
                                 pass
 
                             # try to get alternative text from ribbonStructure
                             try:
-                                textJSON = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                    "commands"
-                                ][action.data()]["text"]
+                                textJSON = self.ribbonStructure["workbenches"][
+                                    workbenchName
+                                ]["toolbars"][toolbar]["commands"][action.data()][
+                                    "text"
+                                ]
 
                                 # There is a bug in freecad with the comp-sketch menu hase the wrong text
                                 if (
                                     action.data() == "PartDesign_CompSketches"
-                                    and self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                        "commands"
-                                    ][action.data()]["text"]
+                                    and self.ribbonStructure["workbenches"][
+                                        workbenchName
+                                    ]["toolbars"][toolbar]["commands"][action.data()][
+                                        "text"
+                                    ]
                                     == "Create datum"
                                 ):
                                     textJSON = "Create sketch"
@@ -2081,13 +2387,19 @@ class ModernMenu(RibbonBar):
                                     # if it is a normal command:
                                     if len(action.data().split(", ")) <= 1:
                                         Command = Gui.Command.get(CommandName)
-                                        MenuName = CommandInfoCorrections(CommandName)["menuText"].replace("&", "")
+                                        MenuName = CommandInfoCorrections(CommandName)[
+                                            "menuText"
+                                        ].replace("&", "")
                                         if CommandName == action.data():
                                             if (
                                                 MenuName
-                                                != self.ribbonStructure["workbenches"][workbenchName]["toolbars"][
-                                                    toolbar
-                                                ]["commands"][action.data()]["text"]
+                                                != self.ribbonStructure["workbenches"][
+                                                    workbenchName
+                                                ]["toolbars"][toolbar]["commands"][
+                                                    action.data()
+                                                ][
+                                                    "text"
+                                                ]
                                                 and MenuName != ""
                                                 and textJSON != ""
                                             ):
@@ -2097,9 +2409,13 @@ class ModernMenu(RibbonBar):
                                         MenuName = action.text()
                                         if (
                                             MenuName
-                                            != self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                                "commands"
-                                            ][action.data()]["text"]
+                                            != self.ribbonStructure["workbenches"][
+                                                workbenchName
+                                            ]["toolbars"][toolbar]["commands"][
+                                                action.data()
+                                            ][
+                                                "text"
+                                            ]
                                             and MenuName != ""
                                             and textJSON != ""
                                         ):
@@ -2124,9 +2440,9 @@ class ModernMenu(RibbonBar):
                                 CommandName = button.text()
 
                             try:
-                                pixmap = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                    "commands"
-                                ][CommandName]["icon"]
+                                pixmap = self.ribbonStructure["workbenches"][
+                                    workbenchName
+                                ]["toolbars"][toolbar]["commands"][CommandName]["icon"]
                             except Exception:
                                 pass
                             actionIcon = self.ReturnCommandIcon(action.data(), pixmap)
@@ -2135,18 +2451,24 @@ class ModernMenu(RibbonBar):
 
                             # try to get alternative icon from ribbonStructure
                             try:
-                                icon_Json = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                    "commands"
-                                ][CommandName]["icon"]
+                                icon_Json = self.ribbonStructure["workbenches"][
+                                    workbenchName
+                                ]["toolbars"][toolbar]["commands"][CommandName]["icon"]
                                 if icon_Json != "":
                                     action.setIcon(Gui.getIcon(icon_Json))
                             except KeyError:
                                 pass
 
                             # If the icon is still none, try to retrieve it from the data file
-                            if action.icon() is None or (action.icon() is not None and action.icon().isNull()):
-                                StandardFunctions.Print(f"An icon retrieved from data file for '{CommandName}'")
-                                DataFile = os.path.join(os.path.dirname(__file__), "RibbonDataFile.dat")
+                            if action.icon() is None or (
+                                action.icon() is not None and action.icon().isNull()
+                            ):
+                                StandardFunctions.Print(
+                                    f"An icon retrieved from data file for '{CommandName}'"
+                                )
+                                DataFile = os.path.join(
+                                    os.path.dirname(__file__), "RibbonDataFile.dat"
+                                )
 
                                 if os.path.exists(DataFile) is True:
                                     Data = {}
@@ -2160,7 +2482,11 @@ class ModernMenu(RibbonBar):
                                             # This works only for FreeCAD Commands
                                             CommandName_Icon = action.data()
                                             if CommandName_Icon == IconItem[0]:
-                                                Icon: QIcon = Serialize_Ribbon.deserializeIcon(IconItem[1])
+                                                Icon: QIcon = (
+                                                    Serialize_Ribbon.deserializeIcon(
+                                                        IconItem[1]
+                                                    )
+                                                )
                                                 action.setIcon(Icon)
                                     except Exception as e:
                                         if Parameters_Ribbon.DEBUG_MODE is True:
@@ -2172,9 +2498,9 @@ class ModernMenu(RibbonBar):
 
                             # get button size from ribbonStructure
                             try:
-                                buttonSize = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                    "commands"
-                                ][CommandName]["size"]
+                                buttonSize = self.ribbonStructure["workbenches"][
+                                    workbenchName
+                                ]["toolbars"][toolbar]["commands"][CommandName]["size"]
                                 if buttonSize == "":
                                     buttonSize = "small"
                             except KeyError:
@@ -2191,7 +2517,10 @@ class ModernMenu(RibbonBar):
                             action.setText(action.text().replace("&", ""))
                             if buttonSize == "small":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_SMALL
-                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
+                                if (
+                                    IconOnly is True
+                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
+                                ):
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2230,7 +2559,10 @@ class ModernMenu(RibbonBar):
 
                             elif buttonSize == "medium":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_MEDIUM
-                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
+                                if (
+                                    IconOnly is True
+                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
+                                ):
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2267,7 +2599,10 @@ class ModernMenu(RibbonBar):
                                 )  # Set fixedheight to false. This is set in the custom widgets
                             elif buttonSize == "large":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_LARGE
-                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
+                                if (
+                                    IconOnly is True
+                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
+                                ):
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2305,17 +2640,23 @@ class ModernMenu(RibbonBar):
                             else:
                                 if Parameters_Ribbon.DEBUG_MODE is True:
                                     if buttonSize != "none":
-                                        print(f"{action.text()} is ignored. Its size was: {buttonSize}")
+                                        print(
+                                            f"{action.text()} is ignored. Its size was: {buttonSize}"
+                                        )
                                 pass
 
                             if btn.menu() is not None:
-                                btn.popupMode(QToolButton.ToolButtonPopupMode.MenuButtonPopup)
+                                btn.popupMode(
+                                    QToolButton.ToolButtonPopupMode.MenuButtonPopup
+                                )
 
                             # Set the background always to background color.
                             # Styling is managed in the custom button class
                             StyleSheet_Addition_Button = (
                                 "QToolButton, QToolButton:hover {background-color: "
-                                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
+                                + StyleMapping_Ribbon.ReturnStyleItem(
+                                    "Background_Color"
+                                )
                                 + ";border: none"
                                 + ";}"
                             )
@@ -2330,7 +2671,10 @@ class ModernMenu(RibbonBar):
                             continue
 
             # Change the name of the view panels to "View"
-            if panel.title() in "Views - Ribbon_newPanel" or panel.title() in "Individual views":
+            if (
+                panel.title() in "Views - Ribbon_newPanel"
+                or panel.title() in "Individual views"
+            ):
                 panel.setTitle(" Views ")
             else:
                 # Remove possible workbench names from the titles
@@ -2370,7 +2714,9 @@ class ModernMenu(RibbonBar):
             actionList = []
             for i in range(len(ButtonList)):
                 button = ButtonList[i]
-                StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+                StyleSheet_Menu = (
+                    "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+                )
                 button.setStyleSheet(StyleSheet_Menu)
                 if len(button.actions()) == 1:
                     actionList.append(button.actions()[0])
@@ -2378,14 +2724,20 @@ class ModernMenu(RibbonBar):
                     actionList.append(button.actions())
             OptionButton = panel.panelOptionButton()
             if len(actionList) > 0:
-                Menu = CustomControls.CustomOptionMenu(OptionButton.menu(), actionList, self)
+                Menu = CustomControls.CustomOptionMenu(
+                    OptionButton.menu(), actionList, self
+                )
                 OptionButton.setMenu(Menu)
-                StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+                StyleSheet_Menu = (
+                    "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+                )
                 Menu.setStyleSheet(StyleSheet_Menu)
                 # Set the behavior of the option button
                 OptionButton.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
                 # Remove the image to avoid double arrows
-                OptionButton.setStyleSheet("RibbonPanelOptionButton::menu-indicator {image: none;}")
+                OptionButton.setStyleSheet(
+                    "RibbonPanelOptionButton::menu-indicator {image: none;}"
+                )
                 Menu = OptionButton.menu()
 
                 # Set the icon
@@ -2394,7 +2746,9 @@ class ModernMenu(RibbonBar):
                     OptionButton.setIcon(OptionButton_Icon)
                 else:
                     OptionButton.setArrowType(Qt.ArrowType.DownArrow)
-                    OptionButton.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
+                    OptionButton.setToolButtonStyle(
+                        Qt.ToolButtonStyle.ToolButtonTextBesideIcon
+                    )
                     OptionButton.setText("more...")
             if len(actionList) == 0:
                 panel.panelOptionButton().hide()
@@ -2403,13 +2757,21 @@ class ModernMenu(RibbonBar):
 
         # Set the previous/next buttons
         category = self.currentCategory()
-        ScrollLeftButton_Category: RibbonCategoryLayoutButton = category.findChildren(RibbonCategoryLayoutButton)[0]
-        ScrollRightButton_Category: RibbonCategoryLayoutButton = category.findChildren(RibbonCategoryLayoutButton)[1]
+        ScrollLeftButton_Category: RibbonCategoryLayoutButton = category.findChildren(
+            RibbonCategoryLayoutButton
+        )[0]
+        ScrollRightButton_Category: RibbonCategoryLayoutButton = category.findChildren(
+            RibbonCategoryLayoutButton
+        )[1]
         ScrollLeftButton_Category.setMinimumWidth(self.iconSize * 0.5)
         ScrollRightButton_Category.setMinimumWidth(self.iconSize * 0.5)
         # get the icons
-        ScrollLeftButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category")
-        ScrollRightButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category")
+        ScrollLeftButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem(
+            "ScrollLeftButton_Category"
+        )
+        ScrollRightButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem(
+            "ScrollRightButton_Category"
+        )
         # Set the icons
         if ScrollLeftButton_Category_Icon is not None:
             ScrollLeftButton_Category.setIcon(ScrollLeftButton_Category_Icon)
@@ -2423,23 +2785,37 @@ class ModernMenu(RibbonBar):
         ScrollLeftButton_Category.setFixedHeight(Parameters_Ribbon.ICON_SIZE_SMALL * 3)
         ScrollRightButton_Category.setFixedHeight(Parameters_Ribbon.ICON_SIZE_SMALL * 3)
         # Set the stylesheet
-        ScrollLeftButton_Category.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton"))
-        ScrollRightButton_Category.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton"))
-        # Connect the custom click event
-        ScrollLeftButton_Category.mousePressEvent = lambda clickLeft: self.on_ScrollButton_Category_clicked(
-            clickLeft, ScrollLeftButton_Category
+        ScrollLeftButton_Category.setStyleSheet(
+            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton")
         )
-        ScrollRightButton_Category.mousePressEvent = lambda clickRight: self.on_ScrollButton_Category_clicked(
-            clickRight, ScrollRightButton_Category
+        ScrollRightButton_Category.setStyleSheet(
+            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton")
+        )
+        # Connect the custom click event
+        ScrollLeftButton_Category.mousePressEvent = (
+            lambda clickLeft: self.on_ScrollButton_Category_clicked(
+                clickLeft, ScrollLeftButton_Category
+            )
+        )
+        ScrollRightButton_Category.mousePressEvent = (
+            lambda clickRight: self.on_ScrollButton_Category_clicked(
+                clickRight, ScrollRightButton_Category
+            )
         )
 
         # Set the maximum height to a high value to prevent from the ribbon to be clipped off
-        self.currentCategory().setMinimumHeight(self.RibbonHeight - self.RibbonMinimalHeight - 3)
-        self.currentCategory().setMaximumHeight(self.RibbonHeight - self.RibbonMinimalHeight - 3)
+        self.currentCategory().setMinimumHeight(
+            self.RibbonHeight - self.RibbonMinimalHeight - 3
+        )
+        self.currentCategory().setMaximumHeight(
+            self.RibbonHeight - self.RibbonMinimalHeight - 3
+        )
         self.setRibbonHeight(self.RibbonHeight)
         return
 
-    def on_ScrollButton_Category_clicked(self, event, ScrollButton: RibbonCategoryLayoutButton):
+    def on_ScrollButton_Category_clicked(
+        self, event, ScrollButton: RibbonCategoryLayoutButton
+    ):
         for i in range(Parameters_Ribbon.RIBBON_CLICKSPEED):
             ScrollButton.click()
         return
@@ -2460,7 +2836,10 @@ class ModernMenu(RibbonBar):
             parentWidget = toolbar.parentWidget()
             toolbar.setHidden(True)
             # hide toolbars that are not in the statusBar and show toolbars that are in the statusbar.
-            if parentWidget.objectName() == "statusBar" or parentWidget.objectName() == "StatusBarArea":
+            if (
+                parentWidget.objectName() == "statusBar"
+                or parentWidget.objectName() == "StatusBarArea"
+            ):
                 toolbar.setEnabled(True)
                 toolbar.setVisible(True)
             # # # Show specific toolbars and go to the next
@@ -2484,7 +2863,11 @@ class ModernMenu(RibbonBar):
         return
 
     def FoldRibbon(self, Ignore=False):
-        if Parameters_Ribbon.AUTOHIDE_RIBBON is True and self.isLoaded is True and Ignore is False:
+        if (
+            Parameters_Ribbon.AUTOHIDE_RIBBON is True
+            and self.isLoaded is True
+            and Ignore is False
+        ):
             if len(mw.findChildren(QDockWidget, "Ribbon")) > 0:
                 TB: QDockWidget = mw.findChildren(QDockWidget, "Ribbon")[0]
                 TB.setMinimumHeight(self.RibbonMinimalHeight)
@@ -2504,7 +2887,10 @@ class ModernMenu(RibbonBar):
 
                     for Group in CustomToolbars:
                         Parameter = App.ParamGet(
-                            "User parameter:BaseApp/Workbench/" + WorkBenchName + "/Toolbar/" + Group
+                            "User parameter:BaseApp/Workbench/"
+                            + WorkBenchName
+                            + "/Toolbar/"
+                            + Group
                         )
                         Name = Parameter.GetString("Name")
                         Toolbars.append([Name, WorkBenchName])
@@ -2513,10 +2899,14 @@ class ModernMenu(RibbonBar):
 
     def List_ReturnCustomToolbars_Global(self):
         Toolbars = []
-        CustomToolbars: list = App.ParamGet("User parameter:BaseApp/Workbench/Global/Toolbar").GetGroups()
+        CustomToolbars: list = App.ParamGet(
+            "User parameter:BaseApp/Workbench/Global/Toolbar"
+        ).GetGroups()
 
         for Group in CustomToolbars:
-            Parameter = App.ParamGet("User parameter:BaseApp/Workbench/Global/Toolbar/" + Group)
+            Parameter = App.ParamGet(
+                "User parameter:BaseApp/Workbench/Global/Toolbar/" + Group
+            )
             Name = Parameter.GetString("Name")
             Toolbars.append([Name, "Global"])
 
@@ -2527,7 +2917,9 @@ class ModernMenu(RibbonBar):
 
         try:
             # Get the commands from the custom panel
-            Commands = self.ribbonStructure["customToolbars"][WorkBenchName][CustomToolbar]["commands"]
+            Commands = self.ribbonStructure["customToolbars"][WorkBenchName][
+                CustomToolbar
+            ]["commands"]
 
             # Get the command and its original toolbar
             for key, value in list(Commands.items()):
@@ -2536,7 +2928,9 @@ class ModernMenu(RibbonBar):
                     # Get the english menutext
                     MenuName = CommandInfoCorrections(CommandName)["menuText"]
                     # Get the translated menutext
-                    MenuNameTtranslated = CommandInfoCorrections(CommandName)["ActionText"]
+                    MenuNameTtranslated = CommandInfoCorrections(CommandName)[
+                        "ActionText"
+                    ]
 
                     if MenuName == key:
                         try:
@@ -2551,11 +2945,16 @@ class ModernMenu(RibbonBar):
                                     if Toolbutton.text() == Child.text():
                                         IsInList = True
 
-                                if Child.text() == MenuNameTtranslated and IsInList is False:
+                                if (
+                                    Child.text() == MenuNameTtranslated
+                                    and IsInList is False
+                                ):
                                     ButtonList.append(Child)
                         except Exception as e:
                             if Parameters_Ribbon.DEBUG_MODE is True:
-                                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}, 3", "Warning")
+                                StandardFunctions.Print(
+                                    f"{e.with_traceback(e.__traceback__)}, 3", "Warning"
+                                )
                             continue
         except Exception:
             pass
@@ -2569,7 +2968,9 @@ class ModernMenu(RibbonBar):
             if WorkBenchName in self.ribbonStructure["newPanels"]:
                 if NewPanel in self.ribbonStructure["newPanels"][WorkBenchName]:
                     # Get the commands from the custom panel
-                    Commands = self.ribbonStructure["newPanels"][WorkBenchName][NewPanel]
+                    Commands = self.ribbonStructure["newPanels"][WorkBenchName][
+                        NewPanel
+                    ]
 
                     # Get the command and its original toolbar
                     for CommandItem in Commands:
@@ -2588,7 +2989,9 @@ class ModernMenu(RibbonBar):
                                     CommandActionList = Command.getAction()
                                 if Command is None:
                                     if Parameters_Ribbon.DEBUG_MODE is True:
-                                        StandardFunctions.Print(f"{CommandName} was None", "Warning")
+                                        StandardFunctions.Print(
+                                            f"{CommandName} was None", "Warning"
+                                        )
                             # If the commandname can be splitted, it is a FreeCAD dropdown
                             if len(CommandName.split(", ")) > 1:
                                 CommandActionList = self.LoadDropDownAction(CommandName)
@@ -2599,10 +3002,14 @@ class ModernMenu(RibbonBar):
                                 # if there is only one action, add it directly
                                 if len(CommandActionList) == 1:
                                     NewToolbutton.addAction(CommandActionList[0])
-                                    NewToolbutton.setDefaultAction(NewToolbutton.actions()[0])
+                                    NewToolbutton.setDefaultAction(
+                                        NewToolbutton.actions()[0]
+                                    )
                                     # If the commandname is from a FreeCAD dropdown, set the commandname as text
                                     if len(CommandName.split(", ")) > 1:
-                                        NewToolbutton.setText(NewToolbutton.actions()[0].text())
+                                        NewToolbutton.setText(
+                                            NewToolbutton.actions()[0].text()
+                                        )
                                 # if there are more actions, create a menu
                                 elif len(CommandActionList) > 1:
                                     menu = QMenu()
@@ -2620,7 +3027,9 @@ class ModernMenu(RibbonBar):
                                 # Set the text for the toolbutton
                                 if len(CommandName.split(", ")) <= 1:
                                     NewToolbutton.setText(
-                                        CommandInfoCorrections(CommandName)["menuText"].replace("&", "")
+                                        CommandInfoCorrections(CommandName)[
+                                            "menuText"
+                                        ].replace("&", "")
                                     )
                                 # # If the commandname is from a FreeCAD dropdown, set the commandname as text
                                 # if len(CommandName.split(", ")) > 1:
@@ -2637,7 +3046,9 @@ class ModernMenu(RibbonBar):
                                 # if there is only one action, add it directly
                                 if len(CommandActionList) == 1:
                                     NewToolbutton.addAction(CommandActionList[0])
-                                    NewToolbutton.setDefaultAction(NewToolbutton.actions()[0])
+                                    NewToolbutton.setDefaultAction(
+                                        NewToolbutton.actions()[0]
+                                    )
                                 # if there are more actions, create a menu
                                 if len(CommandActionList) > 1:
                                     menu = QMenu()
@@ -2660,7 +3071,9 @@ class ModernMenu(RibbonBar):
 
         except Exception as e:
             if Parameters_Ribbon.DEBUG_MODE is True:
-                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}, 4", "Warning")
+                StandardFunctions.Print(
+                    f"{e.with_traceback(e.__traceback__)}, 4", "Warning"
+                )
             pass
         return ButtonList
 
@@ -2701,12 +3114,14 @@ class ModernMenu(RibbonBar):
         # Check whichs is has the most height: 3 small buttons, 2 medium buttons or 1 large button
         # and set the height accordingly
         if (
-            Parameters_Ribbon.ICON_SIZE_SMALL * 3 >= Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
+            Parameters_Ribbon.ICON_SIZE_SMALL * 3
+            >= Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
             and Parameters_Ribbon.ICON_SIZE_SMALL * 3 >= LargeButtonHeight
         ):
             ribbonHeight = ribbonHeight + Parameters_Ribbon.ICON_SIZE_SMALL * 3 + 6
         elif (
-            Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 >= Parameters_Ribbon.ICON_SIZE_SMALL * 3
+            Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
+            >= Parameters_Ribbon.ICON_SIZE_SMALL * 3
             and Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 >= LargeButtonHeight
         ):
             ribbonHeight = ribbonHeight + Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 + 4
@@ -2819,10 +3234,18 @@ class ModernMenu(RibbonBar):
             Enable = False
 
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
-        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
-        OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
+        OverlayParam_Left = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
+        )
+        OverlayParam_Right = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
+        )
+        OverlayParam_Top = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayTop"
+        )
+        OverlayParam_Bottom = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
+        )
 
         # If overlay is enabled, go here
         PanelsLeft = []
@@ -2905,10 +3328,16 @@ class ModernMenu(RibbonBar):
         OverlayParam_Right = None
         OverlayParam_Bottom = None
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
-        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
+        OverlayParam_Left = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
+        )
+        OverlayParam_Right = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
+        )
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
+        OverlayParam_Bottom = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
+        )
 
         # Ge the focused dockwidget
         FocusWidget = mw.focusWidget().parent().objectName()
@@ -2954,22 +3383,32 @@ class ModernMenu(RibbonBar):
             RightPanels = OverlayParam_Right.GetString("Widgets")
             if FocusWidget in RightPanels:
                 RightPanels = OverlayParam_Left.GetString("Widgets")
-                RightPanels = RightPanels.replace(f"{FocusWidget}", "").replace(",,", ",")
+                RightPanels = RightPanels.replace(f"{FocusWidget}", "").replace(
+                    ",,", ","
+                )
                 OverlayParam_Right.SetString("Widgets", f"{RightPanels}")
                 return
             BottomPanels = OverlayParam_Bottom.GetString("Widgets")
             if FocusWidget in BottomPanels:
                 BottomPanels = OverlayParam_Bottom.GetString("Widgets")
-                BottomPanels = BottomPanels.replace(f"{FocusWidget}", "").replace(",,", ",")
+                BottomPanels = BottomPanels.replace(f"{FocusWidget}", "").replace(
+                    ",,", ","
+                )
                 OverlayParam_Bottom.SetString("Widgets", f"{BottomPanels}")
                 return
         return
 
     def CustomTransparancy(self):
-        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
-        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
+        OverlayParam_Left = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
+        )
+        OverlayParam_Right = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
+        )
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
+        OverlayParam_Bottom = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
+        )
 
         Enable = None
         if OverlayParam_Left.GetBool("Transparent") is False:
@@ -2991,10 +3430,16 @@ class ModernMenu(RibbonBar):
         OverlayParam_Right = None
         OverlayParam_Bottom = None
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
-        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
+        OverlayParam_Left = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
+        )
+        OverlayParam_Right = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
+        )
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
+        OverlayParam_Bottom = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
+        )
 
         # Ge the focused dockwidget
         FocusWidget = mw.focusWidget().parent().objectName()
@@ -3020,15 +3465,21 @@ class ModernMenu(RibbonBar):
         if position == "":
             LeftPanels = OverlayParam_Left.GetString("Widgets")
             if FocusWidget in LeftPanels:
-                OverlayParam_Left.SetBool("Transparent", not OverlayParam_Left.GetBool("Transparent"))
+                OverlayParam_Left.SetBool(
+                    "Transparent", not OverlayParam_Left.GetBool("Transparent")
+                )
                 return
             RightPanels = OverlayParam_Right.GetString("Widgets")
             if FocusWidget in RightPanels:
-                OverlayParam_Right.SetBool("Transparent", not OverlayParam_Right.GetBool("Transparent"))
+                OverlayParam_Right.SetBool(
+                    "Transparent", not OverlayParam_Right.GetBool("Transparent")
+                )
                 return
             BottomPanels = OverlayParam_Bottom.GetString("Widgets")
             if FocusWidget in BottomPanels:
-                OverlayParam_Bottom.SetBool("Transparent", not OverlayParam_Bottom.GetBool("Transparent"))
+                OverlayParam_Bottom.SetBool(
+                    "Transparent", not OverlayParam_Bottom.GetBool("Transparent")
+                )
                 return
         return
 
@@ -3036,7 +3487,9 @@ class ModernMenu(RibbonBar):
         actionList = []
 
         try:
-            for DropDownCommand, Commands in self.ribbonStructure["dropdownButtons"].items():
+            for DropDownCommand, Commands in self.ribbonStructure[
+                "dropdownButtons"
+            ].items():
                 if CommandName == DropDownCommand:
                     for CommandItem in Commands:
                         Command = Gui.Command.get(CommandItem[0])
@@ -3047,7 +3500,9 @@ class ModernMenu(RibbonBar):
             return actionList
         except Exception as e:
             if Parameters_Ribbon.DEBUG_MODE is True:
-                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}", "Warning")
+                StandardFunctions.Print(
+                    f"{e.with_traceback(e.__traceback__)}", "Warning"
+                )
             return
 
     def CloseFreeCAD(self):
@@ -3063,7 +3518,9 @@ class ModernMenu(RibbonBar):
         # if self.isLoaded:
         StatusBarState = mw.findChild(QStatusBar, "statusBar").isVisible()
         # Get the style and restore button
-        RestoreButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
+        RestoreButton: QToolButton = self.rightToolBar().findChildren(
+            QToolButton, "RestoreButton"
+        )[0]
         # If the mainwindow is maximized, set the mainwindow to normal, set a size and icon
         if mw.isMaximized() is True:
             try:
@@ -3151,18 +3608,27 @@ class ModernMenu(RibbonBar):
 
     def CheckLanguage(self):
         FreeCAD_preferences = App.ParamGet("User parameter:BaseApp/Preferences/General")
-        if self.ribbonStructure["language"] != FreeCAD_preferences.GetString("Language"):
+        if self.ribbonStructure["language"] != FreeCAD_preferences.GetString(
+            "Language"
+        ):
             if "workbenches" in self.ribbonStructure:
                 for workbenchName in self.ribbonStructure["workbenches"]:
                     if "toolbars" in self.ribbonStructure["workbenches"][workbenchName]:
-                        for ToolBar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]:
-                            if "commands" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar]:
-                                for Command in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar][
-                                    "commands"
-                                ]:
-                                    self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar]["commands"][
-                                        Command
-                                    ]["text"] = ""
+                        for ToolBar in self.ribbonStructure["workbenches"][
+                            workbenchName
+                        ]["toolbars"]:
+                            if (
+                                "commands"
+                                in self.ribbonStructure["workbenches"][workbenchName][
+                                    "toolbars"
+                                ][ToolBar]
+                            ):
+                                for Command in self.ribbonStructure["workbenches"][
+                                    workbenchName
+                                ]["toolbars"][ToolBar]["commands"]:
+                                    self.ribbonStructure["workbenches"][workbenchName][
+                                        "toolbars"
+                                    ][ToolBar]["commands"][Command]["text"] = ""
 
             print("Ribbon UI: Custom text are reset because the language was changed")
         return
@@ -3180,27 +3646,36 @@ class EventInspector(QObject):
             mw.showMaximal()
             Style = mw.style()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
-            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
+            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(
+                QToolButton, "RestoreButton"
+            )[0]
             try:
-                RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton))
+                RestoreButton.setIcon(
+                    Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton)
+                )
             except Exception:
                 pass
             return QObject.eventFilter(self, obj, event)
         # This is a workaround for windows
         # If the window stat changes and the titlebar is hidden, catch the event
         if (
-            event.type() == QEvent.Type.WindowStateChange or event.type() == QEvent.Type.DragMove
+            event.type() == QEvent.Type.WindowStateChange
+            or event.type() == QEvent.Type.DragMove
         ) and Parameters_Ribbon.HIDE_TITLEBAR_FC is True:
             # Get the main window, its style, the ribbon and the restore button
             mw = Gui.getMainWindow()
             Style = mw.style()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
-            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
+            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(
+                QToolButton, "RestoreButton"
+            )[0]
             # If the mainwindow is maximized, set the window state to maximize and set the correct icon
             if mw.isMaximized():
                 try:
                     # RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton))
-                    RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2])
+                    RestoreButton.setIcon(
+                        StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2]
+                    )
                 except Exception:
                     pass
                 return QObject.eventFilter(self, obj, event)
@@ -3208,13 +3683,18 @@ class EventInspector(QObject):
             if mw.isMaximized() is False:
                 try:
                     # RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarMaxButton))
-                    RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1])
+                    RestoreButton.setIcon(
+                        StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1]
+                    )
                 except Exception:
                     pass
                 return QObject.eventFilter(self, obj, event)
         # If the event is a modfied event, update the title
         # This is done when switching from one part to another
-        if event.type() == QEvent.Type.ModifiedChange and Parameters_Ribbon.TOOLBAR_POSITION == 0:
+        if (
+            event.type() == QEvent.Type.ModifiedChange
+            and Parameters_Ribbon.TOOLBAR_POSITION == 0
+        ):
             # Get the mainwindow, the ribbon and the title
             mw = Gui.getMainWindow()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
@@ -3222,7 +3702,9 @@ class EventInspector(QObject):
             # If there is an active document, continue here
             if App.ActiveDocument is not None:
                 # Define the standard title as a prefix
-                Prefix = f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
+                Prefix = (
+                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
+                )
                 # if the title is not equal to the prefix with the active document label,
                 # Get the text from the active tab from the viewport and combine it with the prefix
                 # Set it as the new title
@@ -3233,7 +3715,9 @@ class EventInspector(QObject):
                     RibbonBar.setTitle(Prefix + " - " + CurrentText)
             # If there is no active document, set just the standard title
             if App.ActiveDocument is None:
-                RibbonBar.setTitle(f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}")
+                RibbonBar.setTitle(
+                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
+                )
             return QObject.eventFilter(self, obj, event)
         return False
 

--- a/FCBinding.py
+++ b/FCBinding.py
@@ -181,9 +181,7 @@ class ModernMenu(RibbonBar):
     # Create an offset for the panelheight
     PanelHeightOffset = 36
     # Create an offset for the whole ribbon height
-    RibbonOffset = (
-        50 + QuickAccessButtonSize * 2
-    )  # Set to zero to hide the panel titles
+    RibbonOffset = 50 + QuickAccessButtonSize * 2  # Set to zero to hide the panel titles
 
     # Set the minimum height for the ribbon
     RibbonMinimalHeight = QuickAccessButtonSize * 2 + 16
@@ -317,13 +315,8 @@ class ModernMenu(RibbonBar):
             ]
         else:
             try:
-                if (
-                    "Views - Ribbon_newPanel"
-                    in self.ribbonStructure["newPanels"]["Global"]
-                ):
-                    del self.ribbonStructure["newPanels"]["Global"][
-                        "Views - Ribbon_newPanel"
-                    ]
+                if "Views - Ribbon_newPanel" in self.ribbonStructure["newPanels"]["Global"]:
+                    del self.ribbonStructure["newPanels"]["Global"]["Views - Ribbon_newPanel"]
             except Exception:
                 pass
         # # Add a toolbar "tools"
@@ -333,14 +326,11 @@ class ModernMenu(RibbonBar):
         try:
             NeedsUpdating = False
             if "Tools_newPanel" in self.ribbonStructure["newPanels"]["Global"]:
-                for item in self.ribbonStructure["newPanels"]["Global"][
-                    "Tools_newPanel"
-                ]:
+                for item in self.ribbonStructure["newPanels"]["Global"]["Tools_newPanel"]:
                     if item[1] != "Standard":
                         NeedsUpdating = True
             if (
-                "Tools_newPanel" not in self.ribbonStructure["newPanels"]["Global"]
-                and UseToolsPanel is True
+                "Tools_newPanel" not in self.ribbonStructure["newPanels"]["Global"] and UseToolsPanel is True
             ) or NeedsUpdating is True:
                 StandardFunctions.add_keys_nested_dict(
                     self.ribbonStructure,
@@ -409,9 +399,7 @@ class ModernMenu(RibbonBar):
 
         # Get the address of the repository address
         PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
-        self.ReproAdress = StandardFunctions.ReturnXML_Value(
-            PackageXML, "url", "type", "repository"
-        )
+        self.ReproAdress = StandardFunctions.ReturnXML_Value(PackageXML, "url", "type", "repository")
         if self.ReproAdress != "" or self.ReproAdress is not None:
             print(translate("FreeCAD Ribbon", "FreeCAD Ribbon: ") + self.ReproAdress)
 
@@ -421,9 +409,7 @@ class ModernMenu(RibbonBar):
                 for WorkBenchName in self.ribbonStructure["newPanels"]:
                     for NewPanel in self.ribbonStructure["newPanels"][WorkBenchName]:
                         # Get the commands from the custom panel
-                        Commands = self.ribbonStructure["newPanels"][WorkBenchName][
-                            NewPanel
-                        ]
+                        Commands = self.ribbonStructure["newPanels"][WorkBenchName][NewPanel]
 
                         # Get the command and its original toolbar
                         for CommandItem in Commands:
@@ -445,15 +431,9 @@ class ModernMenu(RibbonBar):
         # Activate the workbenches used in the dropdown buttons otherwise the button stays empty
         try:
             if "dropdownButtons" in self.ribbonStructure:
-                for DropDownCommand, Commands in self.ribbonStructure[
-                    "dropdownButtons"
-                ].items():
+                for DropDownCommand, Commands in self.ribbonStructure["dropdownButtons"].items():
                     for CommandItem in Commands:
-                        if (
-                            CommandItem[1] != "General"
-                            and CommandItem[1] != "Global"
-                            and CommandItem[1] != "Standard"
-                        ):
+                        if CommandItem[1] != "General" and CommandItem[1] != "Global" and CommandItem[1] != "Standard":
                             # Activate the workbench if not loaded
                             Gui.activateWorkbench(CommandItem[1])
         except Exception as e:
@@ -472,15 +452,11 @@ class ModernMenu(RibbonBar):
             Branch = "main"
             File = "package.xml"
             ElementName = "version"
-            LatestVersion = StandardFunctions.ReturnXML_Value_Git(
-                User, Repo, Branch, File, ElementName
-            )
+            LatestVersion = StandardFunctions.ReturnXML_Value_Git(User, Repo, Branch, File, ElementName)
             if LatestVersion is not None:
                 # Get the current version
                 PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
-                CurrentVersion = StandardFunctions.ReturnXML_Value(
-                    PackageXML, "version"
-                )
+                CurrentVersion = StandardFunctions.ReturnXML_Value(PackageXML, "version")
                 # Check if you are on a developer version. If so set developer version
                 if CurrentVersion.lower().endswith("x"):
                     self.DeveloperVersion = CurrentVersion
@@ -513,29 +489,15 @@ class ModernMenu(RibbonBar):
         StyleSheet = Path(Parameters_Ribbon.STYLESHEET).read_text()
         # modify the stylesheet to set the border and background for a toolbar and menu
         hexColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
-        hexColorTab = StyleMapping_Ribbon.ReturnStyleItem(
-            "Background_Color", True, True
-        )
-        if (
-            hexColor is not None
-            and hexColor != ""
-            and Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True
-        ):
+        hexColorTab = StyleMapping_Ribbon.ReturnStyleItem("Background_Color", True, True)
+        if hexColor is not None and hexColor != "" and Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True:
             # Set the quickaccess toolbar background color. This fixes a transparant toolbar.
-            self.quickAccessToolBar().setStyleSheet(
-                "QToolBar {background: " + hexColor + ";}"
-            )
+            self.quickAccessToolBar().setStyleSheet("QToolBar {background: " + hexColor + ";}")
             self.tabBar().setStyleSheet("background: " + hexColorTab + ";")
             # Set the background color. This fixes transparant backgrounds when FreeCAD has no stylesheet
-            StyleSheet_Addition = (
-                "\n\nQToolButton {background: solid " + hexColor + ";}"
-            )
+            StyleSheet_Addition = "\n\nQToolButton {background: solid " + hexColor + ";}"
             StyleSheet_Addition_2 = (
-                "\n\nRibbonBar {border: none;background: solid "
-                + hexColor
-                + ";color: "
-                + hexColor
-                + ";}"
+                "\n\nRibbonBar {border: none;background: solid " + hexColor + ";color: " + hexColor + ";}"
             )
             StyleSheet = StyleSheet_Addition_2 + StyleSheet + StyleSheet_Addition
         self.setStyleSheet(StyleSheet)
@@ -545,13 +507,9 @@ class ModernMenu(RibbonBar):
             StyleSheet_Addition_3 = (
                 """QTabBar::tab {
                     background: """
-                + StyleMapping_Ribbon.ReturnStyleItem(
-                    "Background_Color_Hover", True, True
-                )
+                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color_Hover", True, True)
                 + """;color: """
-                + StyleMapping_Ribbon.ReturnStyleItem(
-                    "Background_Color_Hover", True, True
-                )
+                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color_Hover", True, True)
                 + """;min-width: """
                 + str(self.TabBar_Size)
                 + """px;
@@ -624,9 +582,7 @@ class ModernMenu(RibbonBar):
         self.tabBar().tabBarClicked.connect(self.onTabBarClicked)
 
         # override the default scroll behavior with a custom function
-        self.tabBar().wheelEvent = lambda event_tabBar: self.wheelEvent_TabBar(
-            event_tabBar
-        )
+        self.tabBar().wheelEvent = lambda event_tabBar: self.wheelEvent_TabBar(event_tabBar)
         self.wheelEvent = lambda event_CC: self.wheelEvent_CC(event_CC)
         self.tabBar().setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.currentCategory().setFocusPolicy(Qt.FocusPolicy.StrongFocus)
@@ -639,20 +595,12 @@ class ModernMenu(RibbonBar):
         ScrollLeftButton_Tab: QToolButton = self.tabBar().findChildren(QToolButton)[0]
         ScrollRightButton_Tab: QToolButton = self.tabBar().findChildren(QToolButton)[1]
         # get the icons
-        ScrollLeftButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem(
-            "ScrollLeftButton_Tab"
-        )
-        ScrollRightButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem(
-            "ScrollRightButton_Tab"
-        )
+        ScrollLeftButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab")
+        ScrollRightButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab")
         # Set the icons
         StyleSheet = "QToolButton {image: none;margin-top:6px;margin-bottom:6px;};QToolButton::arrow {image: none};"
         BackgroundColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
-        if (
-            int(App.Version()[0]) == 0
-            and int(App.Version()[1]) <= 21
-            and BackgroundColor is not None
-        ):
+        if int(App.Version()[0]) == 0 and int(App.Version()[1]) <= 21 and BackgroundColor is not None:
             StyleSheet = (
                 """QToolButton {image: none;background: """
                 + BackgroundColor
@@ -662,9 +610,7 @@ class ModernMenu(RibbonBar):
             ScrollLeftButton_Tab.setStyleSheet(StyleSheet)
             ScrollLeftButton_Tab.setIcon(ScrollLeftButton_Tab_Icon)
         else:
-            ScrollRightButton_Tab.setToolButtonStyle(
-                Qt.ToolButtonStyle.ToolButtonTextOnly
-            )
+            ScrollRightButton_Tab.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
         if ScrollRightButton_Tab_Icon is not None:
             ScrollRightButton_Tab.setStyleSheet(StyleSheet)
             ScrollRightButton_Tab.setIcon(ScrollRightButton_Tab_Icon)
@@ -672,13 +618,9 @@ class ModernMenu(RibbonBar):
             ScrollRightButton_Tab.setArrowType(Qt.ArrowType.RightArrow)
 
         # Remove persistant toolbars
-        PersistentToolbars = App.ParamGet(
-            "User parameter:Tux/PersistentToolbars/User"
-        ).GetGroups()
+        PersistentToolbars = App.ParamGet("User parameter:Tux/PersistentToolbars/User").GetGroups()
         for Group in PersistentToolbars:
-            Parameter = App.ParamGet(
-                "User parameter:Tux/PersistentToolbars/User/" + Group
-            )
+            Parameter = App.ParamGet("User parameter:Tux/PersistentToolbars/User/" + Group)
             Parameter.SetString("Top", "")
             Parameter.SetString("Left", "")
             Parameter.SetString("Right", "")
@@ -689,9 +631,7 @@ class ModernMenu(RibbonBar):
         # Application menu
         ShortcutKey = "Alt+A"
         try:
-            CustomShortCuts = App.ParamGet(
-                "User parameter:BaseApp/Preferences/Shortcut"
-            )
+            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
             if "Ribbon_Menu" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Menu")
         except Exception:
@@ -708,10 +648,7 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().enterEvent = lambda enter: self.leaveEvent(enter)
 
         # Rearrange the tabbar and toolbars
-        if (
-            Parameters_Ribbon.TOOLBAR_POSITION == 0
-            or Parameters_Ribbon.TOOLBAR_POSITION == 1
-        ):
+        if Parameters_Ribbon.TOOLBAR_POSITION == 0 or Parameters_Ribbon.TOOLBAR_POSITION == 1:
             # Get the widgets
             _quickAccessToolBarWidget = self.quickAccessToolBar()
             _titleLabel = self._titleWidget._titleLabel
@@ -729,38 +666,24 @@ class ModernMenu(RibbonBar):
                 _titleLabel.setAlignment(Qt.AlignmentFlag.AlignCenter)
                 _titleLabel.setFont(font)
                 # Set the label text to FreeCAD's version
-                text = (
-                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
-                )
+                text = f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
                 _titleLabel.setText(text)
                 # Create a spacer to set the tab
                 spacer = QWidget()
-                spacer.setSizePolicy(
-                    QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
-                )
+                spacer.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
                 spacer.setFixedWidth(3)
                 self._titleWidget._tabBarLayout.setContentsMargins(3, 3, 3, 0)
                 self._titleWidget._tabBarLayout.addWidget(
                     _quickAccessToolBarWidget, 0, 0, 1, 2, Qt.AlignmentFlag.AlignVCenter
                 )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter
-                )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter
-                )
-                self._titleWidget._tabBarLayout.addWidget(
-                    spacer, 1, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter
-                )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _tabBar, 1, 1, 1, 4, Qt.AlignmentFlag.AlignVCenter
-                )
+                self._titleWidget._tabBarLayout.addWidget(_titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(_rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(spacer, 1, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(_tabBar, 1, 1, 1, 4, Qt.AlignmentFlag.AlignVCenter)
                 # Change the offsets
                 self.RibbonMinimalHeight = self.QuickAccessButtonSize * 2 + 20
                 self.RibbonOffset = 54 + self.QuickAccessButtonSize * 2
-                self._titleWidget._tabBarLayout.setRowMinimumHeight(
-                    0, self.QuickAccessButtonSize
-                )
+                self._titleWidget._tabBarLayout.setRowMinimumHeight(0, self.QuickAccessButtonSize)
                 self._titleWidget._tabBarLayout.setRowMinimumHeight(1, self.TabBar_Size)
                 # self.setTitle("FreeCAD")
             if Parameters_Ribbon.TOOLBAR_POSITION == 1:  # Toolbars inline with tabbar
@@ -768,40 +691,26 @@ class ModernMenu(RibbonBar):
                 self._titleWidget._tabBarLayout.addWidget(
                     _quickAccessToolBarWidget, 0, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter
                 )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _tabBar, 0, 1, 1, 1, Qt.AlignmentFlag.AlignVCenter
-                )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter
-                )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter
-                )
+                self._titleWidget._tabBarLayout.addWidget(_tabBar, 0, 1, 1, 1, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(_titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(_rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter)
                 # Change the offsets
                 self.RibbonMinimalHeight = self.QuickAccessButtonSize + 10
                 self.RibbonOffset = 46 + self.QuickAccessButtonSize
-                self._titleWidget._tabBarLayout.setRowMinimumHeight(
-                    0, self.QuickAccessButtonSize
-                )
+                self._titleWidget._tabBarLayout.setRowMinimumHeight(0, self.QuickAccessButtonSize)
 
         # Get the main window, its style, the ribbon and the restore button
-        RestoreButton: QToolButton = self.rightToolBar().findChildren(
-            QToolButton, "RestoreButton"
-        )[0]
+        RestoreButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
         # If the mainwindow is maximized, set the window state to maximize and set the correct icon
         if mw.isMaximized():
             try:
-                RestoreButton.setIcon(
-                    StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2]
-                )
+                RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2])
             except Exception:
                 pass
         # If the mainwindow is not maximized, set the window state to no state and set the correct icon
         if mw.isMaximized() is False:
             try:
-                RestoreButton.setIcon(
-                    StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1]
-                )
+                RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1])
             except Exception:
                 pass
 
@@ -834,10 +743,7 @@ class ModernMenu(RibbonBar):
         TB.show()
         # In FreeCAD 1.0, Overlays are introduced. These have also an enterEvent which results in strange behavior
         # Therefore this function is only activated when FreeCAD's overlay function is disabled.
-        if (
-            Parameters_Ribbon.SHOW_ON_HOVER is True
-            and Parameters_Ribbon.USE_FC_OVERLAY is False
-        ):
+        if Parameters_Ribbon.SHOW_ON_HOVER is True and Parameters_Ribbon.USE_FC_OVERLAY is False:
             self.UnfoldRibbon()
             return
 
@@ -849,9 +755,7 @@ class ModernMenu(RibbonBar):
     # implementation to add actions to the Filemenu. Needed for the accessories menu
     def addAction(self, action: QAction):
         menu = self.findChild(RibbonMenu, "Ribbon")
-        StyleSheet_Menu = (
-            "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
-        )
+        StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
         menu.setStyleSheet(StyleSheet_Menu)
         if menu is None:
             menu = self.addFileMenu()
@@ -932,9 +836,7 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().setContentsMargins(0, 0, 9, 0)
         # Set the size of the menu button
         self.applicationOptionButton().setFixedSize(
-            self.QuickAccessButtonSize
-            + FontMetrics.boundingRect(Text.text()).width()
-            + 12,
+            self.QuickAccessButtonSize + FontMetrics.boundingRect(Text.text()).width() + 12,
             self.QuickAccessButtonSize,
         )
         # Set the icon
@@ -943,24 +845,19 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().setStyleSheet(
             StyleMapping_Ribbon.ReturnStyleSheet(
                 "applicationbutton",
-                padding_right=str(FontMetrics.horizontalAdvance(Text.text(), -1) + 12)
-                + "px",
+                padding_right=str(FontMetrics.horizontalAdvance(Text.text(), -1) + 12) + "px",
                 radius="4px",
             )
         )
         # Add the default tooltip
-        self.applicationOptionButton().setToolTip(
-            translate("FreeCAD Ribbon", "FreeCAD Ribbon")
-        )
+        self.applicationOptionButton().setToolTip(translate("FreeCAD Ribbon", "FreeCAD Ribbon"))
 
         # add the menus from the menubar to the application button
         self.ApplicationMenus()
 
         # add quick access buttons
         i = 1  # Start value for button count. Used for width of quickaccess toolbar
-        toolBarWidth = (
-            (self.QuickAccessButtonSize * self.sizeFactor) * i
-        ) + self.applicationOptionButton().width()
+        toolBarWidth = ((self.QuickAccessButtonSize * self.sizeFactor) * i) + self.applicationOptionButton().width()
         for commandName in self.ribbonStructure["quickAccessCommands"]:
             i = i + 1
             # Define a width
@@ -992,11 +889,7 @@ class ModernMenu(RibbonBar):
                         height = self.QuickAccessButtonSize
                         button.setFixedSize(width, height)
                         # Set the stylesheet
-                        button.setStyleSheet(
-                            StyleMapping_Ribbon.ReturnStyleSheet(
-                                "toolbutton", "2px", f"{padding}px"
-                            )
-                        )
+                        button.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", f"{padding}px"))
                     elif len(QuickAction) > 1:
                         # set the padding for a dropdown button
                         padding = self.PaddingRight
@@ -1008,15 +901,9 @@ class ModernMenu(RibbonBar):
                         height = self.QuickAccessButtonSize
                         button.setFixedSize(width, height)
                         # Set the PopupMode
-                        button.setPopupMode(
-                            QToolButton.ToolButtonPopupMode.InstantPopup
-                        )
+                        button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
                         # Set the stylesheet
-                        button.setStyleSheet(
-                            StyleMapping_Ribbon.ReturnStyleSheet(
-                                "toolbutton", "2px", f"{padding}px"
-                            )
-                        )
+                        button.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", f"{padding}px"))
 
                 # If it is a custom dropdown, add the actions one by one.
                 if commandName.endswith("_ddb") is True:
@@ -1038,9 +925,7 @@ class ModernMenu(RibbonBar):
 
                     # Set the stylesheet
                     button.setStyleSheet(
-                        StyleMapping_Ribbon.ReturnStyleSheet(
-                            "toolbutton", "2px", padding_right=f"{padding}px"
-                        )
+                        StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", padding_right=f"{padding}px")
                     )
 
                 # Set the height
@@ -1052,9 +937,7 @@ class ModernMenu(RibbonBar):
                 if len(button.actions()) > 0:
                     self.addQuickAccessButton(button)
                 else:
-                    StandardFunctions.Print(
-                        f"{commandName} did not contain any actions!", "Log"
-                    )
+                    StandardFunctions.Print(f"{commandName} did not contain any actions!", "Log")
 
                 toolBarWidth = toolBarWidth + width
             except Exception as e:
@@ -1070,9 +953,7 @@ class ModernMenu(RibbonBar):
         # Set the width of the quickaccess toolbar.
         self.quickAccessToolBar().setMinimumWidth(toolBarWidth)
         # Set the size policy
-        self.quickAccessToolBar().setSizePolicy(
-            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.MinimumExpanding
-        )
+        self.quickAccessToolBar().setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.MinimumExpanding)
         # needed for excluding from hiding toolbars
         self.quickAccessToolBar().setObjectName("quickAccessToolBar")
         self.quickAccessToolBar().setWindowTitle("quickAccessToolBar")
@@ -1084,23 +965,17 @@ class ModernMenu(RibbonBar):
         self.tabBar().setFont(font)
 
         self.tabBar().setIconSize(QSize(self.TabBar_Size - 6, self.TabBar_Size - 6))
-        self.tabBar().setStyleSheet(
-            "margin: 0px;padding: 0px;height: " + str(self.TabBar_Size) + ";"
-        )
+        self.tabBar().setStyleSheet("margin: 0px;padding: 0px;height: " + str(self.TabBar_Size) + ";")
 
         # Correct colors when no stylesheet is selected for FreeCAD.
         self.quickAccessToolBar().setStyleSheet("")
         if Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True:
-            FreeCAD_preferences = App.ParamGet(
-                "User parameter:BaseApp/Preferences/MainWindow"
-            )
+            FreeCAD_preferences = App.ParamGet("User parameter:BaseApp/Preferences/MainWindow")
             currentStyleSheet = FreeCAD_preferences.GetString("StyleSheet")
             if currentStyleSheet == "":
                 hexColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
                 # Set the quickaccess toolbar background color
-                self.quickAccessToolBar().setStyleSheet(
-                    "background-color: " + hexColor + ";"
-                )
+                self.quickAccessToolBar().setStyleSheet("background-color: " + hexColor + ";")
 
         # Get the order of workbenches from Parameters
         WorkbenchOrderedList: list = Parameters_Ribbon.TAB_ORDER.split(",")
@@ -1116,10 +991,7 @@ class ModernMenu(RibbonBar):
         # There is an issue with the internal assembly wb showing the wrong panel
         # when assembly4 wb is installed and positioned for the internal assembly wb
         for i in range(len(WorkbenchOrderedList)):
-            if (
-                WorkbenchOrderedList[i] == "Assembly4Workbench"
-                or WorkbenchOrderedList[i] == "Assembly3Workbench"
-            ):
+            if WorkbenchOrderedList[i] == "Assembly4Workbench" or WorkbenchOrderedList[i] == "Assembly3Workbench":
                 try:
                     index_1 = WorkbenchOrderedList.index(WorkbenchOrderedList[i])
                     index_2 = WorkbenchOrderedList.index("AssemblyWorkbench")
@@ -1159,14 +1031,10 @@ class ModernMenu(RibbonBar):
                             icon: QIcon = self.ReturnWorkbenchIcon(workbenchName)
                             self.tabBar().setTabIcon(len(self.categories()) - 1, icon)
                         if Parameters_Ribbon.TABBAR_STYLE == 2:
-                            self.tabBar().setTabIcon(
-                                len(self.categories()) - 1, QIcon()
-                            )
+                            self.tabBar().setTabIcon(len(self.categories()) - 1, QIcon())
 
                         # Set the tab data
-                        self.tabBar().setTabData(
-                            len(self.categories()) - 1, workbenchName
-                        )
+                        self.tabBar().setTabData(len(self.categories()) - 1, workbenchName)
 
                         # Set the tooltip
                         MenuText = workbench.MenuText
@@ -1175,20 +1043,14 @@ class ModernMenu(RibbonBar):
                             ToolTipText.lower() != MenuText.lower() + " workbench"
                             and MenuText.lower() != ToolTipText.lower()
                         ):
-                            MenuText = (
-                                f"<b>{workbench.MenuText}</b><br>{workbench.ToolTip}"
-                            )
+                            MenuText = f"<b>{workbench.MenuText}</b><br>{workbench.ToolTip}"
                         else:
                             MenuText = f"<b>{MenuText}<b>"
 
-                        self.tabBar().setTabToolTip(
-                            len(self.categories()) - 1, MenuText
-                        )
+                        self.tabBar().setTabToolTip(len(self.categories()) - 1, MenuText)
 
         # Set the size of the collapseRibbonButton
-        self.collapseRibbonButton().setFixedSize(
-            self.RightToolBarButtonSize, self.RightToolBarButtonSize
-        )
+        self.collapseRibbonButton().setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
 
         # add the searchbar if available
         SearchBarWidth = self.AddSearchBar()
@@ -1206,18 +1068,10 @@ class ModernMenu(RibbonBar):
         if self.OverlayMenu is not None:
             OverlayMenu = QToolButton()
             OverlayMenu.setIcon(QIcon(os.path.join(pathIcons, "Draft_Layer.svg")))
-            OverlayMenu.setToolTip(
-                translate("FreeCAD Ribbon", "Overlay functions") + "..."
-            )
+            OverlayMenu.setToolTip(translate("FreeCAD Ribbon", "Overlay functions") + "...")
             OverlayMenu.setMenu(self.OverlayMenu)
-            OverlayMenu.setFixedSize(
-                self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
-            )
-            OverlayMenu.setStyleSheet(
-                StyleMapping_Ribbon.ReturnStyleSheet(
-                    control="toolbutton", padding_right="12px"
-                )
-            )
+            OverlayMenu.setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
+            OverlayMenu.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px"))
             OverlayMenu.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
             Font = OverlayMenu.font()
             Font.setPixelSize(Parameters_Ribbon.FONTSIZE_MENUS)
@@ -1255,47 +1109,31 @@ class ModernMenu(RibbonBar):
         SettingsMenu.addAction(self.RibbonMenu.menuAction())
         SettingsMenu.setIcon(Gui.getIcon("Std_DlgParameter.svg"))
         SettingsMenu.setToolTip(translate("FreeCAD Ribbon", "Preferences") + "...")
-        SettingsMenu.setFixedSize(
-            self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
-        )
-        SettingsMenu.setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet(
-                control="toolbutton", padding_right="12px"
-            )
-        )
+        SettingsMenu.setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
+        SettingsMenu.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px"))
         SettingsMenu.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         # add the settingsmenu to the right toolbar
         self.rightToolBar().addWidget(SettingsMenu)
 
         # Set the helpbutton
         self.helpRibbonButton().setEnabled(True)
-        self.helpRibbonButton().setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
-        )
+        self.helpRibbonButton().setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self.helpRibbonButton().setToolTip(translate("FreeCAD Ribbon", "Help") + "...")
         # Get the default help action from FreeCAD
         helpMenu = mw.findChildren(QMenu, "&Help")[0]
         helpAction = helpMenu.actions()[0]
         self.helpRibbonButton().setIcon(helpAction.icon())
         self.helpRibbonButton().setMenu(self.HelpMenu)
-        self.helpRibbonButton().setFixedSize(
-            self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
-        )
+        self.helpRibbonButton().setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
         self.helpRibbonButton().setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet(
-                control="toolbutton", padding_right="12px"
-            )
+            StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px")
         )
-        self.helpRibbonButton().setPopupMode(
-            QToolButton.ToolButtonPopupMode.InstantPopup
-        )
+        self.helpRibbonButton().setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
 
         # Add a button the enable or disable AutoHide
         pinButton = QToolButton()
         pinButton.setCheckable(True)
-        pinButton.setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
-        )
+        pinButton.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         pinButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
         # Set the correct icon
         if Parameters_Ribbon.AUTOHIDE_RIBBON is True:
@@ -1313,14 +1151,10 @@ class ModernMenu(RibbonBar):
             pinButton.setChecked(False)
         if Parameters_Ribbon.AUTOHIDE_RIBBON is False:
             pinButton.setChecked(True)
-        pinButton.setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px")
-        )
+        pinButton.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px"))
         ShortcutKey = "Alt+T"
         try:
-            CustomShortCuts = App.ParamGet(
-                "User parameter:BaseApp/Preferences/Shortcut"
-            )
+            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
             if "Ribbon_Pin" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Pin")
             if ShortcutKey != "" and ShortcutKey is not None:
@@ -1328,16 +1162,13 @@ class ModernMenu(RibbonBar):
         except Exception:
             pass
         # Set the tooltip
-        ToolTip = translate(
-            "FreeCAD Ribbon", "Click to toggle the autohide function on or off"
-        )
+        ToolTip = translate("FreeCAD Ribbon", "Click to toggle the autohide function on or off")
         if ShortcutKey != "none":
             ToolTip = ToolTip + f"<br></br><i>{ShortcutKey}</i>"
         pinButton.setToolTip(
             translate(
                 "FreeCAD Ribbon",
-                "Click to toggle the autohide function on or off"
-                + f"<br></br><i>{ShortcutKey}</i>",
+                "Click to toggle the autohide function on or off" + f"<br></br><i>{ShortcutKey}</i>",
             )
         )
 
@@ -1371,13 +1202,9 @@ class ModernMenu(RibbonBar):
                     padding_right="3px",
                 )
             )
-            MinimzeButton.setIcon(
-                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[3]
-            )
+            MinimzeButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[3])
             MinimzeButton.clicked.connect(self.MinimizeFreeCAD)
-            MinimzeButton.setFixedSize(
-                self.RightToolBarButtonSize, self.RightToolBarButtonSize
-            )
+            MinimzeButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
             self.rightToolBar().addWidget(MinimzeButton)
             # Restore button
             RestoreButton = QToolButton()
@@ -1392,13 +1219,9 @@ class ModernMenu(RibbonBar):
                     padding_right="3px",
                 )
             )
-            RestoreButton.setIcon(
-                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2]
-            )
+            RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2])
             RestoreButton.clicked.connect(self.RestoreFreeCAD)
-            RestoreButton.setFixedSize(
-                self.RightToolBarButtonSize, self.RightToolBarButtonSize
-            )
+            RestoreButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
             self.rightToolBar().addWidget(RestoreButton)
             # Close button
             CloseButton = QToolButton()
@@ -1413,29 +1236,19 @@ class ModernMenu(RibbonBar):
                     HoverColor="#e62424",
                 )
             )
-            CloseButton.setIcon(
-                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[0]
-            )
+            CloseButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[0])
             CloseButton.clicked.connect(self.CloseFreeCAD)
-            CloseButton.setFixedSize(
-                self.RightToolBarButtonSize, self.RightToolBarButtonSize
-            )
+            CloseButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
             self.rightToolBar().addWidget(CloseButton)
 
         # Set the width of the right toolbar
-        RightToolbarWidth = (
-            SearchBarWidth
-            + 3 * (self.RightToolBarButtonSize + 16)
-            + self.RightToolBarButtonSize
-        )
+        RightToolbarWidth = SearchBarWidth + 3 * (self.RightToolBarButtonSize + 16) + self.RightToolBarButtonSize
         if Parameters_Ribbon.USE_FC_OVERLAY is True:
             RightToolbarWidth = SearchBarWidth + 2 * (self.RightToolBarButtonSize + 16)
         self.rightToolBar().setMinimumWidth(RightToolbarWidth)
         self.setRightToolBarHeight(self.RibbonMinimalHeight)
         # Set the size policy
-        self.rightToolBar().setSizePolicy(
-            QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding
-        )
+        self.rightToolBar().setSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding)
         self.rightToolBar().setSizeIncrement(1, 1)
         # Set the objectName for the right toolbar. needed for excluding from hiding.
         self.rightToolBar().setObjectName("rightToolBar")
@@ -1453,17 +1266,11 @@ class ModernMenu(RibbonBar):
 
                 sea = SearchBoxLight.SearchBoxLight(
                     getItemGroups=lambda: __import__("GetItemGroups").getItemGroups(),
-                    getToolTip=lambda groupId, setParent: __import__(
-                        "GetItemGroups"
-                    ).getToolTip(groupId, setParent),
-                    getItemDelegate=lambda: __import__(
-                        "IndentedItemDelegate"
-                    ).IndentedItemDelegate(),
+                    getToolTip=lambda groupId, setParent: __import__("GetItemGroups").getToolTip(groupId, setParent),
+                    getItemDelegate=lambda: __import__("IndentedItemDelegate").IndentedItemDelegate(),
                 )
                 sea.resultSelected.connect(
-                    lambda index, groupId: __import__("GetItemGroups").onResultSelected(
-                        index, groupId
-                    )
+                    lambda index, groupId: __import__("GetItemGroups").onResultSelected(index, groupId)
                 )
                 sea.setFixedSize(width, self.RightToolBarButtonSize)
                 BeforeAction = self.rightToolBar().actions()[1]
@@ -1481,18 +1288,13 @@ class ModernMenu(RibbonBar):
         MenuBar = mw.menuBar()
 
         # Set a stylesheet specific for the menubar. Otherwise the fontsize of the menus will not be applied
-        StyleSheet_MenuBar = (
-            "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
-        )
+        StyleSheet_MenuBar = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
         MenuBar.setStyleSheet(StyleSheet_MenuBar)
         # # Add the actions of the menubar to the application menu
         for child in MenuBar.actions():
             if child.objectName() != "&Help" and child.objectName != "AccessoriesMenu":
                 ApplictionMenu.addAction(child)
-            if (
-                child.objectName == "AccessoriesMenu"
-                and self.AccessoriesMenu is not None
-            ):
+            if child.objectName == "AccessoriesMenu" and self.AccessoriesMenu is not None:
                 ApplictionMenu.addMenu(self.AccessoriesMenu)
 
         # if you on macOS, add the ribbon menus to the menubar
@@ -1521,9 +1323,7 @@ class ModernMenu(RibbonBar):
             color = StyleMapping_Ribbon.ReturnStyleItem("DevelopColor")
             Label = QLabel()
             Label.setText("Development version")
-            Label.setStyleSheet(
-                f"color: {color};border: 1px solid {color};border-radius: 2px;"
-            )
+            Label.setStyleSheet(f"color: {color};border: 1px solid {color};border-radius: 2px;")
             ApplictionMenu.addWidget(Label)
         # if there is an update, add a button that opens the addon manager
         if self.UpdateVersion != "" and self.DeveloperVersion == "":
@@ -1562,17 +1362,12 @@ class ModernMenu(RibbonBar):
                 self.AccessoriesMenu.addActions(subMenus)
 
         # Create the overlay menu when the native overlay function is not used
-        if (
-            Parameters_Ribbon.USE_FC_OVERLAY is False
-            and Parameters_Ribbon.USE_OVERLAY is True
-        ):
+        if Parameters_Ribbon.USE_FC_OVERLAY is False and Parameters_Ribbon.USE_OVERLAY is True:
             OverlayMenu = QMenu(translate("FreeCAD Ribbon", "Overlay") + "...", self)
             OverlayMenu.setToolTipsVisible(True)
 
             # Toggle overlay for all -----------------------------------------------------
-            OverlayButton_All = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle overlay for all")
-            )
+            OverlayButton_All = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle overlay for all"))
             OverlayButton_All.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1583,9 +1378,7 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "F4"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayAll" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayAll")
             except Exception as e:
@@ -1595,9 +1388,7 @@ class ModernMenu(RibbonBar):
             OverlayButton_All.setShortcut(ShortcutKey)
 
             # Toggle transparancy for all -----------------------------------------------------
-            TransparancyButton_All = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle transparancy")
-            )
+            TransparancyButton_All = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle transparancy"))
             TransparancyButton_All.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1608,13 +1399,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Shift+F4"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayTransparentAll" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString(
-                        "Std_DockOverlayTransparentAll"
-                    )
+                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayTransparentAll")
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1623,9 +1410,7 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle overlay for active panel-----------------------------------------------------
-            OverlayButton_Active = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle overlay")
-            )
+            OverlayButton_Active = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle overlay"))
             OverlayButton_Active.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1636,9 +1421,7 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "F3"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayToggle" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggle")
             except Exception as e:
@@ -1648,9 +1431,7 @@ class ModernMenu(RibbonBar):
             OverlayButton_Active.setShortcut(ShortcutKey)
 
             # Toggle transparancy for active panel-----------------------------------------------------
-            TransparancyButton = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle transparant mode")
-            )
+            TransparancyButton = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle transparant mode"))
             TransparancyButton.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1661,13 +1442,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Shift+F3"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayToggleTransparent" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString(
-                        "Std_DockOverlayToggleTransparent"
-                    )
+                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleTransparent")
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1676,25 +1453,15 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle mouse bypass-----------------------------------------------------
-            ToggleMouseByPass = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Bypass mouse events")
-            )
-            ToggleMouseByPass.setToolTip(
-                translate(
-                    "FreeCAD Ribbon", "Bypass mouse events in docked overlay windows"
-                )
-            )
+            ToggleMouseByPass = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Bypass mouse events"))
+            ToggleMouseByPass.setToolTip(translate("FreeCAD Ribbon", "Bypass mouse events in docked overlay windows"))
             ToggleMouseByPass.triggered.connect(self.ToggleMouseByPass)
             # Get the shortcut from the original command
             ShortcutKey = "T,T"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayMouseTransparent" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString(
-                        "Std_DockOverlayMouseTransparent"
-                    )
+                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayMouseTransparent")
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1703,9 +1470,7 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle overlay for left panels-----------------------------------------------------
-            OverlayButton_Left = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle left")
-            )
+            OverlayButton_Left = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle left"))
             OverlayButton_Left.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1716,9 +1481,7 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+left"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayToggleLeft" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleLeft")
             except Exception as e:
@@ -1727,9 +1490,7 @@ class ModernMenu(RibbonBar):
                 ShortcutKey = "Ctrl+left"
             OverlayButton_Left.setShortcut(ShortcutKey)
             # Toggle overlay for right panels-----------------------------------------------------
-            OverlayButton_Right = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle right")
-            )
+            OverlayButton_Right = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle right"))
             OverlayButton_Right.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1740,22 +1501,16 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+right"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayToggleRight" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString(
-                        "Std_DockOverlayToggleRight"
-                    )
+                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleRight")
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
                 ShortcutKey = "Ctrl+right"
             OverlayButton_Right.setShortcut(ShortcutKey)
             # Toggle overlay for Bottom panels-----------------------------------------------------
-            OverlayButton_Bottom = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle bottom")
-            )
+            OverlayButton_Bottom = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle bottom"))
             OverlayButton_Bottom.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1766,13 +1521,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+down"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayToggleBottom" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString(
-                        "Std_DockOverlayToggleBottom"
-                    )
+                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleBottom")
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1783,23 +1534,15 @@ class ModernMenu(RibbonBar):
             self.OverlayMenu = OverlayMenu
 
         # Create a ribbon menu
-        RibbonMenu = QMenu(
-            translate("FreeCAD Ribbon", "Ribbon UI preferences") + " ...", self
-        )
+        RibbonMenu = QMenu(translate("FreeCAD Ribbon", "Ribbon UI preferences") + " ...", self)
         RibbonMenu.setToolTipsVisible(True)
         # Add the ribbon design button
-        DesignButton = RibbonMenu.addAction(
-            translate("FreeCAD Ribbon", "Ribbon layout")
-        )
-        DesignButton.setToolTip(
-            translate("FreeCAD Ribbon", "Design the ribbon to your preference")
-        )
+        DesignButton = RibbonMenu.addAction(translate("FreeCAD Ribbon", "Ribbon layout"))
+        DesignButton.setToolTip(translate("FreeCAD Ribbon", "Design the ribbon to your preference"))
         DesignButton.triggered.connect(self.loadDesignMenu)
         ShortcutKey = "Alt+L"
         try:
-            CustomShortCuts = App.ParamGet(
-                "User parameter:BaseApp/Preferences/Shortcut"
-            )
+            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
             if "Ribbon_Layout" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Layout")
         except Exception:
@@ -1808,19 +1551,13 @@ class ModernMenu(RibbonBar):
             DesignButton.setShortcut(ShortcutKey)
             self.LayoutMenuShortCut = ShortcutKey
         # Add the preference button
-        PreferenceButton = RibbonMenu.addAction(
-            translate("FreeCAD Ribbon", "Preferences")
-        )
-        PreferenceButton.setToolTip(
-            translate("FreeCAD Ribbon", "Set preferences for the Ribbon UI")
-        )
+        PreferenceButton = RibbonMenu.addAction(translate("FreeCAD Ribbon", "Preferences"))
+        PreferenceButton.setToolTip(translate("FreeCAD Ribbon", "Set preferences for the Ribbon UI"))
         PreferenceButton.setMenuRole(QAction.MenuRole.NoRole)
         PreferenceButton.triggered.connect(self.loadSettingsMenu)
         ShortcutKey = "Alt+P"
         try:
-            CustomShortCuts = App.ParamGet(
-                "User parameter:BaseApp/Preferences/Shortcut"
-            )
+            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
             if "Ribbon_Preferences" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Preferences")
         except Exception:
@@ -1832,12 +1569,8 @@ class ModernMenu(RibbonBar):
         if os.path.exists(ScriptDir) is True:
             ListScripts = os.listdir(ScriptDir)
             if len(ListScripts) > 0:
-                ScriptButtonMenu = RibbonMenu.addMenu(
-                    translate("FreeCAD Ribbon", "Scripts")
-                )
-                ScriptButtonMenu.setToolTip(
-                    translate("FreeCAD Ribbon", "Scripts to help setup the ribbon.")
-                )
+                ScriptButtonMenu = RibbonMenu.addMenu(translate("FreeCAD Ribbon", "Scripts"))
+                ScriptButtonMenu.setToolTip(translate("FreeCAD Ribbon", "Scripts to help setup the ribbon."))
                 for i in range(len(ListScripts)):
                     ScriptButtonMenu.addAction(
                         ListScripts[i],
@@ -1869,11 +1602,7 @@ class ModernMenu(RibbonBar):
 
         # Add the ribbon helpbutton under the FreeCAD
         RibbonHelpButton = QAction(translate("FreeCAD Ribbon", "Ribbon UI help"))
-        RibbonHelpButton.setToolTip(
-            translate(
-                "FreeCAD Ribbon", "Open the help page for the Ribbon UI in your browser"
-            )
-        )
+        RibbonHelpButton.setToolTip(translate("FreeCAD Ribbon", "Open the help page for the Ribbon UI in your browser"))
         RibbonHelpButton.setIcon(HelpIcon)
         RibbonHelpButton.triggered.connect(self.on_RibbonHelpButton_clicked)
         HelpMenu.insertAction(actions[1], RibbonHelpButton)
@@ -1896,15 +1625,11 @@ class ModernMenu(RibbonBar):
         PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
         version = StandardFunctions.ReturnXML_Value(PackageXML, "version")
         # Create the ribbon about button
-        AboutButton_Ribbon = AboutMenu.addAction(
-            translate("FreeCAD Ribbon", "About Ribbon UI ") + version
-        )
+        AboutButton_Ribbon = AboutMenu.addAction(translate("FreeCAD Ribbon", "About Ribbon UI ") + version)
         AboutButton_Ribbon.setIcon(AboutIcon)
         AboutButton_Ribbon.triggered.connect(self.on_AboutButton_clicked)
         # Create the what's new button
-        WhatsNewButton_Ribbon = AboutMenu.addAction(
-            translate("FreeCAD Ribbon", "What's new?")
-        )
+        WhatsNewButton_Ribbon = AboutMenu.addAction(translate("FreeCAD Ribbon", "What's new?"))
         WhatsNewButton_Ribbon.triggered.connect(self.on_WhatsNewButton_clicked)
         # add the aboutmenu to the help menu
         HelpMenu.addMenu(AboutMenu)
@@ -1951,9 +1676,7 @@ class ModernMenu(RibbonBar):
             Parameters_Ribbon.Settings.SetBoolSetting("AutoHideRibbon", True)
             Parameters_Ribbon.AUTOHIDE_RIBBON = True
 
-            pinButton: QToolButton = self.rightToolBar().findChildren(
-                QToolButton, "Pin Ribbon"
-            )[0]
+            pinButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "Pin Ribbon")[0]
             pinButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed"))
 
             # Make sure that the ribbon remains visible
@@ -1965,9 +1688,7 @@ class ModernMenu(RibbonBar):
             Parameters_Ribbon.Settings.SetBoolSetting("AutoHideRibbon", False)
             Parameters_Ribbon.AUTOHIDE_RIBBON = False
 
-            pinButton: QToolButton = self.rightToolBar().findChildren(
-                QToolButton, "Pin Ribbon"
-            )[0]
+            pinButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "Pin Ribbon")[0]
             pinButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_open"))
 
             # Make sure that the ribbon remains visible
@@ -2012,9 +1733,7 @@ class ModernMenu(RibbonBar):
         # Set the text color depending in tabstyle
         if Parameters_Ribbon.TABBAR_STYLE != 1:
             self.tabBar().setStyleSheet(
-                "QTabBar::tab {color: "
-                + StyleMapping_Ribbon.ReturnStyleItem("FontColor")
-                + ";}"
+                "QTabBar::tab {color: " + StyleMapping_Ribbon.ReturnStyleItem("FontColor") + ";}"
             )
         if Parameters_Ribbon.TABBAR_STYLE == 1:
             self.tabBar().setStyleSheet(
@@ -2095,20 +1814,16 @@ class ModernMenu(RibbonBar):
         # Get the custom panels and add them to the list of toolbars
         try:
             if workbenchName in self.ribbonStructure["customToolbars"]:
-                for CustomPanel in self.ribbonStructure["customToolbars"][
-                    workbenchName
-                ]:
+                for CustomPanel in self.ribbonStructure["customToolbars"][workbenchName]:
                     ListToolbars.append(CustomPanel)
 
                     # remove the original toolbars from the list
-                    Commands = self.ribbonStructure["customToolbars"][workbenchName][
-                        CustomPanel
-                    ]["commands"]
+                    Commands = self.ribbonStructure["customToolbars"][workbenchName][CustomPanel]["commands"]
                     for Command in Commands:
                         try:
-                            OriginalToolbar = self.ribbonStructure["customToolbars"][
-                                workbenchName
-                            ][CustomPanel]["commands"][Command]
+                            OriginalToolbar = self.ribbonStructure["customToolbars"][workbenchName][CustomPanel][
+                                "commands"
+                            ][Command]
                             ListToolbars.remove(OriginalToolbar)
                         except Exception:
                             continue
@@ -2128,9 +1843,7 @@ class ModernMenu(RibbonBar):
 
         try:
             # Get the order of toolbars
-            ToolbarOrder: list = self.ribbonStructure["workbenches"][workbenchName][
-                "toolbars"
-            ]["order"]
+            ToolbarOrder: list = self.ribbonStructure["workbenches"][workbenchName]["toolbars"]["order"]
 
             # Sort the list of toolbars according the toolbar order
             def SortToolbars(toolbar):
@@ -2194,51 +1907,30 @@ class ModernMenu(RibbonBar):
 
             # add separators to the command list.
             if workbenchName in self.ribbonStructure["workbenches"]:
-                if (
-                    toolbar != ""
-                    and toolbar
-                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
-                ):
-                    if (
-                        "order"
-                        in self.ribbonStructure["workbenches"][workbenchName][
-                            "toolbars"
-                        ][toolbar]
-                    ):
+                if toolbar != "" and toolbar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]:
+                    if "order" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]:
                         for j in range(
-                            len(
-                                self.ribbonStructure["workbenches"][workbenchName][
-                                    "toolbars"
-                                ][toolbar]["order"]
-                            )
+                            len(self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"])
                         ):
                             if (
                                 "separator"
-                                in self.ribbonStructure["workbenches"][workbenchName][
-                                    "toolbars"
-                                ][toolbar]["order"][j].lower()
+                                in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"][
+                                    j
+                                ].lower()
                             ):
                                 separator = QToolButton()
                                 separator.setText(
-                                    self.ribbonStructure["workbenches"][workbenchName][
-                                        "toolbars"
-                                    ][toolbar]["order"][j]
+                                    self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"][j]
                                 )
                                 allButtons.insert(j, separator)
 
             if workbenchName in self.ribbonStructure["workbenches"]:
                 # order buttons like defined in ribbonStructure
                 if (
-                    toolbar
-                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
-                    and "order"
-                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][
-                        toolbar
-                    ]
+                    toolbar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
+                    and "order" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]
                 ):
-                    OrderList: list = self.ribbonStructure["workbenches"][
-                        workbenchName
-                    ]["toolbars"][toolbar]["order"]
+                    OrderList: list = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"]
 
                     # XXX check that positionsList consists of strings only
                     def sortButtons(button: QToolButton):
@@ -2247,9 +1939,7 @@ class ModernMenu(RibbonBar):
                         # Get the menu text
                         if len(button.actions()) > 0:
                             action = button.actions()[0]
-                            Text = StandardFunctions.CommandInfoCorrections(
-                                action.data()
-                            )["menuText"]
+                            Text = StandardFunctions.CommandInfoCorrections(action.data())["menuText"]
 
                         if Text == "":
                             return -1
@@ -2269,8 +1959,12 @@ class ModernMenu(RibbonBar):
                 []
             )  # if buttons are used in multiple workbenches, they can show up double. (Sketcher_NewSketch)
             # for button in allButtons:
-            NoSmallButtons_spacer = 0  # needed to count the number of small buttons in a column. (bug fix with adding separators)
-            NoMediumButtons_spacer = 0  # needed to count the number of medium buttons in a column. (bug fix with adding separators)
+            NoSmallButtons_spacer = (
+                0  # needed to count the number of small buttons in a column. (bug fix with adding separators)
+            )
+            NoMediumButtons_spacer = (
+                0  # needed to count the number of medium buttons in a column. (bug fix with adding separators)
+            )
 
             # Define number of rows used per button size
             LargeButtonRows = 3
@@ -2293,9 +1987,9 @@ class ModernMenu(RibbonBar):
                 buttonSize = "small"
                 try:
                     action = button.defaultAction()
-                    buttonSize = self.ribbonStructure["workbenches"][workbenchName][
-                        "toolbars"
-                    ][toolbar]["commands"][action.data()]["size"]
+                    buttonSize = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["commands"][
+                        action.data()
+                    ]["size"]
                     if buttonSize == "small":
                         NoSmallButtons_spacer += 1
                     if buttonSize == "medium":
@@ -2386,28 +2080,22 @@ class ModernMenu(RibbonBar):
                             try:
                                 # If the text is not from a hardcoded dropdown:
                                 if len(action.data().split(", ")) <= 1:
-                                    text = StandardFunctions.CommandInfoCorrections(
-                                        action.data()
-                                    )["ActionText"]
+                                    text = StandardFunctions.CommandInfoCorrections(action.data())["ActionText"]
                             except Exception:
                                 pass
 
                             # try to get alternative text from ribbonStructure
                             try:
-                                textJSON = self.ribbonStructure["workbenches"][
-                                    workbenchName
-                                ]["toolbars"][toolbar]["commands"][action.data()][
-                                    "text"
-                                ]
+                                textJSON = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                    "commands"
+                                ][action.data()]["text"]
 
                                 # There is a bug in freecad with the comp-sketch menu hase the wrong text
                                 if (
                                     action.data() == "PartDesign_CompSketches"
-                                    and self.ribbonStructure["workbenches"][
-                                        workbenchName
-                                    ]["toolbars"][toolbar]["commands"][action.data()][
-                                        "text"
-                                    ]
+                                    and self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                        "commands"
+                                    ][action.data()]["text"]
                                     == "Create datum"
                                 ):
                                     textJSON = "Create sketch"
@@ -2418,19 +2106,13 @@ class ModernMenu(RibbonBar):
                                     # if it is a normal command:
                                     if len(action.data().split(", ")) <= 1:
                                         Command = Gui.Command.get(CommandName)
-                                        MenuName = CommandInfoCorrections(CommandName)[
-                                            "menuText"
-                                        ].replace("&", "")
+                                        MenuName = CommandInfoCorrections(CommandName)["menuText"].replace("&", "")
                                         if CommandName == action.data():
                                             if (
                                                 MenuName
-                                                != self.ribbonStructure["workbenches"][
-                                                    workbenchName
-                                                ]["toolbars"][toolbar]["commands"][
-                                                    action.data()
-                                                ][
-                                                    "text"
-                                                ]
+                                                != self.ribbonStructure["workbenches"][workbenchName]["toolbars"][
+                                                    toolbar
+                                                ]["commands"][action.data()]["text"]
                                                 and MenuName != ""
                                                 and textJSON != ""
                                             ):
@@ -2440,13 +2122,9 @@ class ModernMenu(RibbonBar):
                                         MenuName = action.text()
                                         if (
                                             MenuName
-                                            != self.ribbonStructure["workbenches"][
-                                                workbenchName
-                                            ]["toolbars"][toolbar]["commands"][
-                                                action.data()
-                                            ][
-                                                "text"
-                                            ]
+                                            != self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                                "commands"
+                                            ][action.data()]["text"]
                                             and MenuName != ""
                                             and textJSON != ""
                                         ):
@@ -2471,9 +2149,9 @@ class ModernMenu(RibbonBar):
                                 CommandName = button.text()
 
                             try:
-                                pixmap = self.ribbonStructure["workbenches"][
-                                    workbenchName
-                                ]["toolbars"][toolbar]["commands"][CommandName]["icon"]
+                                pixmap = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                    "commands"
+                                ][CommandName]["icon"]
                             except Exception:
                                 pass
                             actionIcon = self.ReturnCommandIcon(action.data(), pixmap)
@@ -2482,24 +2160,18 @@ class ModernMenu(RibbonBar):
 
                             # try to get alternative icon from ribbonStructure
                             try:
-                                icon_Json = self.ribbonStructure["workbenches"][
-                                    workbenchName
-                                ]["toolbars"][toolbar]["commands"][CommandName]["icon"]
+                                icon_Json = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                    "commands"
+                                ][CommandName]["icon"]
                                 if icon_Json != "":
                                     action.setIcon(Gui.getIcon(icon_Json))
                             except KeyError:
                                 pass
 
                             # If the icon is still none, try to retrieve it from the data file
-                            if action.icon() is None or (
-                                action.icon() is not None and action.icon().isNull()
-                            ):
-                                StandardFunctions.Print(
-                                    f"An icon retrieved from data file for '{CommandName}'"
-                                )
-                                DataFile = os.path.join(
-                                    os.path.dirname(__file__), "RibbonDataFile.dat"
-                                )
+                            if action.icon() is None or (action.icon() is not None and action.icon().isNull()):
+                                StandardFunctions.Print(f"An icon retrieved from data file for '{CommandName}'")
+                                DataFile = os.path.join(os.path.dirname(__file__), "RibbonDataFile.dat")
 
                                 if os.path.exists(DataFile) is True:
                                     Data = {}
@@ -2513,11 +2185,7 @@ class ModernMenu(RibbonBar):
                                             # This works only for FreeCAD Commands
                                             CommandName_Icon = action.data()
                                             if CommandName_Icon == IconItem[0]:
-                                                Icon: QIcon = (
-                                                    Serialize_Ribbon.deserializeIcon(
-                                                        IconItem[1]
-                                                    )
-                                                )
+                                                Icon: QIcon = Serialize_Ribbon.deserializeIcon(IconItem[1])
                                                 action.setIcon(Icon)
                                     except Exception as e:
                                         if Parameters_Ribbon.DEBUG_MODE is True:
@@ -2529,9 +2197,9 @@ class ModernMenu(RibbonBar):
 
                             # get button size from ribbonStructure
                             try:
-                                buttonSize = self.ribbonStructure["workbenches"][
-                                    workbenchName
-                                ]["toolbars"][toolbar]["commands"][CommandName]["size"]
+                                buttonSize = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                    "commands"
+                                ][CommandName]["size"]
                                 if buttonSize == "":
                                     buttonSize = "small"
                             except KeyError:
@@ -2548,10 +2216,7 @@ class ModernMenu(RibbonBar):
                             action.setText(action.text().replace("&", ""))
                             if buttonSize == "small":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_SMALL
-                                if (
-                                    IconOnly is True
-                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
-                                ):
+                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2590,10 +2255,7 @@ class ModernMenu(RibbonBar):
 
                             elif buttonSize == "medium":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_MEDIUM
-                                if (
-                                    IconOnly is True
-                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
-                                ):
+                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2630,10 +2292,7 @@ class ModernMenu(RibbonBar):
                                 )  # Set fixedheight to false. This is set in the custom widgets
                             elif buttonSize == "large":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_LARGE
-                                if (
-                                    IconOnly is True
-                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
-                                ):
+                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2671,23 +2330,17 @@ class ModernMenu(RibbonBar):
                             else:
                                 if Parameters_Ribbon.DEBUG_MODE is True:
                                     if buttonSize != "none":
-                                        print(
-                                            f"{action.text()} is ignored. Its size was: {buttonSize}"
-                                        )
+                                        print(f"{action.text()} is ignored. Its size was: {buttonSize}")
                                 pass
 
                             if btn.menu() is not None:
-                                btn.popupMode(
-                                    QToolButton.ToolButtonPopupMode.MenuButtonPopup
-                                )
+                                btn.popupMode(QToolButton.ToolButtonPopupMode.MenuButtonPopup)
 
                             # Set the background always to background color.
                             # Styling is managed in the custom button class
                             StyleSheet_Addition_Button = (
                                 "QToolButton, QToolButton:hover {background-color: "
-                                + StyleMapping_Ribbon.ReturnStyleItem(
-                                    "Background_Color"
-                                )
+                                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
                                 + ";border: none"
                                 + ";}"
                             )
@@ -2702,10 +2355,7 @@ class ModernMenu(RibbonBar):
                             continue
 
             # Change the name of the view panels to "View"
-            if (
-                panel.title() in "Views - Ribbon_newPanel"
-                or panel.title() in "Individual views"
-            ):
+            if panel.title() in "Views - Ribbon_newPanel" or panel.title() in "Individual views":
                 panel.setTitle(" Views ")
             else:
                 # Remove possible workbench names from the titles
@@ -2745,9 +2395,7 @@ class ModernMenu(RibbonBar):
             actionList = []
             for i in range(len(ButtonList)):
                 button = ButtonList[i]
-                StyleSheet_Menu = (
-                    "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
-                )
+                StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
                 button.setStyleSheet(StyleSheet_Menu)
                 if len(button.actions()) == 1:
                     actionList.append(button.actions()[0])
@@ -2755,20 +2403,14 @@ class ModernMenu(RibbonBar):
                     actionList.append(button.actions())
             OptionButton = panel.panelOptionButton()
             if len(actionList) > 0:
-                Menu = CustomControls.CustomOptionMenu(
-                    OptionButton.menu(), actionList, self
-                )
+                Menu = CustomControls.CustomOptionMenu(OptionButton.menu(), actionList, self)
                 OptionButton.setMenu(Menu)
-                StyleSheet_Menu = (
-                    "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
-                )
+                StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
                 Menu.setStyleSheet(StyleSheet_Menu)
                 # Set the behavior of the option button
                 OptionButton.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
                 # Remove the image to avoid double arrows
-                OptionButton.setStyleSheet(
-                    "RibbonPanelOptionButton::menu-indicator {image: none;}"
-                )
+                OptionButton.setStyleSheet("RibbonPanelOptionButton::menu-indicator {image: none;}")
                 Menu = OptionButton.menu()
 
                 # Set the icon
@@ -2777,9 +2419,7 @@ class ModernMenu(RibbonBar):
                     OptionButton.setIcon(OptionButton_Icon)
                 else:
                     OptionButton.setArrowType(Qt.ArrowType.DownArrow)
-                    OptionButton.setToolButtonStyle(
-                        Qt.ToolButtonStyle.ToolButtonTextBesideIcon
-                    )
+                    OptionButton.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
                     OptionButton.setText("more...")
             if len(actionList) == 0:
                 panel.panelOptionButton().hide()
@@ -2788,21 +2428,13 @@ class ModernMenu(RibbonBar):
 
         # Set the previous/next buttons
         category = self.currentCategory()
-        ScrollLeftButton_Category: RibbonCategoryLayoutButton = category.findChildren(
-            RibbonCategoryLayoutButton
-        )[0]
-        ScrollRightButton_Category: RibbonCategoryLayoutButton = category.findChildren(
-            RibbonCategoryLayoutButton
-        )[1]
+        ScrollLeftButton_Category: RibbonCategoryLayoutButton = category.findChildren(RibbonCategoryLayoutButton)[0]
+        ScrollRightButton_Category: RibbonCategoryLayoutButton = category.findChildren(RibbonCategoryLayoutButton)[1]
         ScrollLeftButton_Category.setMinimumWidth(self.iconSize * 0.5)
         ScrollRightButton_Category.setMinimumWidth(self.iconSize * 0.5)
         # get the icons
-        ScrollLeftButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem(
-            "ScrollLeftButton_Category"
-        )
-        ScrollRightButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem(
-            "ScrollRightButton_Category"
-        )
+        ScrollLeftButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category")
+        ScrollRightButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category")
         # Set the icons
         if ScrollLeftButton_Category_Icon is not None:
             ScrollLeftButton_Category.setIcon(ScrollLeftButton_Category_Icon)
@@ -2816,37 +2448,23 @@ class ModernMenu(RibbonBar):
         ScrollLeftButton_Category.setFixedHeight(Parameters_Ribbon.ICON_SIZE_SMALL * 3)
         ScrollRightButton_Category.setFixedHeight(Parameters_Ribbon.ICON_SIZE_SMALL * 3)
         # Set the stylesheet
-        ScrollLeftButton_Category.setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton")
-        )
-        ScrollRightButton_Category.setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton")
-        )
+        ScrollLeftButton_Category.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton"))
+        ScrollRightButton_Category.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton"))
         # Connect the custom click event
-        ScrollLeftButton_Category.mousePressEvent = (
-            lambda clickLeft: self.on_ScrollButton_Category_clicked(
-                clickLeft, ScrollLeftButton_Category
-            )
+        ScrollLeftButton_Category.mousePressEvent = lambda clickLeft: self.on_ScrollButton_Category_clicked(
+            clickLeft, ScrollLeftButton_Category
         )
-        ScrollRightButton_Category.mousePressEvent = (
-            lambda clickRight: self.on_ScrollButton_Category_clicked(
-                clickRight, ScrollRightButton_Category
-            )
+        ScrollRightButton_Category.mousePressEvent = lambda clickRight: self.on_ScrollButton_Category_clicked(
+            clickRight, ScrollRightButton_Category
         )
 
         # Set the maximum height to a high value to prevent from the ribbon to be clipped off
-        self.currentCategory().setMinimumHeight(
-            self.RibbonHeight - self.RibbonMinimalHeight - 3
-        )
-        self.currentCategory().setMaximumHeight(
-            self.RibbonHeight - self.RibbonMinimalHeight - 3
-        )
+        self.currentCategory().setMinimumHeight(self.RibbonHeight - self.RibbonMinimalHeight - 3)
+        self.currentCategory().setMaximumHeight(self.RibbonHeight - self.RibbonMinimalHeight - 3)
         self.setRibbonHeight(self.RibbonHeight)
         return
 
-    def on_ScrollButton_Category_clicked(
-        self, event, ScrollButton: RibbonCategoryLayoutButton
-    ):
+    def on_ScrollButton_Category_clicked(self, event, ScrollButton: RibbonCategoryLayoutButton):
         for i in range(Parameters_Ribbon.RIBBON_CLICKSPEED):
             ScrollButton.click()
         return
@@ -2867,9 +2485,14 @@ class ModernMenu(RibbonBar):
             parentWidget = toolbar.parentWidget()
             toolbar.setHidden(True)
             # hide toolbars that are not in the statusBar and show toolbars that are in the statusbar.
+            if parentWidget.objectName() == "statusBar" or parentWidget.objectName() == "StatusBarArea":
+                toolbar.setEnabled(True)
+                toolbar.setVisible(True)
+            #
             if (
-                parentWidget.objectName() == "statusBar"
-                or parentWidget.objectName() == "StatusBarArea"
+                mw.toolBarArea(toolbar) == Qt.ToolBarArea.LeftToolBarArea
+                or mw.toolBarArea(toolbar) == Qt.ToolBarArea.RightToolBarArea
+                or mw.toolBarArea(toolbar) == Qt.ToolBarArea.BottomToolBarArea
             ):
                 toolbar.setEnabled(True)
                 toolbar.setVisible(True)
@@ -2894,11 +2517,7 @@ class ModernMenu(RibbonBar):
         return
 
     def FoldRibbon(self, Ignore=False):
-        if (
-            Parameters_Ribbon.AUTOHIDE_RIBBON is True
-            and self.isLoaded is True
-            and Ignore is False
-        ):
+        if Parameters_Ribbon.AUTOHIDE_RIBBON is True and self.isLoaded is True and Ignore is False:
             if len(mw.findChildren(QDockWidget, "Ribbon")) > 0:
                 TB: QDockWidget = mw.findChildren(QDockWidget, "Ribbon")[0]
                 TB.setMinimumHeight(self.RibbonMinimalHeight)
@@ -2918,10 +2537,7 @@ class ModernMenu(RibbonBar):
 
                     for Group in CustomToolbars:
                         Parameter = App.ParamGet(
-                            "User parameter:BaseApp/Workbench/"
-                            + WorkBenchName
-                            + "/Toolbar/"
-                            + Group
+                            "User parameter:BaseApp/Workbench/" + WorkBenchName + "/Toolbar/" + Group
                         )
                         Name = Parameter.GetString("Name")
                         Toolbars.append([Name, WorkBenchName])
@@ -2930,14 +2546,10 @@ class ModernMenu(RibbonBar):
 
     def List_ReturnCustomToolbars_Global(self):
         Toolbars = []
-        CustomToolbars: list = App.ParamGet(
-            "User parameter:BaseApp/Workbench/Global/Toolbar"
-        ).GetGroups()
+        CustomToolbars: list = App.ParamGet("User parameter:BaseApp/Workbench/Global/Toolbar").GetGroups()
 
         for Group in CustomToolbars:
-            Parameter = App.ParamGet(
-                "User parameter:BaseApp/Workbench/Global/Toolbar/" + Group
-            )
+            Parameter = App.ParamGet("User parameter:BaseApp/Workbench/Global/Toolbar/" + Group)
             Name = Parameter.GetString("Name")
             Toolbars.append([Name, "Global"])
 
@@ -2948,9 +2560,7 @@ class ModernMenu(RibbonBar):
 
         try:
             # Get the commands from the custom panel
-            Commands = self.ribbonStructure["customToolbars"][WorkBenchName][
-                CustomToolbar
-            ]["commands"]
+            Commands = self.ribbonStructure["customToolbars"][WorkBenchName][CustomToolbar]["commands"]
 
             # Get the command and its original toolbar
             for key, value in list(Commands.items()):
@@ -2959,9 +2569,7 @@ class ModernMenu(RibbonBar):
                     # Get the english menutext
                     MenuName = CommandInfoCorrections(CommandName)["menuText"]
                     # Get the translated menutext
-                    MenuNameTtranslated = CommandInfoCorrections(CommandName)[
-                        "ActionText"
-                    ]
+                    MenuNameTtranslated = CommandInfoCorrections(CommandName)["ActionText"]
 
                     if MenuName == key:
                         try:
@@ -2976,16 +2584,11 @@ class ModernMenu(RibbonBar):
                                     if Toolbutton.text() == Child.text():
                                         IsInList = True
 
-                                if (
-                                    Child.text() == MenuNameTtranslated
-                                    and IsInList is False
-                                ):
+                                if Child.text() == MenuNameTtranslated and IsInList is False:
                                     ButtonList.append(Child)
                         except Exception as e:
                             if Parameters_Ribbon.DEBUG_MODE is True:
-                                StandardFunctions.Print(
-                                    f"{e.with_traceback(e.__traceback__)}, 3", "Warning"
-                                )
+                                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}, 3", "Warning")
                             continue
         except Exception:
             pass
@@ -2999,9 +2602,7 @@ class ModernMenu(RibbonBar):
             if WorkBenchName in self.ribbonStructure["newPanels"]:
                 if NewPanel in self.ribbonStructure["newPanels"][WorkBenchName]:
                     # Get the commands from the custom panel
-                    Commands = self.ribbonStructure["newPanels"][WorkBenchName][
-                        NewPanel
-                    ]
+                    Commands = self.ribbonStructure["newPanels"][WorkBenchName][NewPanel]
 
                     # Get the command and its original toolbar
                     for CommandItem in Commands:
@@ -3020,9 +2621,7 @@ class ModernMenu(RibbonBar):
                                     CommandActionList = Command.getAction()
                                 if Command is None:
                                     if Parameters_Ribbon.DEBUG_MODE is True:
-                                        StandardFunctions.Print(
-                                            f"{CommandName} was None", "Warning"
-                                        )
+                                        StandardFunctions.Print(f"{CommandName} was None", "Warning")
                             # If the commandname can be splitted, it is a FreeCAD dropdown
                             if len(CommandName.split(", ")) > 1:
                                 CommandActionList = self.LoadDropDownAction(CommandName)
@@ -3033,14 +2632,10 @@ class ModernMenu(RibbonBar):
                                 # if there is only one action, add it directly
                                 if len(CommandActionList) == 1:
                                     NewToolbutton.addAction(CommandActionList[0])
-                                    NewToolbutton.setDefaultAction(
-                                        NewToolbutton.actions()[0]
-                                    )
+                                    NewToolbutton.setDefaultAction(NewToolbutton.actions()[0])
                                     # If the commandname is from a FreeCAD dropdown, set the commandname as text
                                     if len(CommandName.split(", ")) > 1:
-                                        NewToolbutton.setText(
-                                            NewToolbutton.actions()[0].text()
-                                        )
+                                        NewToolbutton.setText(NewToolbutton.actions()[0].text())
                                 # if there are more actions, create a menu
                                 elif len(CommandActionList) > 1:
                                     menu = QMenu()
@@ -3058,9 +2653,7 @@ class ModernMenu(RibbonBar):
                                 # Set the text for the toolbutton
                                 if len(CommandName.split(", ")) <= 1:
                                     NewToolbutton.setText(
-                                        CommandInfoCorrections(CommandName)[
-                                            "menuText"
-                                        ].replace("&", "")
+                                        CommandInfoCorrections(CommandName)["menuText"].replace("&", "")
                                     )
                                 # # If the commandname is from a FreeCAD dropdown, set the commandname as text
                                 # if len(CommandName.split(", ")) > 1:
@@ -3077,9 +2670,7 @@ class ModernMenu(RibbonBar):
                                 # if there is only one action, add it directly
                                 if len(CommandActionList) == 1:
                                     NewToolbutton.addAction(CommandActionList[0])
-                                    NewToolbutton.setDefaultAction(
-                                        NewToolbutton.actions()[0]
-                                    )
+                                    NewToolbutton.setDefaultAction(NewToolbutton.actions()[0])
                                 # if there are more actions, create a menu
                                 if len(CommandActionList) > 1:
                                     menu = QMenu()
@@ -3102,9 +2693,7 @@ class ModernMenu(RibbonBar):
 
         except Exception as e:
             if Parameters_Ribbon.DEBUG_MODE is True:
-                StandardFunctions.Print(
-                    f"{e.with_traceback(e.__traceback__)}, 4", "Warning"
-                )
+                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}, 4", "Warning")
             pass
         return ButtonList
 
@@ -3145,14 +2734,12 @@ class ModernMenu(RibbonBar):
         # Check whichs is has the most height: 3 small buttons, 2 medium buttons or 1 large button
         # and set the height accordingly
         if (
-            Parameters_Ribbon.ICON_SIZE_SMALL * 3
-            >= Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
+            Parameters_Ribbon.ICON_SIZE_SMALL * 3 >= Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
             and Parameters_Ribbon.ICON_SIZE_SMALL * 3 >= LargeButtonHeight
         ):
             ribbonHeight = ribbonHeight + Parameters_Ribbon.ICON_SIZE_SMALL * 3 + 6
         elif (
-            Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
-            >= Parameters_Ribbon.ICON_SIZE_SMALL * 3
+            Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 >= Parameters_Ribbon.ICON_SIZE_SMALL * 3
             and Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 >= LargeButtonHeight
         ):
             ribbonHeight = ribbonHeight + Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 + 4
@@ -3265,18 +2852,10 @@ class ModernMenu(RibbonBar):
             Enable = False
 
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
-        )
-        OverlayParam_Right = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
-        )
-        OverlayParam_Top = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayTop"
-        )
-        OverlayParam_Bottom = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
-        )
+        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
+        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
+        OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
+        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
 
         # If overlay is enabled, go here
         PanelsLeft = []
@@ -3359,16 +2938,10 @@ class ModernMenu(RibbonBar):
         OverlayParam_Right = None
         OverlayParam_Bottom = None
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
-        )
-        OverlayParam_Right = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
-        )
+        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
+        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
-        )
+        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
 
         # Ge the focused dockwidget
         FocusWidget = mw.focusWidget().parent().objectName()
@@ -3414,32 +2987,22 @@ class ModernMenu(RibbonBar):
             RightPanels = OverlayParam_Right.GetString("Widgets")
             if FocusWidget in RightPanels:
                 RightPanels = OverlayParam_Left.GetString("Widgets")
-                RightPanels = RightPanels.replace(f"{FocusWidget}", "").replace(
-                    ",,", ","
-                )
+                RightPanels = RightPanels.replace(f"{FocusWidget}", "").replace(",,", ",")
                 OverlayParam_Right.SetString("Widgets", f"{RightPanels}")
                 return
             BottomPanels = OverlayParam_Bottom.GetString("Widgets")
             if FocusWidget in BottomPanels:
                 BottomPanels = OverlayParam_Bottom.GetString("Widgets")
-                BottomPanels = BottomPanels.replace(f"{FocusWidget}", "").replace(
-                    ",,", ","
-                )
+                BottomPanels = BottomPanels.replace(f"{FocusWidget}", "").replace(",,", ",")
                 OverlayParam_Bottom.SetString("Widgets", f"{BottomPanels}")
                 return
         return
 
     def CustomTransparancy(self):
-        OverlayParam_Left = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
-        )
-        OverlayParam_Right = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
-        )
+        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
+        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
-        )
+        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
 
         Enable = None
         if OverlayParam_Left.GetBool("Transparent") is False:
@@ -3461,16 +3024,10 @@ class ModernMenu(RibbonBar):
         OverlayParam_Right = None
         OverlayParam_Bottom = None
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
-        )
-        OverlayParam_Right = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
-        )
+        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
+        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
-        )
+        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
 
         # Ge the focused dockwidget
         FocusWidget = mw.focusWidget().parent().objectName()
@@ -3496,21 +3053,15 @@ class ModernMenu(RibbonBar):
         if position == "":
             LeftPanels = OverlayParam_Left.GetString("Widgets")
             if FocusWidget in LeftPanels:
-                OverlayParam_Left.SetBool(
-                    "Transparent", not OverlayParam_Left.GetBool("Transparent")
-                )
+                OverlayParam_Left.SetBool("Transparent", not OverlayParam_Left.GetBool("Transparent"))
                 return
             RightPanels = OverlayParam_Right.GetString("Widgets")
             if FocusWidget in RightPanels:
-                OverlayParam_Right.SetBool(
-                    "Transparent", not OverlayParam_Right.GetBool("Transparent")
-                )
+                OverlayParam_Right.SetBool("Transparent", not OverlayParam_Right.GetBool("Transparent"))
                 return
             BottomPanels = OverlayParam_Bottom.GetString("Widgets")
             if FocusWidget in BottomPanels:
-                OverlayParam_Bottom.SetBool(
-                    "Transparent", not OverlayParam_Bottom.GetBool("Transparent")
-                )
+                OverlayParam_Bottom.SetBool("Transparent", not OverlayParam_Bottom.GetBool("Transparent"))
                 return
         return
 
@@ -3518,9 +3069,7 @@ class ModernMenu(RibbonBar):
         actionList = []
 
         try:
-            for DropDownCommand, Commands in self.ribbonStructure[
-                "dropdownButtons"
-            ].items():
+            for DropDownCommand, Commands in self.ribbonStructure["dropdownButtons"].items():
                 if CommandName == DropDownCommand:
                     for CommandItem in Commands:
                         Command = Gui.Command.get(CommandItem[0])
@@ -3531,9 +3080,7 @@ class ModernMenu(RibbonBar):
             return actionList
         except Exception as e:
             if Parameters_Ribbon.DEBUG_MODE is True:
-                StandardFunctions.Print(
-                    f"{e.with_traceback(e.__traceback__)}", "Warning"
-                )
+                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}", "Warning")
             return
 
     def CloseFreeCAD(self):
@@ -3549,9 +3096,7 @@ class ModernMenu(RibbonBar):
         # if self.isLoaded:
         StatusBarState = mw.findChild(QStatusBar, "statusBar").isVisible()
         # Get the style and restore button
-        RestoreButton: QToolButton = self.rightToolBar().findChildren(
-            QToolButton, "RestoreButton"
-        )[0]
+        RestoreButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
         # If the mainwindow is maximized, set the mainwindow to normal, set a size and icon
         if mw.isMaximized() is True:
             try:
@@ -3639,27 +3184,18 @@ class ModernMenu(RibbonBar):
 
     def CheckLanguage(self):
         FreeCAD_preferences = App.ParamGet("User parameter:BaseApp/Preferences/General")
-        if self.ribbonStructure["language"] != FreeCAD_preferences.GetString(
-            "Language"
-        ):
+        if self.ribbonStructure["language"] != FreeCAD_preferences.GetString("Language"):
             if "workbenches" in self.ribbonStructure:
                 for workbenchName in self.ribbonStructure["workbenches"]:
                     if "toolbars" in self.ribbonStructure["workbenches"][workbenchName]:
-                        for ToolBar in self.ribbonStructure["workbenches"][
-                            workbenchName
-                        ]["toolbars"]:
-                            if (
-                                "commands"
-                                in self.ribbonStructure["workbenches"][workbenchName][
-                                    "toolbars"
-                                ][ToolBar]
-                            ):
-                                for Command in self.ribbonStructure["workbenches"][
-                                    workbenchName
-                                ]["toolbars"][ToolBar]["commands"]:
-                                    self.ribbonStructure["workbenches"][workbenchName][
-                                        "toolbars"
-                                    ][ToolBar]["commands"][Command]["text"] = ""
+                        for ToolBar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]:
+                            if "commands" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar]:
+                                for Command in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar][
+                                    "commands"
+                                ]:
+                                    self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar]["commands"][
+                                        Command
+                                    ]["text"] = ""
 
             print("Ribbon UI: Custom text are reset because the language was changed")
         return
@@ -3677,36 +3213,27 @@ class EventInspector(QObject):
             mw.showMaximal()
             Style = mw.style()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
-            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(
-                QToolButton, "RestoreButton"
-            )[0]
+            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
             try:
-                RestoreButton.setIcon(
-                    Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton)
-                )
+                RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton))
             except Exception:
                 pass
             return QObject.eventFilter(self, obj, event)
         # This is a workaround for windows
         # If the window stat changes and the titlebar is hidden, catch the event
         if (
-            event.type() == QEvent.Type.WindowStateChange
-            or event.type() == QEvent.Type.DragMove
+            event.type() == QEvent.Type.WindowStateChange or event.type() == QEvent.Type.DragMove
         ) and Parameters_Ribbon.HIDE_TITLEBAR_FC is True:
             # Get the main window, its style, the ribbon and the restore button
             mw = Gui.getMainWindow()
             Style = mw.style()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
-            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(
-                QToolButton, "RestoreButton"
-            )[0]
+            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
             # If the mainwindow is maximized, set the window state to maximize and set the correct icon
             if mw.isMaximized():
                 try:
                     # RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton))
-                    RestoreButton.setIcon(
-                        StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2]
-                    )
+                    RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2])
                 except Exception:
                     pass
                 return QObject.eventFilter(self, obj, event)
@@ -3714,18 +3241,13 @@ class EventInspector(QObject):
             if mw.isMaximized() is False:
                 try:
                     # RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarMaxButton))
-                    RestoreButton.setIcon(
-                        StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1]
-                    )
+                    RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1])
                 except Exception:
                     pass
                 return QObject.eventFilter(self, obj, event)
         # If the event is a modfied event, update the title
         # This is done when switching from one part to another
-        if (
-            event.type() == QEvent.Type.ModifiedChange
-            and Parameters_Ribbon.TOOLBAR_POSITION == 0
-        ):
+        if event.type() == QEvent.Type.ModifiedChange and Parameters_Ribbon.TOOLBAR_POSITION == 0:
             # Get the mainwindow, the ribbon and the title
             mw = Gui.getMainWindow()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
@@ -3733,9 +3255,7 @@ class EventInspector(QObject):
             # If there is an active document, continue here
             if App.ActiveDocument is not None:
                 # Define the standard title as a prefix
-                Prefix = (
-                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
-                )
+                Prefix = f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
                 # if the title is not equal to the prefix with the active document label,
                 # Get the text from the active tab from the viewport and combine it with the prefix
                 # Set it as the new title
@@ -3746,9 +3266,7 @@ class EventInspector(QObject):
                     RibbonBar.setTitle(Prefix + " - " + CurrentText)
             # If there is no active document, set just the standard title
             if App.ActiveDocument is None:
-                RibbonBar.setTitle(
-                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
-                )
+                RibbonBar.setTitle(f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}")
             return QObject.eventFilter(self, obj, event)
         return False
 

--- a/FCBinding.py
+++ b/FCBinding.py
@@ -181,7 +181,9 @@ class ModernMenu(RibbonBar):
     # Create an offset for the panelheight
     PanelHeightOffset = 36
     # Create an offset for the whole ribbon height
-    RibbonOffset = 50 + QuickAccessButtonSize * 2  # Set to zero to hide the panel titles
+    RibbonOffset = (
+        50 + QuickAccessButtonSize * 2
+    )  # Set to zero to hide the panel titles
 
     # Set the minimum height for the ribbon
     RibbonMinimalHeight = QuickAccessButtonSize * 2 + 16
@@ -315,8 +317,13 @@ class ModernMenu(RibbonBar):
             ]
         else:
             try:
-                if "Views - Ribbon_newPanel" in self.ribbonStructure["newPanels"]["Global"]:
-                    del self.ribbonStructure["newPanels"]["Global"]["Views - Ribbon_newPanel"]
+                if (
+                    "Views - Ribbon_newPanel"
+                    in self.ribbonStructure["newPanels"]["Global"]
+                ):
+                    del self.ribbonStructure["newPanels"]["Global"][
+                        "Views - Ribbon_newPanel"
+                    ]
             except Exception:
                 pass
         # # Add a toolbar "tools"
@@ -326,11 +333,14 @@ class ModernMenu(RibbonBar):
         try:
             NeedsUpdating = False
             if "Tools_newPanel" in self.ribbonStructure["newPanels"]["Global"]:
-                for item in self.ribbonStructure["newPanels"]["Global"]["Tools_newPanel"]:
+                for item in self.ribbonStructure["newPanels"]["Global"][
+                    "Tools_newPanel"
+                ]:
                     if item[1] != "Standard":
                         NeedsUpdating = True
             if (
-                "Tools_newPanel" not in self.ribbonStructure["newPanels"]["Global"] and UseToolsPanel is True
+                "Tools_newPanel" not in self.ribbonStructure["newPanels"]["Global"]
+                and UseToolsPanel is True
             ) or NeedsUpdating is True:
                 StandardFunctions.add_keys_nested_dict(
                     self.ribbonStructure,
@@ -399,7 +409,9 @@ class ModernMenu(RibbonBar):
 
         # Get the address of the repository address
         PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
-        self.ReproAdress = StandardFunctions.ReturnXML_Value(PackageXML, "url", "type", "repository")
+        self.ReproAdress = StandardFunctions.ReturnXML_Value(
+            PackageXML, "url", "type", "repository"
+        )
         if self.ReproAdress != "" or self.ReproAdress is not None:
             print(translate("FreeCAD Ribbon", "FreeCAD Ribbon: ") + self.ReproAdress)
 
@@ -409,7 +421,9 @@ class ModernMenu(RibbonBar):
                 for WorkBenchName in self.ribbonStructure["newPanels"]:
                     for NewPanel in self.ribbonStructure["newPanels"][WorkBenchName]:
                         # Get the commands from the custom panel
-                        Commands = self.ribbonStructure["newPanels"][WorkBenchName][NewPanel]
+                        Commands = self.ribbonStructure["newPanels"][WorkBenchName][
+                            NewPanel
+                        ]
 
                         # Get the command and its original toolbar
                         for CommandItem in Commands:
@@ -431,9 +445,15 @@ class ModernMenu(RibbonBar):
         # Activate the workbenches used in the dropdown buttons otherwise the button stays empty
         try:
             if "dropdownButtons" in self.ribbonStructure:
-                for DropDownCommand, Commands in self.ribbonStructure["dropdownButtons"].items():
+                for DropDownCommand, Commands in self.ribbonStructure[
+                    "dropdownButtons"
+                ].items():
                     for CommandItem in Commands:
-                        if CommandItem[1] != "General" and CommandItem[1] != "Global" and CommandItem[1] != "Standard":
+                        if (
+                            CommandItem[1] != "General"
+                            and CommandItem[1] != "Global"
+                            and CommandItem[1] != "Standard"
+                        ):
                             # Activate the workbench if not loaded
                             Gui.activateWorkbench(CommandItem[1])
         except Exception as e:
@@ -452,11 +472,15 @@ class ModernMenu(RibbonBar):
             Branch = "main"
             File = "package.xml"
             ElementName = "version"
-            LatestVersion = StandardFunctions.ReturnXML_Value_Git(User, Repo, Branch, File, ElementName)
+            LatestVersion = StandardFunctions.ReturnXML_Value_Git(
+                User, Repo, Branch, File, ElementName
+            )
             if LatestVersion is not None:
                 # Get the current version
                 PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
-                CurrentVersion = StandardFunctions.ReturnXML_Value(PackageXML, "version")
+                CurrentVersion = StandardFunctions.ReturnXML_Value(
+                    PackageXML, "version"
+                )
                 # Check if you are on a developer version. If so set developer version
                 if CurrentVersion.lower().endswith("x"):
                     self.DeveloperVersion = CurrentVersion
@@ -489,15 +513,29 @@ class ModernMenu(RibbonBar):
         StyleSheet = Path(Parameters_Ribbon.STYLESHEET).read_text()
         # modify the stylesheet to set the border and background for a toolbar and menu
         hexColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
-        hexColorTab = StyleMapping_Ribbon.ReturnStyleItem("Background_Color", True, True)
-        if hexColor is not None and hexColor != "" and Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True:
+        hexColorTab = StyleMapping_Ribbon.ReturnStyleItem(
+            "Background_Color", True, True
+        )
+        if (
+            hexColor is not None
+            and hexColor != ""
+            and Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True
+        ):
             # Set the quickaccess toolbar background color. This fixes a transparant toolbar.
-            self.quickAccessToolBar().setStyleSheet("QToolBar {background: " + hexColor + ";}")
+            self.quickAccessToolBar().setStyleSheet(
+                "QToolBar {background: " + hexColor + ";}"
+            )
             self.tabBar().setStyleSheet("background: " + hexColorTab + ";")
             # Set the background color. This fixes transparant backgrounds when FreeCAD has no stylesheet
-            StyleSheet_Addition = "\n\nQToolButton {background: solid " + hexColor + ";}"
+            StyleSheet_Addition = (
+                "\n\nQToolButton {background: solid " + hexColor + ";}"
+            )
             StyleSheet_Addition_2 = (
-                "\n\nRibbonBar {border: none;background: solid " + hexColor + ";color: " + hexColor + ";}"
+                "\n\nRibbonBar {border: none;background: solid "
+                + hexColor
+                + ";color: "
+                + hexColor
+                + ";}"
             )
             StyleSheet = StyleSheet_Addition_2 + StyleSheet + StyleSheet_Addition
         self.setStyleSheet(StyleSheet)
@@ -507,9 +545,13 @@ class ModernMenu(RibbonBar):
             StyleSheet_Addition_3 = (
                 """QTabBar::tab {
                     background: """
-                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color_Hover", True, True)
+                + StyleMapping_Ribbon.ReturnStyleItem(
+                    "Background_Color_Hover", True, True
+                )
                 + """;color: """
-                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color_Hover", True, True)
+                + StyleMapping_Ribbon.ReturnStyleItem(
+                    "Background_Color_Hover", True, True
+                )
                 + """;min-width: """
                 + str(self.TabBar_Size)
                 + """px;
@@ -582,7 +624,9 @@ class ModernMenu(RibbonBar):
         self.tabBar().tabBarClicked.connect(self.onTabBarClicked)
 
         # override the default scroll behavior with a custom function
-        self.tabBar().wheelEvent = lambda event_tabBar: self.wheelEvent_TabBar(event_tabBar)
+        self.tabBar().wheelEvent = lambda event_tabBar: self.wheelEvent_TabBar(
+            event_tabBar
+        )
         self.wheelEvent = lambda event_CC: self.wheelEvent_CC(event_CC)
         self.tabBar().setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.currentCategory().setFocusPolicy(Qt.FocusPolicy.StrongFocus)
@@ -595,12 +639,20 @@ class ModernMenu(RibbonBar):
         ScrollLeftButton_Tab: QToolButton = self.tabBar().findChildren(QToolButton)[0]
         ScrollRightButton_Tab: QToolButton = self.tabBar().findChildren(QToolButton)[1]
         # get the icons
-        ScrollLeftButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab")
-        ScrollRightButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab")
+        ScrollLeftButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem(
+            "ScrollLeftButton_Tab"
+        )
+        ScrollRightButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem(
+            "ScrollRightButton_Tab"
+        )
         # Set the icons
         StyleSheet = "QToolButton {image: none;margin-top:6px;margin-bottom:6px;};QToolButton::arrow {image: none};"
         BackgroundColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
-        if int(App.Version()[0]) == 0 and int(App.Version()[1]) <= 21 and BackgroundColor is not None:
+        if (
+            int(App.Version()[0]) == 0
+            and int(App.Version()[1]) <= 21
+            and BackgroundColor is not None
+        ):
             StyleSheet = (
                 """QToolButton {image: none;background: """
                 + BackgroundColor
@@ -610,7 +662,9 @@ class ModernMenu(RibbonBar):
             ScrollLeftButton_Tab.setStyleSheet(StyleSheet)
             ScrollLeftButton_Tab.setIcon(ScrollLeftButton_Tab_Icon)
         else:
-            ScrollRightButton_Tab.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+            ScrollRightButton_Tab.setToolButtonStyle(
+                Qt.ToolButtonStyle.ToolButtonTextOnly
+            )
         if ScrollRightButton_Tab_Icon is not None:
             ScrollRightButton_Tab.setStyleSheet(StyleSheet)
             ScrollRightButton_Tab.setIcon(ScrollRightButton_Tab_Icon)
@@ -618,9 +672,13 @@ class ModernMenu(RibbonBar):
             ScrollRightButton_Tab.setArrowType(Qt.ArrowType.RightArrow)
 
         # Remove persistant toolbars
-        PersistentToolbars = App.ParamGet("User parameter:Tux/PersistentToolbars/User").GetGroups()
+        PersistentToolbars = App.ParamGet(
+            "User parameter:Tux/PersistentToolbars/User"
+        ).GetGroups()
         for Group in PersistentToolbars:
-            Parameter = App.ParamGet("User parameter:Tux/PersistentToolbars/User/" + Group)
+            Parameter = App.ParamGet(
+                "User parameter:Tux/PersistentToolbars/User/" + Group
+            )
             Parameter.SetString("Top", "")
             Parameter.SetString("Left", "")
             Parameter.SetString("Right", "")
@@ -631,7 +689,9 @@ class ModernMenu(RibbonBar):
         # Application menu
         ShortcutKey = "Alt+A"
         try:
-            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+            CustomShortCuts = App.ParamGet(
+                "User parameter:BaseApp/Preferences/Shortcut"
+            )
             if "Ribbon_Menu" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Menu")
         except Exception:
@@ -648,7 +708,10 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().enterEvent = lambda enter: self.leaveEvent(enter)
 
         # Rearrange the tabbar and toolbars
-        if Parameters_Ribbon.TOOLBAR_POSITION == 0 or Parameters_Ribbon.TOOLBAR_POSITION == 1:
+        if (
+            Parameters_Ribbon.TOOLBAR_POSITION == 0
+            or Parameters_Ribbon.TOOLBAR_POSITION == 1
+        ):
             # Get the widgets
             _quickAccessToolBarWidget = self.quickAccessToolBar()
             _titleLabel = self._titleWidget._titleLabel
@@ -666,24 +729,38 @@ class ModernMenu(RibbonBar):
                 _titleLabel.setAlignment(Qt.AlignmentFlag.AlignCenter)
                 _titleLabel.setFont(font)
                 # Set the label text to FreeCAD's version
-                text = f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
+                text = (
+                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
+                )
                 _titleLabel.setText(text)
                 # Create a spacer to set the tab
                 spacer = QWidget()
-                spacer.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
+                spacer.setSizePolicy(
+                    QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
+                )
                 spacer.setFixedWidth(3)
                 self._titleWidget._tabBarLayout.setContentsMargins(3, 3, 3, 0)
                 self._titleWidget._tabBarLayout.addWidget(
                     _quickAccessToolBarWidget, 0, 0, 1, 2, Qt.AlignmentFlag.AlignVCenter
                 )
-                self._titleWidget._tabBarLayout.addWidget(_titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter)
-                self._titleWidget._tabBarLayout.addWidget(_rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter)
-                self._titleWidget._tabBarLayout.addWidget(spacer, 1, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter)
-                self._titleWidget._tabBarLayout.addWidget(_tabBar, 1, 1, 1, 4, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(
+                    _titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter
+                )
+                self._titleWidget._tabBarLayout.addWidget(
+                    _rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter
+                )
+                self._titleWidget._tabBarLayout.addWidget(
+                    spacer, 1, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter
+                )
+                self._titleWidget._tabBarLayout.addWidget(
+                    _tabBar, 1, 1, 1, 4, Qt.AlignmentFlag.AlignVCenter
+                )
                 # Change the offsets
                 self.RibbonMinimalHeight = self.QuickAccessButtonSize * 2 + 20
                 self.RibbonOffset = 54 + self.QuickAccessButtonSize * 2
-                self._titleWidget._tabBarLayout.setRowMinimumHeight(0, self.QuickAccessButtonSize)
+                self._titleWidget._tabBarLayout.setRowMinimumHeight(
+                    0, self.QuickAccessButtonSize
+                )
                 self._titleWidget._tabBarLayout.setRowMinimumHeight(1, self.TabBar_Size)
                 # self.setTitle("FreeCAD")
             if Parameters_Ribbon.TOOLBAR_POSITION == 1:  # Toolbars inline with tabbar
@@ -691,26 +768,40 @@ class ModernMenu(RibbonBar):
                 self._titleWidget._tabBarLayout.addWidget(
                     _quickAccessToolBarWidget, 0, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter
                 )
-                self._titleWidget._tabBarLayout.addWidget(_tabBar, 0, 1, 1, 1, Qt.AlignmentFlag.AlignVCenter)
-                self._titleWidget._tabBarLayout.addWidget(_titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter)
-                self._titleWidget._tabBarLayout.addWidget(_rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(
+                    _tabBar, 0, 1, 1, 1, Qt.AlignmentFlag.AlignVCenter
+                )
+                self._titleWidget._tabBarLayout.addWidget(
+                    _titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter
+                )
+                self._titleWidget._tabBarLayout.addWidget(
+                    _rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter
+                )
                 # Change the offsets
                 self.RibbonMinimalHeight = self.QuickAccessButtonSize + 10
                 self.RibbonOffset = 46 + self.QuickAccessButtonSize
-                self._titleWidget._tabBarLayout.setRowMinimumHeight(0, self.QuickAccessButtonSize)
+                self._titleWidget._tabBarLayout.setRowMinimumHeight(
+                    0, self.QuickAccessButtonSize
+                )
 
         # Get the main window, its style, the ribbon and the restore button
-        RestoreButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
+        RestoreButton: QToolButton = self.rightToolBar().findChildren(
+            QToolButton, "RestoreButton"
+        )[0]
         # If the mainwindow is maximized, set the window state to maximize and set the correct icon
         if mw.isMaximized():
             try:
-                RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2])
+                RestoreButton.setIcon(
+                    StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2]
+                )
             except Exception:
                 pass
         # If the mainwindow is not maximized, set the window state to no state and set the correct icon
         if mw.isMaximized() is False:
             try:
-                RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1])
+                RestoreButton.setIcon(
+                    StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1]
+                )
             except Exception:
                 pass
 
@@ -743,7 +834,10 @@ class ModernMenu(RibbonBar):
         TB.show()
         # In FreeCAD 1.0, Overlays are introduced. These have also an enterEvent which results in strange behavior
         # Therefore this function is only activated when FreeCAD's overlay function is disabled.
-        if Parameters_Ribbon.SHOW_ON_HOVER is True and Parameters_Ribbon.USE_FC_OVERLAY is False:
+        if (
+            Parameters_Ribbon.SHOW_ON_HOVER is True
+            and Parameters_Ribbon.USE_FC_OVERLAY is False
+        ):
             self.UnfoldRibbon()
             return
 
@@ -755,7 +849,9 @@ class ModernMenu(RibbonBar):
     # implementation to add actions to the Filemenu. Needed for the accessories menu
     def addAction(self, action: QAction):
         menu = self.findChild(RibbonMenu, "Ribbon")
-        StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+        StyleSheet_Menu = (
+            "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+        )
         menu.setStyleSheet(StyleSheet_Menu)
         if menu is None:
             menu = self.addFileMenu()
@@ -836,7 +932,9 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().setContentsMargins(0, 0, 9, 0)
         # Set the size of the menu button
         self.applicationOptionButton().setFixedSize(
-            self.QuickAccessButtonSize + FontMetrics.boundingRect(Text.text()).width() + 12,
+            self.QuickAccessButtonSize
+            + FontMetrics.boundingRect(Text.text()).width()
+            + 12,
             self.QuickAccessButtonSize,
         )
         # Set the icon
@@ -845,19 +943,24 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().setStyleSheet(
             StyleMapping_Ribbon.ReturnStyleSheet(
                 "applicationbutton",
-                padding_right=str(FontMetrics.horizontalAdvance(Text.text(), -1) + 12) + "px",
+                padding_right=str(FontMetrics.horizontalAdvance(Text.text(), -1) + 12)
+                + "px",
                 radius="4px",
             )
         )
         # Add the default tooltip
-        self.applicationOptionButton().setToolTip(translate("FreeCAD Ribbon", "FreeCAD Ribbon"))
+        self.applicationOptionButton().setToolTip(
+            translate("FreeCAD Ribbon", "FreeCAD Ribbon")
+        )
 
         # add the menus from the menubar to the application button
         self.ApplicationMenus()
 
         # add quick access buttons
         i = 1  # Start value for button count. Used for width of quickaccess toolbar
-        toolBarWidth = ((self.QuickAccessButtonSize * self.sizeFactor) * i) + self.applicationOptionButton().width()
+        toolBarWidth = (
+            (self.QuickAccessButtonSize * self.sizeFactor) * i
+        ) + self.applicationOptionButton().width()
         for commandName in self.ribbonStructure["quickAccessCommands"]:
             i = i + 1
             # Define a width
@@ -889,7 +992,11 @@ class ModernMenu(RibbonBar):
                         height = self.QuickAccessButtonSize
                         button.setFixedSize(width, height)
                         # Set the stylesheet
-                        button.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", f"{padding}px"))
+                        button.setStyleSheet(
+                            StyleMapping_Ribbon.ReturnStyleSheet(
+                                "toolbutton", "2px", f"{padding}px"
+                            )
+                        )
                     elif len(QuickAction) > 1:
                         # set the padding for a dropdown button
                         padding = self.PaddingRight
@@ -901,9 +1008,15 @@ class ModernMenu(RibbonBar):
                         height = self.QuickAccessButtonSize
                         button.setFixedSize(width, height)
                         # Set the PopupMode
-                        button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+                        button.setPopupMode(
+                            QToolButton.ToolButtonPopupMode.InstantPopup
+                        )
                         # Set the stylesheet
-                        button.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", f"{padding}px"))
+                        button.setStyleSheet(
+                            StyleMapping_Ribbon.ReturnStyleSheet(
+                                "toolbutton", "2px", f"{padding}px"
+                            )
+                        )
 
                 # If it is a custom dropdown, add the actions one by one.
                 if commandName.endswith("_ddb") is True:
@@ -925,7 +1038,9 @@ class ModernMenu(RibbonBar):
 
                     # Set the stylesheet
                     button.setStyleSheet(
-                        StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", padding_right=f"{padding}px")
+                        StyleMapping_Ribbon.ReturnStyleSheet(
+                            "toolbutton", "2px", padding_right=f"{padding}px"
+                        )
                     )
 
                 # Set the height
@@ -937,7 +1052,9 @@ class ModernMenu(RibbonBar):
                 if len(button.actions()) > 0:
                     self.addQuickAccessButton(button)
                 else:
-                    StandardFunctions.Print(f"{commandName} did not contain any actions!", "Log")
+                    StandardFunctions.Print(
+                        f"{commandName} did not contain any actions!", "Log"
+                    )
 
                 toolBarWidth = toolBarWidth + width
             except Exception as e:
@@ -953,7 +1070,9 @@ class ModernMenu(RibbonBar):
         # Set the width of the quickaccess toolbar.
         self.quickAccessToolBar().setMinimumWidth(toolBarWidth)
         # Set the size policy
-        self.quickAccessToolBar().setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.MinimumExpanding)
+        self.quickAccessToolBar().setSizePolicy(
+            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.MinimumExpanding
+        )
         # needed for excluding from hiding toolbars
         self.quickAccessToolBar().setObjectName("quickAccessToolBar")
         self.quickAccessToolBar().setWindowTitle("quickAccessToolBar")
@@ -965,17 +1084,23 @@ class ModernMenu(RibbonBar):
         self.tabBar().setFont(font)
 
         self.tabBar().setIconSize(QSize(self.TabBar_Size - 6, self.TabBar_Size - 6))
-        self.tabBar().setStyleSheet("margin: 0px;padding: 0px;height: " + str(self.TabBar_Size) + ";")
+        self.tabBar().setStyleSheet(
+            "margin: 0px;padding: 0px;height: " + str(self.TabBar_Size) + ";"
+        )
 
         # Correct colors when no stylesheet is selected for FreeCAD.
         self.quickAccessToolBar().setStyleSheet("")
         if Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True:
-            FreeCAD_preferences = App.ParamGet("User parameter:BaseApp/Preferences/MainWindow")
+            FreeCAD_preferences = App.ParamGet(
+                "User parameter:BaseApp/Preferences/MainWindow"
+            )
             currentStyleSheet = FreeCAD_preferences.GetString("StyleSheet")
             if currentStyleSheet == "":
                 hexColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
                 # Set the quickaccess toolbar background color
-                self.quickAccessToolBar().setStyleSheet("background-color: " + hexColor + ";")
+                self.quickAccessToolBar().setStyleSheet(
+                    "background-color: " + hexColor + ";"
+                )
 
         # Get the order of workbenches from Parameters
         WorkbenchOrderedList: list = Parameters_Ribbon.TAB_ORDER.split(",")
@@ -991,7 +1116,10 @@ class ModernMenu(RibbonBar):
         # There is an issue with the internal assembly wb showing the wrong panel
         # when assembly4 wb is installed and positioned for the internal assembly wb
         for i in range(len(WorkbenchOrderedList)):
-            if WorkbenchOrderedList[i] == "Assembly4Workbench" or WorkbenchOrderedList[i] == "Assembly3Workbench":
+            if (
+                WorkbenchOrderedList[i] == "Assembly4Workbench"
+                or WorkbenchOrderedList[i] == "Assembly3Workbench"
+            ):
                 try:
                     index_1 = WorkbenchOrderedList.index(WorkbenchOrderedList[i])
                     index_2 = WorkbenchOrderedList.index("AssemblyWorkbench")
@@ -1031,10 +1159,14 @@ class ModernMenu(RibbonBar):
                             icon: QIcon = self.ReturnWorkbenchIcon(workbenchName)
                             self.tabBar().setTabIcon(len(self.categories()) - 1, icon)
                         if Parameters_Ribbon.TABBAR_STYLE == 2:
-                            self.tabBar().setTabIcon(len(self.categories()) - 1, QIcon())
+                            self.tabBar().setTabIcon(
+                                len(self.categories()) - 1, QIcon()
+                            )
 
                         # Set the tab data
-                        self.tabBar().setTabData(len(self.categories()) - 1, workbenchName)
+                        self.tabBar().setTabData(
+                            len(self.categories()) - 1, workbenchName
+                        )
 
                         # Set the tooltip
                         MenuText = workbench.MenuText
@@ -1043,14 +1175,20 @@ class ModernMenu(RibbonBar):
                             ToolTipText.lower() != MenuText.lower() + " workbench"
                             and MenuText.lower() != ToolTipText.lower()
                         ):
-                            MenuText = f"<b>{workbench.MenuText}</b><br>{workbench.ToolTip}"
+                            MenuText = (
+                                f"<b>{workbench.MenuText}</b><br>{workbench.ToolTip}"
+                            )
                         else:
                             MenuText = f"<b>{MenuText}<b>"
 
-                        self.tabBar().setTabToolTip(len(self.categories()) - 1, MenuText)
+                        self.tabBar().setTabToolTip(
+                            len(self.categories()) - 1, MenuText
+                        )
 
         # Set the size of the collapseRibbonButton
-        self.collapseRibbonButton().setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
+        self.collapseRibbonButton().setFixedSize(
+            self.RightToolBarButtonSize, self.RightToolBarButtonSize
+        )
 
         # add the searchbar if available
         SearchBarWidth = self.AddSearchBar()
@@ -1068,10 +1206,18 @@ class ModernMenu(RibbonBar):
         if self.OverlayMenu is not None:
             OverlayMenu = QToolButton()
             OverlayMenu.setIcon(QIcon(os.path.join(pathIcons, "Draft_Layer.svg")))
-            OverlayMenu.setToolTip(translate("FreeCAD Ribbon", "Overlay functions") + "...")
+            OverlayMenu.setToolTip(
+                translate("FreeCAD Ribbon", "Overlay functions") + "..."
+            )
             OverlayMenu.setMenu(self.OverlayMenu)
-            OverlayMenu.setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
-            OverlayMenu.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px"))
+            OverlayMenu.setFixedSize(
+                self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
+            )
+            OverlayMenu.setStyleSheet(
+                StyleMapping_Ribbon.ReturnStyleSheet(
+                    control="toolbutton", padding_right="12px"
+                )
+            )
             OverlayMenu.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
             Font = OverlayMenu.font()
             Font.setPixelSize(Parameters_Ribbon.FONTSIZE_MENUS)
@@ -1109,31 +1255,47 @@ class ModernMenu(RibbonBar):
         SettingsMenu.addAction(self.RibbonMenu.menuAction())
         SettingsMenu.setIcon(Gui.getIcon("Std_DlgParameter.svg"))
         SettingsMenu.setToolTip(translate("FreeCAD Ribbon", "Preferences") + "...")
-        SettingsMenu.setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
-        SettingsMenu.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px"))
+        SettingsMenu.setFixedSize(
+            self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
+        )
+        SettingsMenu.setStyleSheet(
+            StyleMapping_Ribbon.ReturnStyleSheet(
+                control="toolbutton", padding_right="12px"
+            )
+        )
         SettingsMenu.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         # add the settingsmenu to the right toolbar
         self.rightToolBar().addWidget(SettingsMenu)
 
         # Set the helpbutton
         self.helpRibbonButton().setEnabled(True)
-        self.helpRibbonButton().setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self.helpRibbonButton().setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
         self.helpRibbonButton().setToolTip(translate("FreeCAD Ribbon", "Help") + "...")
         # Get the default help action from FreeCAD
         helpMenu = mw.findChildren(QMenu, "&Help")[0]
         helpAction = helpMenu.actions()[0]
         self.helpRibbonButton().setIcon(helpAction.icon())
         self.helpRibbonButton().setMenu(self.HelpMenu)
-        self.helpRibbonButton().setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
-        self.helpRibbonButton().setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px")
+        self.helpRibbonButton().setFixedSize(
+            self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
         )
-        self.helpRibbonButton().setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+        self.helpRibbonButton().setStyleSheet(
+            StyleMapping_Ribbon.ReturnStyleSheet(
+                control="toolbutton", padding_right="12px"
+            )
+        )
+        self.helpRibbonButton().setPopupMode(
+            QToolButton.ToolButtonPopupMode.InstantPopup
+        )
 
         # Add a button the enable or disable AutoHide
         pinButton = QToolButton()
         pinButton.setCheckable(True)
-        pinButton.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        pinButton.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
         pinButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
         # Set the correct icon
         if Parameters_Ribbon.AUTOHIDE_RIBBON is True:
@@ -1151,10 +1313,14 @@ class ModernMenu(RibbonBar):
             pinButton.setChecked(False)
         if Parameters_Ribbon.AUTOHIDE_RIBBON is False:
             pinButton.setChecked(True)
-        pinButton.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px"))
+        pinButton.setStyleSheet(
+            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px")
+        )
         ShortcutKey = "Alt+T"
         try:
-            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+            CustomShortCuts = App.ParamGet(
+                "User parameter:BaseApp/Preferences/Shortcut"
+            )
             if "Ribbon_Pin" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Pin")
             if ShortcutKey != "" and ShortcutKey is not None:
@@ -1162,13 +1328,16 @@ class ModernMenu(RibbonBar):
         except Exception:
             pass
         # Set the tooltip
-        ToolTip = translate("FreeCAD Ribbon", "Click to toggle the autohide function on or off")
+        ToolTip = translate(
+            "FreeCAD Ribbon", "Click to toggle the autohide function on or off"
+        )
         if ShortcutKey != "none":
             ToolTip = ToolTip + f"<br></br><i>{ShortcutKey}</i>"
         pinButton.setToolTip(
             translate(
                 "FreeCAD Ribbon",
-                "Click to toggle the autohide function on or off" + f"<br></br><i>{ShortcutKey}</i>",
+                "Click to toggle the autohide function on or off"
+                + f"<br></br><i>{ShortcutKey}</i>",
             )
         )
 
@@ -1202,9 +1371,13 @@ class ModernMenu(RibbonBar):
                     padding_right="3px",
                 )
             )
-            MinimzeButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[3])
+            MinimzeButton.setIcon(
+                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[3]
+            )
             MinimzeButton.clicked.connect(self.MinimizeFreeCAD)
-            MinimzeButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
+            MinimzeButton.setFixedSize(
+                self.RightToolBarButtonSize, self.RightToolBarButtonSize
+            )
             self.rightToolBar().addWidget(MinimzeButton)
             # Restore button
             RestoreButton = QToolButton()
@@ -1219,9 +1392,13 @@ class ModernMenu(RibbonBar):
                     padding_right="3px",
                 )
             )
-            RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2])
+            RestoreButton.setIcon(
+                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2]
+            )
             RestoreButton.clicked.connect(self.RestoreFreeCAD)
-            RestoreButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
+            RestoreButton.setFixedSize(
+                self.RightToolBarButtonSize, self.RightToolBarButtonSize
+            )
             self.rightToolBar().addWidget(RestoreButton)
             # Close button
             CloseButton = QToolButton()
@@ -1236,19 +1413,29 @@ class ModernMenu(RibbonBar):
                     HoverColor="#e62424",
                 )
             )
-            CloseButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[0])
+            CloseButton.setIcon(
+                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[0]
+            )
             CloseButton.clicked.connect(self.CloseFreeCAD)
-            CloseButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
+            CloseButton.setFixedSize(
+                self.RightToolBarButtonSize, self.RightToolBarButtonSize
+            )
             self.rightToolBar().addWidget(CloseButton)
 
         # Set the width of the right toolbar
-        RightToolbarWidth = SearchBarWidth + 3 * (self.RightToolBarButtonSize + 16) + self.RightToolBarButtonSize
+        RightToolbarWidth = (
+            SearchBarWidth
+            + 3 * (self.RightToolBarButtonSize + 16)
+            + self.RightToolBarButtonSize
+        )
         if Parameters_Ribbon.USE_FC_OVERLAY is True:
             RightToolbarWidth = SearchBarWidth + 2 * (self.RightToolBarButtonSize + 16)
         self.rightToolBar().setMinimumWidth(RightToolbarWidth)
         self.setRightToolBarHeight(self.RibbonMinimalHeight)
         # Set the size policy
-        self.rightToolBar().setSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding)
+        self.rightToolBar().setSizePolicy(
+            QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding
+        )
         self.rightToolBar().setSizeIncrement(1, 1)
         # Set the objectName for the right toolbar. needed for excluding from hiding.
         self.rightToolBar().setObjectName("rightToolBar")
@@ -1266,11 +1453,17 @@ class ModernMenu(RibbonBar):
 
                 sea = SearchBoxLight.SearchBoxLight(
                     getItemGroups=lambda: __import__("GetItemGroups").getItemGroups(),
-                    getToolTip=lambda groupId, setParent: __import__("GetItemGroups").getToolTip(groupId, setParent),
-                    getItemDelegate=lambda: __import__("IndentedItemDelegate").IndentedItemDelegate(),
+                    getToolTip=lambda groupId, setParent: __import__(
+                        "GetItemGroups"
+                    ).getToolTip(groupId, setParent),
+                    getItemDelegate=lambda: __import__(
+                        "IndentedItemDelegate"
+                    ).IndentedItemDelegate(),
                 )
                 sea.resultSelected.connect(
-                    lambda index, groupId: __import__("GetItemGroups").onResultSelected(index, groupId)
+                    lambda index, groupId: __import__("GetItemGroups").onResultSelected(
+                        index, groupId
+                    )
                 )
                 sea.setFixedSize(width, self.RightToolBarButtonSize)
                 BeforeAction = self.rightToolBar().actions()[1]
@@ -1288,13 +1481,18 @@ class ModernMenu(RibbonBar):
         MenuBar = mw.menuBar()
 
         # Set a stylesheet specific for the menubar. Otherwise the fontsize of the menus will not be applied
-        StyleSheet_MenuBar = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+        StyleSheet_MenuBar = (
+            "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+        )
         MenuBar.setStyleSheet(StyleSheet_MenuBar)
         # # Add the actions of the menubar to the application menu
         for child in MenuBar.actions():
             if child.objectName() != "&Help" and child.objectName != "AccessoriesMenu":
                 ApplictionMenu.addAction(child)
-            if child.objectName == "AccessoriesMenu" and self.AccessoriesMenu is not None:
+            if (
+                child.objectName == "AccessoriesMenu"
+                and self.AccessoriesMenu is not None
+            ):
                 ApplictionMenu.addMenu(self.AccessoriesMenu)
 
         # if you on macOS, add the ribbon menus to the menubar
@@ -1323,7 +1521,9 @@ class ModernMenu(RibbonBar):
             color = StyleMapping_Ribbon.ReturnStyleItem("DevelopColor")
             Label = QLabel()
             Label.setText("Development version")
-            Label.setStyleSheet(f"color: {color};border: 1px solid {color};border-radius: 2px;")
+            Label.setStyleSheet(
+                f"color: {color};border: 1px solid {color};border-radius: 2px;"
+            )
             ApplictionMenu.addWidget(Label)
         # if there is an update, add a button that opens the addon manager
         if self.UpdateVersion != "" and self.DeveloperVersion == "":
@@ -1362,12 +1562,17 @@ class ModernMenu(RibbonBar):
                 self.AccessoriesMenu.addActions(subMenus)
 
         # Create the overlay menu when the native overlay function is not used
-        if Parameters_Ribbon.USE_FC_OVERLAY is False and Parameters_Ribbon.USE_OVERLAY is True:
+        if (
+            Parameters_Ribbon.USE_FC_OVERLAY is False
+            and Parameters_Ribbon.USE_OVERLAY is True
+        ):
             OverlayMenu = QMenu(translate("FreeCAD Ribbon", "Overlay") + "...", self)
             OverlayMenu.setToolTipsVisible(True)
 
             # Toggle overlay for all -----------------------------------------------------
-            OverlayButton_All = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle overlay for all"))
+            OverlayButton_All = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle overlay for all")
+            )
             OverlayButton_All.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1378,7 +1583,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "F4"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayAll" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayAll")
             except Exception as e:
@@ -1388,7 +1595,9 @@ class ModernMenu(RibbonBar):
             OverlayButton_All.setShortcut(ShortcutKey)
 
             # Toggle transparancy for all -----------------------------------------------------
-            TransparancyButton_All = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle transparancy"))
+            TransparancyButton_All = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle transparancy")
+            )
             TransparancyButton_All.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1399,9 +1608,13 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Shift+F4"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayTransparentAll" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayTransparentAll")
+                    ShortcutKey = CustomShortCuts.GetString(
+                        "Std_DockOverlayTransparentAll"
+                    )
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1410,7 +1623,9 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle overlay for active panel-----------------------------------------------------
-            OverlayButton_Active = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle overlay"))
+            OverlayButton_Active = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle overlay")
+            )
             OverlayButton_Active.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1421,7 +1636,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "F3"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayToggle" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggle")
             except Exception as e:
@@ -1431,7 +1648,9 @@ class ModernMenu(RibbonBar):
             OverlayButton_Active.setShortcut(ShortcutKey)
 
             # Toggle transparancy for active panel-----------------------------------------------------
-            TransparancyButton = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle transparant mode"))
+            TransparancyButton = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle transparant mode")
+            )
             TransparancyButton.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1442,9 +1661,13 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Shift+F3"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayToggleTransparent" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleTransparent")
+                    ShortcutKey = CustomShortCuts.GetString(
+                        "Std_DockOverlayToggleTransparent"
+                    )
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1453,15 +1676,25 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle mouse bypass-----------------------------------------------------
-            ToggleMouseByPass = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Bypass mouse events"))
-            ToggleMouseByPass.setToolTip(translate("FreeCAD Ribbon", "Bypass mouse events in docked overlay windows"))
+            ToggleMouseByPass = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Bypass mouse events")
+            )
+            ToggleMouseByPass.setToolTip(
+                translate(
+                    "FreeCAD Ribbon", "Bypass mouse events in docked overlay windows"
+                )
+            )
             ToggleMouseByPass.triggered.connect(self.ToggleMouseByPass)
             # Get the shortcut from the original command
             ShortcutKey = "T,T"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayMouseTransparent" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayMouseTransparent")
+                    ShortcutKey = CustomShortCuts.GetString(
+                        "Std_DockOverlayMouseTransparent"
+                    )
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1470,7 +1703,9 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle overlay for left panels-----------------------------------------------------
-            OverlayButton_Left = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle left"))
+            OverlayButton_Left = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle left")
+            )
             OverlayButton_Left.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1481,7 +1716,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+left"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayToggleLeft" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleLeft")
             except Exception as e:
@@ -1490,7 +1727,9 @@ class ModernMenu(RibbonBar):
                 ShortcutKey = "Ctrl+left"
             OverlayButton_Left.setShortcut(ShortcutKey)
             # Toggle overlay for right panels-----------------------------------------------------
-            OverlayButton_Right = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle right"))
+            OverlayButton_Right = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle right")
+            )
             OverlayButton_Right.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1501,16 +1740,22 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+right"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayToggleRight" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleRight")
+                    ShortcutKey = CustomShortCuts.GetString(
+                        "Std_DockOverlayToggleRight"
+                    )
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
                 ShortcutKey = "Ctrl+right"
             OverlayButton_Right.setShortcut(ShortcutKey)
             # Toggle overlay for Bottom panels-----------------------------------------------------
-            OverlayButton_Bottom = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle bottom"))
+            OverlayButton_Bottom = OverlayMenu.addAction(
+                translate("FreeCAD Ribbon", "Toggle bottom")
+            )
             OverlayButton_Bottom.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1521,9 +1766,13 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+down"
             try:
-                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+                CustomShortCuts = App.ParamGet(
+                    "User parameter:BaseApp/Preferences/Shortcut"
+                )
                 if "Std_DockOverlayToggleBottom" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleBottom")
+                    ShortcutKey = CustomShortCuts.GetString(
+                        "Std_DockOverlayToggleBottom"
+                    )
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1534,15 +1783,23 @@ class ModernMenu(RibbonBar):
             self.OverlayMenu = OverlayMenu
 
         # Create a ribbon menu
-        RibbonMenu = QMenu(translate("FreeCAD Ribbon", "Ribbon UI preferences") + " ...", self)
+        RibbonMenu = QMenu(
+            translate("FreeCAD Ribbon", "Ribbon UI preferences") + " ...", self
+        )
         RibbonMenu.setToolTipsVisible(True)
         # Add the ribbon design button
-        DesignButton = RibbonMenu.addAction(translate("FreeCAD Ribbon", "Ribbon layout"))
-        DesignButton.setToolTip(translate("FreeCAD Ribbon", "Design the ribbon to your preference"))
+        DesignButton = RibbonMenu.addAction(
+            translate("FreeCAD Ribbon", "Ribbon layout")
+        )
+        DesignButton.setToolTip(
+            translate("FreeCAD Ribbon", "Design the ribbon to your preference")
+        )
         DesignButton.triggered.connect(self.loadDesignMenu)
         ShortcutKey = "Alt+L"
         try:
-            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+            CustomShortCuts = App.ParamGet(
+                "User parameter:BaseApp/Preferences/Shortcut"
+            )
             if "Ribbon_Layout" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Layout")
         except Exception:
@@ -1551,13 +1808,19 @@ class ModernMenu(RibbonBar):
             DesignButton.setShortcut(ShortcutKey)
             self.LayoutMenuShortCut = ShortcutKey
         # Add the preference button
-        PreferenceButton = RibbonMenu.addAction(translate("FreeCAD Ribbon", "Preferences"))
-        PreferenceButton.setToolTip(translate("FreeCAD Ribbon", "Set preferences for the Ribbon UI"))
+        PreferenceButton = RibbonMenu.addAction(
+            translate("FreeCAD Ribbon", "Preferences")
+        )
+        PreferenceButton.setToolTip(
+            translate("FreeCAD Ribbon", "Set preferences for the Ribbon UI")
+        )
         PreferenceButton.setMenuRole(QAction.MenuRole.NoRole)
         PreferenceButton.triggered.connect(self.loadSettingsMenu)
         ShortcutKey = "Alt+P"
         try:
-            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
+            CustomShortCuts = App.ParamGet(
+                "User parameter:BaseApp/Preferences/Shortcut"
+            )
             if "Ribbon_Preferences" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Preferences")
         except Exception:
@@ -1569,8 +1832,12 @@ class ModernMenu(RibbonBar):
         if os.path.exists(ScriptDir) is True:
             ListScripts = os.listdir(ScriptDir)
             if len(ListScripts) > 0:
-                ScriptButtonMenu = RibbonMenu.addMenu(translate("FreeCAD Ribbon", "Scripts"))
-                ScriptButtonMenu.setToolTip(translate("FreeCAD Ribbon", "Scripts to help setup the ribbon."))
+                ScriptButtonMenu = RibbonMenu.addMenu(
+                    translate("FreeCAD Ribbon", "Scripts")
+                )
+                ScriptButtonMenu.setToolTip(
+                    translate("FreeCAD Ribbon", "Scripts to help setup the ribbon.")
+                )
                 for i in range(len(ListScripts)):
                     ScriptButtonMenu.addAction(
                         ListScripts[i],
@@ -1602,7 +1869,11 @@ class ModernMenu(RibbonBar):
 
         # Add the ribbon helpbutton under the FreeCAD
         RibbonHelpButton = QAction(translate("FreeCAD Ribbon", "Ribbon UI help"))
-        RibbonHelpButton.setToolTip(translate("FreeCAD Ribbon", "Open the help page for the Ribbon UI in your browser"))
+        RibbonHelpButton.setToolTip(
+            translate(
+                "FreeCAD Ribbon", "Open the help page for the Ribbon UI in your browser"
+            )
+        )
         RibbonHelpButton.setIcon(HelpIcon)
         RibbonHelpButton.triggered.connect(self.on_RibbonHelpButton_clicked)
         HelpMenu.insertAction(actions[1], RibbonHelpButton)
@@ -1625,11 +1896,15 @@ class ModernMenu(RibbonBar):
         PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
         version = StandardFunctions.ReturnXML_Value(PackageXML, "version")
         # Create the ribbon about button
-        AboutButton_Ribbon = AboutMenu.addAction(translate("FreeCAD Ribbon", "About Ribbon UI ") + version)
+        AboutButton_Ribbon = AboutMenu.addAction(
+            translate("FreeCAD Ribbon", "About Ribbon UI ") + version
+        )
         AboutButton_Ribbon.setIcon(AboutIcon)
         AboutButton_Ribbon.triggered.connect(self.on_AboutButton_clicked)
         # Create the what's new button
-        WhatsNewButton_Ribbon = AboutMenu.addAction(translate("FreeCAD Ribbon", "What's new?"))
+        WhatsNewButton_Ribbon = AboutMenu.addAction(
+            translate("FreeCAD Ribbon", "What's new?")
+        )
         WhatsNewButton_Ribbon.triggered.connect(self.on_WhatsNewButton_clicked)
         # add the aboutmenu to the help menu
         HelpMenu.addMenu(AboutMenu)
@@ -1676,7 +1951,9 @@ class ModernMenu(RibbonBar):
             Parameters_Ribbon.Settings.SetBoolSetting("AutoHideRibbon", True)
             Parameters_Ribbon.AUTOHIDE_RIBBON = True
 
-            pinButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "Pin Ribbon")[0]
+            pinButton: QToolButton = self.rightToolBar().findChildren(
+                QToolButton, "Pin Ribbon"
+            )[0]
             pinButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed"))
 
             # Make sure that the ribbon remains visible
@@ -1688,7 +1965,9 @@ class ModernMenu(RibbonBar):
             Parameters_Ribbon.Settings.SetBoolSetting("AutoHideRibbon", False)
             Parameters_Ribbon.AUTOHIDE_RIBBON = False
 
-            pinButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "Pin Ribbon")[0]
+            pinButton: QToolButton = self.rightToolBar().findChildren(
+                QToolButton, "Pin Ribbon"
+            )[0]
             pinButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_open"))
 
             # Make sure that the ribbon remains visible
@@ -1733,7 +2012,9 @@ class ModernMenu(RibbonBar):
         # Set the text color depending in tabstyle
         if Parameters_Ribbon.TABBAR_STYLE != 1:
             self.tabBar().setStyleSheet(
-                "QTabBar::tab {color: " + StyleMapping_Ribbon.ReturnStyleItem("FontColor") + ";}"
+                "QTabBar::tab {color: "
+                + StyleMapping_Ribbon.ReturnStyleItem("FontColor")
+                + ";}"
             )
         if Parameters_Ribbon.TABBAR_STYLE == 1:
             self.tabBar().setStyleSheet(
@@ -1814,16 +2095,20 @@ class ModernMenu(RibbonBar):
         # Get the custom panels and add them to the list of toolbars
         try:
             if workbenchName in self.ribbonStructure["customToolbars"]:
-                for CustomPanel in self.ribbonStructure["customToolbars"][workbenchName]:
+                for CustomPanel in self.ribbonStructure["customToolbars"][
+                    workbenchName
+                ]:
                     ListToolbars.append(CustomPanel)
 
                     # remove the original toolbars from the list
-                    Commands = self.ribbonStructure["customToolbars"][workbenchName][CustomPanel]["commands"]
+                    Commands = self.ribbonStructure["customToolbars"][workbenchName][
+                        CustomPanel
+                    ]["commands"]
                     for Command in Commands:
                         try:
-                            OriginalToolbar = self.ribbonStructure["customToolbars"][workbenchName][CustomPanel][
-                                "commands"
-                            ][Command]
+                            OriginalToolbar = self.ribbonStructure["customToolbars"][
+                                workbenchName
+                            ][CustomPanel]["commands"][Command]
                             ListToolbars.remove(OriginalToolbar)
                         except Exception:
                             continue
@@ -1843,7 +2128,9 @@ class ModernMenu(RibbonBar):
 
         try:
             # Get the order of toolbars
-            ToolbarOrder: list = self.ribbonStructure["workbenches"][workbenchName]["toolbars"]["order"]
+            ToolbarOrder: list = self.ribbonStructure["workbenches"][workbenchName][
+                "toolbars"
+            ]["order"]
 
             # Sort the list of toolbars according the toolbar order
             def SortToolbars(toolbar):
@@ -1907,30 +2194,51 @@ class ModernMenu(RibbonBar):
 
             # add separators to the command list.
             if workbenchName in self.ribbonStructure["workbenches"]:
-                if toolbar != "" and toolbar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]:
-                    if "order" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]:
+                if (
+                    toolbar != ""
+                    and toolbar
+                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
+                ):
+                    if (
+                        "order"
+                        in self.ribbonStructure["workbenches"][workbenchName][
+                            "toolbars"
+                        ][toolbar]
+                    ):
                         for j in range(
-                            len(self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"])
+                            len(
+                                self.ribbonStructure["workbenches"][workbenchName][
+                                    "toolbars"
+                                ][toolbar]["order"]
+                            )
                         ):
                             if (
                                 "separator"
-                                in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"][
-                                    j
-                                ].lower()
+                                in self.ribbonStructure["workbenches"][workbenchName][
+                                    "toolbars"
+                                ][toolbar]["order"][j].lower()
                             ):
                                 separator = QToolButton()
                                 separator.setText(
-                                    self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"][j]
+                                    self.ribbonStructure["workbenches"][workbenchName][
+                                        "toolbars"
+                                    ][toolbar]["order"][j]
                                 )
                                 allButtons.insert(j, separator)
 
             if workbenchName in self.ribbonStructure["workbenches"]:
                 # order buttons like defined in ribbonStructure
                 if (
-                    toolbar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
-                    and "order" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]
+                    toolbar
+                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
+                    and "order"
+                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][
+                        toolbar
+                    ]
                 ):
-                    OrderList: list = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"]
+                    OrderList: list = self.ribbonStructure["workbenches"][
+                        workbenchName
+                    ]["toolbars"][toolbar]["order"]
 
                     # XXX check that positionsList consists of strings only
                     def sortButtons(button: QToolButton):
@@ -1939,7 +2247,9 @@ class ModernMenu(RibbonBar):
                         # Get the menu text
                         if len(button.actions()) > 0:
                             action = button.actions()[0]
-                            Text = StandardFunctions.CommandInfoCorrections(action.data())["menuText"]
+                            Text = StandardFunctions.CommandInfoCorrections(
+                                action.data()
+                            )["menuText"]
 
                         if Text == "":
                             return -1
@@ -1959,12 +2269,8 @@ class ModernMenu(RibbonBar):
                 []
             )  # if buttons are used in multiple workbenches, they can show up double. (Sketcher_NewSketch)
             # for button in allButtons:
-            NoSmallButtons_spacer = (
-                0  # needed to count the number of small buttons in a column. (bug fix with adding separators)
-            )
-            NoMediumButtons_spacer = (
-                0  # needed to count the number of medium buttons in a column. (bug fix with adding separators)
-            )
+            NoSmallButtons_spacer = 0  # needed to count the number of small buttons in a column. (bug fix with adding separators)
+            NoMediumButtons_spacer = 0  # needed to count the number of medium buttons in a column. (bug fix with adding separators)
 
             # Define number of rows used per button size
             LargeButtonRows = 3
@@ -1987,9 +2293,9 @@ class ModernMenu(RibbonBar):
                 buttonSize = "small"
                 try:
                     action = button.defaultAction()
-                    buttonSize = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["commands"][
-                        action.data()
-                    ]["size"]
+                    buttonSize = self.ribbonStructure["workbenches"][workbenchName][
+                        "toolbars"
+                    ][toolbar]["commands"][action.data()]["size"]
                     if buttonSize == "small":
                         NoSmallButtons_spacer += 1
                     if buttonSize == "medium":
@@ -2080,22 +2386,28 @@ class ModernMenu(RibbonBar):
                             try:
                                 # If the text is not from a hardcoded dropdown:
                                 if len(action.data().split(", ")) <= 1:
-                                    text = StandardFunctions.CommandInfoCorrections(action.data())["ActionText"]
+                                    text = StandardFunctions.CommandInfoCorrections(
+                                        action.data()
+                                    )["ActionText"]
                             except Exception:
                                 pass
 
                             # try to get alternative text from ribbonStructure
                             try:
-                                textJSON = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                    "commands"
-                                ][action.data()]["text"]
+                                textJSON = self.ribbonStructure["workbenches"][
+                                    workbenchName
+                                ]["toolbars"][toolbar]["commands"][action.data()][
+                                    "text"
+                                ]
 
                                 # There is a bug in freecad with the comp-sketch menu hase the wrong text
                                 if (
                                     action.data() == "PartDesign_CompSketches"
-                                    and self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                        "commands"
-                                    ][action.data()]["text"]
+                                    and self.ribbonStructure["workbenches"][
+                                        workbenchName
+                                    ]["toolbars"][toolbar]["commands"][action.data()][
+                                        "text"
+                                    ]
                                     == "Create datum"
                                 ):
                                     textJSON = "Create sketch"
@@ -2106,13 +2418,19 @@ class ModernMenu(RibbonBar):
                                     # if it is a normal command:
                                     if len(action.data().split(", ")) <= 1:
                                         Command = Gui.Command.get(CommandName)
-                                        MenuName = CommandInfoCorrections(CommandName)["menuText"].replace("&", "")
+                                        MenuName = CommandInfoCorrections(CommandName)[
+                                            "menuText"
+                                        ].replace("&", "")
                                         if CommandName == action.data():
                                             if (
                                                 MenuName
-                                                != self.ribbonStructure["workbenches"][workbenchName]["toolbars"][
-                                                    toolbar
-                                                ]["commands"][action.data()]["text"]
+                                                != self.ribbonStructure["workbenches"][
+                                                    workbenchName
+                                                ]["toolbars"][toolbar]["commands"][
+                                                    action.data()
+                                                ][
+                                                    "text"
+                                                ]
                                                 and MenuName != ""
                                                 and textJSON != ""
                                             ):
@@ -2122,9 +2440,13 @@ class ModernMenu(RibbonBar):
                                         MenuName = action.text()
                                         if (
                                             MenuName
-                                            != self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                                "commands"
-                                            ][action.data()]["text"]
+                                            != self.ribbonStructure["workbenches"][
+                                                workbenchName
+                                            ]["toolbars"][toolbar]["commands"][
+                                                action.data()
+                                            ][
+                                                "text"
+                                            ]
                                             and MenuName != ""
                                             and textJSON != ""
                                         ):
@@ -2149,9 +2471,9 @@ class ModernMenu(RibbonBar):
                                 CommandName = button.text()
 
                             try:
-                                pixmap = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                    "commands"
-                                ][CommandName]["icon"]
+                                pixmap = self.ribbonStructure["workbenches"][
+                                    workbenchName
+                                ]["toolbars"][toolbar]["commands"][CommandName]["icon"]
                             except Exception:
                                 pass
                             actionIcon = self.ReturnCommandIcon(action.data(), pixmap)
@@ -2160,18 +2482,24 @@ class ModernMenu(RibbonBar):
 
                             # try to get alternative icon from ribbonStructure
                             try:
-                                icon_Json = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                    "commands"
-                                ][CommandName]["icon"]
+                                icon_Json = self.ribbonStructure["workbenches"][
+                                    workbenchName
+                                ]["toolbars"][toolbar]["commands"][CommandName]["icon"]
                                 if icon_Json != "":
                                     action.setIcon(Gui.getIcon(icon_Json))
                             except KeyError:
                                 pass
 
                             # If the icon is still none, try to retrieve it from the data file
-                            if action.icon() is None or (action.icon() is not None and action.icon().isNull()):
-                                StandardFunctions.Print(f"An icon retrieved from data file for '{CommandName}'")
-                                DataFile = os.path.join(os.path.dirname(__file__), "RibbonDataFile.dat")
+                            if action.icon() is None or (
+                                action.icon() is not None and action.icon().isNull()
+                            ):
+                                StandardFunctions.Print(
+                                    f"An icon retrieved from data file for '{CommandName}'"
+                                )
+                                DataFile = os.path.join(
+                                    os.path.dirname(__file__), "RibbonDataFile.dat"
+                                )
 
                                 if os.path.exists(DataFile) is True:
                                     Data = {}
@@ -2185,7 +2513,11 @@ class ModernMenu(RibbonBar):
                                             # This works only for FreeCAD Commands
                                             CommandName_Icon = action.data()
                                             if CommandName_Icon == IconItem[0]:
-                                                Icon: QIcon = Serialize_Ribbon.deserializeIcon(IconItem[1])
+                                                Icon: QIcon = (
+                                                    Serialize_Ribbon.deserializeIcon(
+                                                        IconItem[1]
+                                                    )
+                                                )
                                                 action.setIcon(Icon)
                                     except Exception as e:
                                         if Parameters_Ribbon.DEBUG_MODE is True:
@@ -2197,9 +2529,9 @@ class ModernMenu(RibbonBar):
 
                             # get button size from ribbonStructure
                             try:
-                                buttonSize = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
-                                    "commands"
-                                ][CommandName]["size"]
+                                buttonSize = self.ribbonStructure["workbenches"][
+                                    workbenchName
+                                ]["toolbars"][toolbar]["commands"][CommandName]["size"]
                                 if buttonSize == "":
                                     buttonSize = "small"
                             except KeyError:
@@ -2216,7 +2548,10 @@ class ModernMenu(RibbonBar):
                             action.setText(action.text().replace("&", ""))
                             if buttonSize == "small":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_SMALL
-                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
+                                if (
+                                    IconOnly is True
+                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
+                                ):
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2255,7 +2590,10 @@ class ModernMenu(RibbonBar):
 
                             elif buttonSize == "medium":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_MEDIUM
-                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
+                                if (
+                                    IconOnly is True
+                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
+                                ):
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2292,7 +2630,10 @@ class ModernMenu(RibbonBar):
                                 )  # Set fixedheight to false. This is set in the custom widgets
                             elif buttonSize == "large":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_LARGE
-                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
+                                if (
+                                    IconOnly is True
+                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
+                                ):
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2330,17 +2671,23 @@ class ModernMenu(RibbonBar):
                             else:
                                 if Parameters_Ribbon.DEBUG_MODE is True:
                                     if buttonSize != "none":
-                                        print(f"{action.text()} is ignored. Its size was: {buttonSize}")
+                                        print(
+                                            f"{action.text()} is ignored. Its size was: {buttonSize}"
+                                        )
                                 pass
 
                             if btn.menu() is not None:
-                                btn.popupMode(QToolButton.ToolButtonPopupMode.MenuButtonPopup)
+                                btn.popupMode(
+                                    QToolButton.ToolButtonPopupMode.MenuButtonPopup
+                                )
 
                             # Set the background always to background color.
                             # Styling is managed in the custom button class
                             StyleSheet_Addition_Button = (
                                 "QToolButton, QToolButton:hover {background-color: "
-                                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
+                                + StyleMapping_Ribbon.ReturnStyleItem(
+                                    "Background_Color"
+                                )
                                 + ";border: none"
                                 + ";}"
                             )
@@ -2355,7 +2702,10 @@ class ModernMenu(RibbonBar):
                             continue
 
             # Change the name of the view panels to "View"
-            if panel.title() in "Views - Ribbon_newPanel" or panel.title() in "Individual views":
+            if (
+                panel.title() in "Views - Ribbon_newPanel"
+                or panel.title() in "Individual views"
+            ):
                 panel.setTitle(" Views ")
             else:
                 # Remove possible workbench names from the titles
@@ -2395,7 +2745,9 @@ class ModernMenu(RibbonBar):
             actionList = []
             for i in range(len(ButtonList)):
                 button = ButtonList[i]
-                StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+                StyleSheet_Menu = (
+                    "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+                )
                 button.setStyleSheet(StyleSheet_Menu)
                 if len(button.actions()) == 1:
                     actionList.append(button.actions()[0])
@@ -2403,14 +2755,20 @@ class ModernMenu(RibbonBar):
                     actionList.append(button.actions())
             OptionButton = panel.panelOptionButton()
             if len(actionList) > 0:
-                Menu = CustomControls.CustomOptionMenu(OptionButton.menu(), actionList, self)
+                Menu = CustomControls.CustomOptionMenu(
+                    OptionButton.menu(), actionList, self
+                )
                 OptionButton.setMenu(Menu)
-                StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+                StyleSheet_Menu = (
+                    "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
+                )
                 Menu.setStyleSheet(StyleSheet_Menu)
                 # Set the behavior of the option button
                 OptionButton.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
                 # Remove the image to avoid double arrows
-                OptionButton.setStyleSheet("RibbonPanelOptionButton::menu-indicator {image: none;}")
+                OptionButton.setStyleSheet(
+                    "RibbonPanelOptionButton::menu-indicator {image: none;}"
+                )
                 Menu = OptionButton.menu()
 
                 # Set the icon
@@ -2419,7 +2777,9 @@ class ModernMenu(RibbonBar):
                     OptionButton.setIcon(OptionButton_Icon)
                 else:
                     OptionButton.setArrowType(Qt.ArrowType.DownArrow)
-                    OptionButton.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
+                    OptionButton.setToolButtonStyle(
+                        Qt.ToolButtonStyle.ToolButtonTextBesideIcon
+                    )
                     OptionButton.setText("more...")
             if len(actionList) == 0:
                 panel.panelOptionButton().hide()
@@ -2428,13 +2788,21 @@ class ModernMenu(RibbonBar):
 
         # Set the previous/next buttons
         category = self.currentCategory()
-        ScrollLeftButton_Category: RibbonCategoryLayoutButton = category.findChildren(RibbonCategoryLayoutButton)[0]
-        ScrollRightButton_Category: RibbonCategoryLayoutButton = category.findChildren(RibbonCategoryLayoutButton)[1]
+        ScrollLeftButton_Category: RibbonCategoryLayoutButton = category.findChildren(
+            RibbonCategoryLayoutButton
+        )[0]
+        ScrollRightButton_Category: RibbonCategoryLayoutButton = category.findChildren(
+            RibbonCategoryLayoutButton
+        )[1]
         ScrollLeftButton_Category.setMinimumWidth(self.iconSize * 0.5)
         ScrollRightButton_Category.setMinimumWidth(self.iconSize * 0.5)
         # get the icons
-        ScrollLeftButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category")
-        ScrollRightButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category")
+        ScrollLeftButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem(
+            "ScrollLeftButton_Category"
+        )
+        ScrollRightButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem(
+            "ScrollRightButton_Category"
+        )
         # Set the icons
         if ScrollLeftButton_Category_Icon is not None:
             ScrollLeftButton_Category.setIcon(ScrollLeftButton_Category_Icon)
@@ -2448,23 +2816,37 @@ class ModernMenu(RibbonBar):
         ScrollLeftButton_Category.setFixedHeight(Parameters_Ribbon.ICON_SIZE_SMALL * 3)
         ScrollRightButton_Category.setFixedHeight(Parameters_Ribbon.ICON_SIZE_SMALL * 3)
         # Set the stylesheet
-        ScrollLeftButton_Category.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton"))
-        ScrollRightButton_Category.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton"))
-        # Connect the custom click event
-        ScrollLeftButton_Category.mousePressEvent = lambda clickLeft: self.on_ScrollButton_Category_clicked(
-            clickLeft, ScrollLeftButton_Category
+        ScrollLeftButton_Category.setStyleSheet(
+            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton")
         )
-        ScrollRightButton_Category.mousePressEvent = lambda clickRight: self.on_ScrollButton_Category_clicked(
-            clickRight, ScrollRightButton_Category
+        ScrollRightButton_Category.setStyleSheet(
+            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton")
+        )
+        # Connect the custom click event
+        ScrollLeftButton_Category.mousePressEvent = (
+            lambda clickLeft: self.on_ScrollButton_Category_clicked(
+                clickLeft, ScrollLeftButton_Category
+            )
+        )
+        ScrollRightButton_Category.mousePressEvent = (
+            lambda clickRight: self.on_ScrollButton_Category_clicked(
+                clickRight, ScrollRightButton_Category
+            )
         )
 
         # Set the maximum height to a high value to prevent from the ribbon to be clipped off
-        self.currentCategory().setMinimumHeight(self.RibbonHeight - self.RibbonMinimalHeight - 3)
-        self.currentCategory().setMaximumHeight(self.RibbonHeight - self.RibbonMinimalHeight - 3)
+        self.currentCategory().setMinimumHeight(
+            self.RibbonHeight - self.RibbonMinimalHeight - 3
+        )
+        self.currentCategory().setMaximumHeight(
+            self.RibbonHeight - self.RibbonMinimalHeight - 3
+        )
         self.setRibbonHeight(self.RibbonHeight)
         return
 
-    def on_ScrollButton_Category_clicked(self, event, ScrollButton: RibbonCategoryLayoutButton):
+    def on_ScrollButton_Category_clicked(
+        self, event, ScrollButton: RibbonCategoryLayoutButton
+    ):
         for i in range(Parameters_Ribbon.RIBBON_CLICKSPEED):
             ScrollButton.click()
         return
@@ -2485,7 +2867,10 @@ class ModernMenu(RibbonBar):
             parentWidget = toolbar.parentWidget()
             toolbar.setHidden(True)
             # hide toolbars that are not in the statusBar and show toolbars that are in the statusbar.
-            if parentWidget.objectName() == "statusBar" or parentWidget.objectName() == "StatusBarArea":
+            if (
+                parentWidget.objectName() == "statusBar"
+                or parentWidget.objectName() == "StatusBarArea"
+            ):
                 toolbar.setEnabled(True)
                 toolbar.setVisible(True)
             #
@@ -2517,7 +2902,11 @@ class ModernMenu(RibbonBar):
         return
 
     def FoldRibbon(self, Ignore=False):
-        if Parameters_Ribbon.AUTOHIDE_RIBBON is True and self.isLoaded is True and Ignore is False:
+        if (
+            Parameters_Ribbon.AUTOHIDE_RIBBON is True
+            and self.isLoaded is True
+            and Ignore is False
+        ):
             if len(mw.findChildren(QDockWidget, "Ribbon")) > 0:
                 TB: QDockWidget = mw.findChildren(QDockWidget, "Ribbon")[0]
                 TB.setMinimumHeight(self.RibbonMinimalHeight)
@@ -2537,7 +2926,10 @@ class ModernMenu(RibbonBar):
 
                     for Group in CustomToolbars:
                         Parameter = App.ParamGet(
-                            "User parameter:BaseApp/Workbench/" + WorkBenchName + "/Toolbar/" + Group
+                            "User parameter:BaseApp/Workbench/"
+                            + WorkBenchName
+                            + "/Toolbar/"
+                            + Group
                         )
                         Name = Parameter.GetString("Name")
                         Toolbars.append([Name, WorkBenchName])
@@ -2546,10 +2938,14 @@ class ModernMenu(RibbonBar):
 
     def List_ReturnCustomToolbars_Global(self):
         Toolbars = []
-        CustomToolbars: list = App.ParamGet("User parameter:BaseApp/Workbench/Global/Toolbar").GetGroups()
+        CustomToolbars: list = App.ParamGet(
+            "User parameter:BaseApp/Workbench/Global/Toolbar"
+        ).GetGroups()
 
         for Group in CustomToolbars:
-            Parameter = App.ParamGet("User parameter:BaseApp/Workbench/Global/Toolbar/" + Group)
+            Parameter = App.ParamGet(
+                "User parameter:BaseApp/Workbench/Global/Toolbar/" + Group
+            )
             Name = Parameter.GetString("Name")
             Toolbars.append([Name, "Global"])
 
@@ -2560,7 +2956,9 @@ class ModernMenu(RibbonBar):
 
         try:
             # Get the commands from the custom panel
-            Commands = self.ribbonStructure["customToolbars"][WorkBenchName][CustomToolbar]["commands"]
+            Commands = self.ribbonStructure["customToolbars"][WorkBenchName][
+                CustomToolbar
+            ]["commands"]
 
             # Get the command and its original toolbar
             for key, value in list(Commands.items()):
@@ -2569,7 +2967,9 @@ class ModernMenu(RibbonBar):
                     # Get the english menutext
                     MenuName = CommandInfoCorrections(CommandName)["menuText"]
                     # Get the translated menutext
-                    MenuNameTtranslated = CommandInfoCorrections(CommandName)["ActionText"]
+                    MenuNameTtranslated = CommandInfoCorrections(CommandName)[
+                        "ActionText"
+                    ]
 
                     if MenuName == key:
                         try:
@@ -2584,11 +2984,16 @@ class ModernMenu(RibbonBar):
                                     if Toolbutton.text() == Child.text():
                                         IsInList = True
 
-                                if Child.text() == MenuNameTtranslated and IsInList is False:
+                                if (
+                                    Child.text() == MenuNameTtranslated
+                                    and IsInList is False
+                                ):
                                     ButtonList.append(Child)
                         except Exception as e:
                             if Parameters_Ribbon.DEBUG_MODE is True:
-                                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}, 3", "Warning")
+                                StandardFunctions.Print(
+                                    f"{e.with_traceback(e.__traceback__)}, 3", "Warning"
+                                )
                             continue
         except Exception:
             pass
@@ -2602,7 +3007,9 @@ class ModernMenu(RibbonBar):
             if WorkBenchName in self.ribbonStructure["newPanels"]:
                 if NewPanel in self.ribbonStructure["newPanels"][WorkBenchName]:
                     # Get the commands from the custom panel
-                    Commands = self.ribbonStructure["newPanels"][WorkBenchName][NewPanel]
+                    Commands = self.ribbonStructure["newPanels"][WorkBenchName][
+                        NewPanel
+                    ]
 
                     # Get the command and its original toolbar
                     for CommandItem in Commands:
@@ -2621,7 +3028,9 @@ class ModernMenu(RibbonBar):
                                     CommandActionList = Command.getAction()
                                 if Command is None:
                                     if Parameters_Ribbon.DEBUG_MODE is True:
-                                        StandardFunctions.Print(f"{CommandName} was None", "Warning")
+                                        StandardFunctions.Print(
+                                            f"{CommandName} was None", "Warning"
+                                        )
                             # If the commandname can be splitted, it is a FreeCAD dropdown
                             if len(CommandName.split(", ")) > 1:
                                 CommandActionList = self.LoadDropDownAction(CommandName)
@@ -2632,10 +3041,14 @@ class ModernMenu(RibbonBar):
                                 # if there is only one action, add it directly
                                 if len(CommandActionList) == 1:
                                     NewToolbutton.addAction(CommandActionList[0])
-                                    NewToolbutton.setDefaultAction(NewToolbutton.actions()[0])
+                                    NewToolbutton.setDefaultAction(
+                                        NewToolbutton.actions()[0]
+                                    )
                                     # If the commandname is from a FreeCAD dropdown, set the commandname as text
                                     if len(CommandName.split(", ")) > 1:
-                                        NewToolbutton.setText(NewToolbutton.actions()[0].text())
+                                        NewToolbutton.setText(
+                                            NewToolbutton.actions()[0].text()
+                                        )
                                 # if there are more actions, create a menu
                                 elif len(CommandActionList) > 1:
                                     menu = QMenu()
@@ -2653,7 +3066,9 @@ class ModernMenu(RibbonBar):
                                 # Set the text for the toolbutton
                                 if len(CommandName.split(", ")) <= 1:
                                     NewToolbutton.setText(
-                                        CommandInfoCorrections(CommandName)["menuText"].replace("&", "")
+                                        CommandInfoCorrections(CommandName)[
+                                            "menuText"
+                                        ].replace("&", "")
                                     )
                                 # # If the commandname is from a FreeCAD dropdown, set the commandname as text
                                 # if len(CommandName.split(", ")) > 1:
@@ -2670,7 +3085,9 @@ class ModernMenu(RibbonBar):
                                 # if there is only one action, add it directly
                                 if len(CommandActionList) == 1:
                                     NewToolbutton.addAction(CommandActionList[0])
-                                    NewToolbutton.setDefaultAction(NewToolbutton.actions()[0])
+                                    NewToolbutton.setDefaultAction(
+                                        NewToolbutton.actions()[0]
+                                    )
                                 # if there are more actions, create a menu
                                 if len(CommandActionList) > 1:
                                     menu = QMenu()
@@ -2693,7 +3110,9 @@ class ModernMenu(RibbonBar):
 
         except Exception as e:
             if Parameters_Ribbon.DEBUG_MODE is True:
-                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}, 4", "Warning")
+                StandardFunctions.Print(
+                    f"{e.with_traceback(e.__traceback__)}, 4", "Warning"
+                )
             pass
         return ButtonList
 
@@ -2734,12 +3153,14 @@ class ModernMenu(RibbonBar):
         # Check whichs is has the most height: 3 small buttons, 2 medium buttons or 1 large button
         # and set the height accordingly
         if (
-            Parameters_Ribbon.ICON_SIZE_SMALL * 3 >= Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
+            Parameters_Ribbon.ICON_SIZE_SMALL * 3
+            >= Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
             and Parameters_Ribbon.ICON_SIZE_SMALL * 3 >= LargeButtonHeight
         ):
             ribbonHeight = ribbonHeight + Parameters_Ribbon.ICON_SIZE_SMALL * 3 + 6
         elif (
-            Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 >= Parameters_Ribbon.ICON_SIZE_SMALL * 3
+            Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
+            >= Parameters_Ribbon.ICON_SIZE_SMALL * 3
             and Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 >= LargeButtonHeight
         ):
             ribbonHeight = ribbonHeight + Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 + 4
@@ -2852,10 +3273,18 @@ class ModernMenu(RibbonBar):
             Enable = False
 
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
-        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
-        OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
+        OverlayParam_Left = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
+        )
+        OverlayParam_Right = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
+        )
+        OverlayParam_Top = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayTop"
+        )
+        OverlayParam_Bottom = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
+        )
 
         # If overlay is enabled, go here
         PanelsLeft = []
@@ -2938,10 +3367,16 @@ class ModernMenu(RibbonBar):
         OverlayParam_Right = None
         OverlayParam_Bottom = None
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
-        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
+        OverlayParam_Left = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
+        )
+        OverlayParam_Right = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
+        )
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
+        OverlayParam_Bottom = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
+        )
 
         # Ge the focused dockwidget
         FocusWidget = mw.focusWidget().parent().objectName()
@@ -2987,22 +3422,32 @@ class ModernMenu(RibbonBar):
             RightPanels = OverlayParam_Right.GetString("Widgets")
             if FocusWidget in RightPanels:
                 RightPanels = OverlayParam_Left.GetString("Widgets")
-                RightPanels = RightPanels.replace(f"{FocusWidget}", "").replace(",,", ",")
+                RightPanels = RightPanels.replace(f"{FocusWidget}", "").replace(
+                    ",,", ","
+                )
                 OverlayParam_Right.SetString("Widgets", f"{RightPanels}")
                 return
             BottomPanels = OverlayParam_Bottom.GetString("Widgets")
             if FocusWidget in BottomPanels:
                 BottomPanels = OverlayParam_Bottom.GetString("Widgets")
-                BottomPanels = BottomPanels.replace(f"{FocusWidget}", "").replace(",,", ",")
+                BottomPanels = BottomPanels.replace(f"{FocusWidget}", "").replace(
+                    ",,", ","
+                )
                 OverlayParam_Bottom.SetString("Widgets", f"{BottomPanels}")
                 return
         return
 
     def CustomTransparancy(self):
-        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
-        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
+        OverlayParam_Left = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
+        )
+        OverlayParam_Right = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
+        )
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
+        OverlayParam_Bottom = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
+        )
 
         Enable = None
         if OverlayParam_Left.GetBool("Transparent") is False:
@@ -3024,10 +3469,16 @@ class ModernMenu(RibbonBar):
         OverlayParam_Right = None
         OverlayParam_Bottom = None
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
-        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
+        OverlayParam_Left = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
+        )
+        OverlayParam_Right = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
+        )
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
+        OverlayParam_Bottom = App.ParamGet(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
+        )
 
         # Ge the focused dockwidget
         FocusWidget = mw.focusWidget().parent().objectName()
@@ -3053,15 +3504,21 @@ class ModernMenu(RibbonBar):
         if position == "":
             LeftPanels = OverlayParam_Left.GetString("Widgets")
             if FocusWidget in LeftPanels:
-                OverlayParam_Left.SetBool("Transparent", not OverlayParam_Left.GetBool("Transparent"))
+                OverlayParam_Left.SetBool(
+                    "Transparent", not OverlayParam_Left.GetBool("Transparent")
+                )
                 return
             RightPanels = OverlayParam_Right.GetString("Widgets")
             if FocusWidget in RightPanels:
-                OverlayParam_Right.SetBool("Transparent", not OverlayParam_Right.GetBool("Transparent"))
+                OverlayParam_Right.SetBool(
+                    "Transparent", not OverlayParam_Right.GetBool("Transparent")
+                )
                 return
             BottomPanels = OverlayParam_Bottom.GetString("Widgets")
             if FocusWidget in BottomPanels:
-                OverlayParam_Bottom.SetBool("Transparent", not OverlayParam_Bottom.GetBool("Transparent"))
+                OverlayParam_Bottom.SetBool(
+                    "Transparent", not OverlayParam_Bottom.GetBool("Transparent")
+                )
                 return
         return
 
@@ -3069,7 +3526,9 @@ class ModernMenu(RibbonBar):
         actionList = []
 
         try:
-            for DropDownCommand, Commands in self.ribbonStructure["dropdownButtons"].items():
+            for DropDownCommand, Commands in self.ribbonStructure[
+                "dropdownButtons"
+            ].items():
                 if CommandName == DropDownCommand:
                     for CommandItem in Commands:
                         Command = Gui.Command.get(CommandItem[0])
@@ -3080,7 +3539,9 @@ class ModernMenu(RibbonBar):
             return actionList
         except Exception as e:
             if Parameters_Ribbon.DEBUG_MODE is True:
-                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}", "Warning")
+                StandardFunctions.Print(
+                    f"{e.with_traceback(e.__traceback__)}", "Warning"
+                )
             return
 
     def CloseFreeCAD(self):
@@ -3096,7 +3557,9 @@ class ModernMenu(RibbonBar):
         # if self.isLoaded:
         StatusBarState = mw.findChild(QStatusBar, "statusBar").isVisible()
         # Get the style and restore button
-        RestoreButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
+        RestoreButton: QToolButton = self.rightToolBar().findChildren(
+            QToolButton, "RestoreButton"
+        )[0]
         # If the mainwindow is maximized, set the mainwindow to normal, set a size and icon
         if mw.isMaximized() is True:
             try:
@@ -3184,18 +3647,27 @@ class ModernMenu(RibbonBar):
 
     def CheckLanguage(self):
         FreeCAD_preferences = App.ParamGet("User parameter:BaseApp/Preferences/General")
-        if self.ribbonStructure["language"] != FreeCAD_preferences.GetString("Language"):
+        if self.ribbonStructure["language"] != FreeCAD_preferences.GetString(
+            "Language"
+        ):
             if "workbenches" in self.ribbonStructure:
                 for workbenchName in self.ribbonStructure["workbenches"]:
                     if "toolbars" in self.ribbonStructure["workbenches"][workbenchName]:
-                        for ToolBar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]:
-                            if "commands" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar]:
-                                for Command in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar][
-                                    "commands"
-                                ]:
-                                    self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar]["commands"][
-                                        Command
-                                    ]["text"] = ""
+                        for ToolBar in self.ribbonStructure["workbenches"][
+                            workbenchName
+                        ]["toolbars"]:
+                            if (
+                                "commands"
+                                in self.ribbonStructure["workbenches"][workbenchName][
+                                    "toolbars"
+                                ][ToolBar]
+                            ):
+                                for Command in self.ribbonStructure["workbenches"][
+                                    workbenchName
+                                ]["toolbars"][ToolBar]["commands"]:
+                                    self.ribbonStructure["workbenches"][workbenchName][
+                                        "toolbars"
+                                    ][ToolBar]["commands"][Command]["text"] = ""
 
             print("Ribbon UI: Custom text are reset because the language was changed")
         return
@@ -3213,27 +3685,36 @@ class EventInspector(QObject):
             mw.showMaximal()
             Style = mw.style()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
-            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
+            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(
+                QToolButton, "RestoreButton"
+            )[0]
             try:
-                RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton))
+                RestoreButton.setIcon(
+                    Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton)
+                )
             except Exception:
                 pass
             return QObject.eventFilter(self, obj, event)
         # This is a workaround for windows
         # If the window stat changes and the titlebar is hidden, catch the event
         if (
-            event.type() == QEvent.Type.WindowStateChange or event.type() == QEvent.Type.DragMove
+            event.type() == QEvent.Type.WindowStateChange
+            or event.type() == QEvent.Type.DragMove
         ) and Parameters_Ribbon.HIDE_TITLEBAR_FC is True:
             # Get the main window, its style, the ribbon and the restore button
             mw = Gui.getMainWindow()
             Style = mw.style()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
-            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
+            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(
+                QToolButton, "RestoreButton"
+            )[0]
             # If the mainwindow is maximized, set the window state to maximize and set the correct icon
             if mw.isMaximized():
                 try:
                     # RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton))
-                    RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2])
+                    RestoreButton.setIcon(
+                        StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2]
+                    )
                 except Exception:
                     pass
                 return QObject.eventFilter(self, obj, event)
@@ -3241,13 +3722,18 @@ class EventInspector(QObject):
             if mw.isMaximized() is False:
                 try:
                     # RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarMaxButton))
-                    RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1])
+                    RestoreButton.setIcon(
+                        StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1]
+                    )
                 except Exception:
                     pass
                 return QObject.eventFilter(self, obj, event)
         # If the event is a modfied event, update the title
         # This is done when switching from one part to another
-        if event.type() == QEvent.Type.ModifiedChange and Parameters_Ribbon.TOOLBAR_POSITION == 0:
+        if (
+            event.type() == QEvent.Type.ModifiedChange
+            and Parameters_Ribbon.TOOLBAR_POSITION == 0
+        ):
             # Get the mainwindow, the ribbon and the title
             mw = Gui.getMainWindow()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
@@ -3255,7 +3741,9 @@ class EventInspector(QObject):
             # If there is an active document, continue here
             if App.ActiveDocument is not None:
                 # Define the standard title as a prefix
-                Prefix = f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
+                Prefix = (
+                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
+                )
                 # if the title is not equal to the prefix with the active document label,
                 # Get the text from the active tab from the viewport and combine it with the prefix
                 # Set it as the new title
@@ -3266,7 +3754,9 @@ class EventInspector(QObject):
                     RibbonBar.setTitle(Prefix + " - " + CurrentText)
             # If there is no active document, set just the standard title
             if App.ActiveDocument is None:
-                RibbonBar.setTitle(f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}")
+                RibbonBar.setTitle(
+                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
+                )
             return QObject.eventFilter(self, obj, event)
         return False
 

--- a/FCBinding.py
+++ b/FCBinding.py
@@ -1097,7 +1097,7 @@ class ModernMenu(RibbonBar):
                     # Add a button for the Save and Restore dialog
                     Button = SettingsMenu.addAction(translate("FreeCAD SaveAndRestore", "Save and restore..."))
                     Button.setToolTip(translate("FreeCAD SaveAndRestore", "Save and restore FreeCAD's setting files"))
-                    Button.triggered.connect(SaveAndRestore.SaveAndRestore.LoadDialog)
+                    Button.triggered.connect(SaveAndRestore.SaveAndRestore.loadDialog)
                     break
         except Exception:
             pass

--- a/FCBinding.py
+++ b/FCBinding.py
@@ -1087,6 +1087,7 @@ class ModernMenu(RibbonBar):
                 if action.objectName() == "SaveAndRestore":
                     SaveAndRestore = action
                     SettingsMenu.addAction(SaveAndRestore)
+                    break
         except Exception:
             pass
         # add the ribbon settings menu

--- a/FCBinding.py
+++ b/FCBinding.py
@@ -785,17 +785,23 @@ class ModernMenu(RibbonBar):
                 )
 
         # Get the main window, its style, the ribbon and the restore button
-        RestoreButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
+        RestoreButton: QToolButton = self.rightToolBar().findChildren(
+            QToolButton, "RestoreButton"
+        )[0]
         # If the mainwindow is maximized, set the window state to maximize and set the correct icon
         if mw.isMaximized():
             try:
-                RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2])
+                RestoreButton.setIcon(
+                    StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2]
+                )
             except Exception:
                 pass
         # If the mainwindow is not maximized, set the window state to no state and set the correct icon
         if mw.isMaximized() is False:
             try:
-                RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1])
+                RestoreButton.setIcon(
+                    StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1]
+                )
             except Exception:
                 pass
 

--- a/FCBinding.py
+++ b/FCBinding.py
@@ -1082,23 +1082,11 @@ class ModernMenu(RibbonBar):
                 SettingsMenu.addAction(CustomizeButton_FreeCAD)
         # Add a save and restore button
         try:
-            path = os.path.dirname(__file__)
-            # Get the folder with add-ons
-            for i in range(2):
-                # Starting point
-                path = os.path.dirname(path)
-
-            # Go through the sub-folders
-            for root, dirs, files in os.walk(path):
-                if "SaveAndRestore" in root:
-                    SaveAndRestore = os.path.join(path, "SaveAndRestore", "SaveAndRestore.py")
-                    import SaveAndRestore
-
-                    # Add a button for the Save and Restore dialog
-                    Button = SettingsMenu.addAction(translate("FreeCAD SaveAndRestore", "Save and restore..."))
-                    Button.setToolTip(translate("FreeCAD SaveAndRestore", "Save and restore FreeCAD's setting files"))
-                    Button.triggered.connect(SaveAndRestore.SaveAndRestore.loadDialog)
-                    break
+            toolsMenu = mw.findChildren(QMenu, "&Tools")[0]
+            for action in toolsMenu.actions():
+                if action.objectName() == "SaveAndRestore":
+                    SaveAndRestore = action
+                    SettingsMenu.addAction(SaveAndRestore)
         except Exception:
             pass
         # add the ribbon settings menu

--- a/FCBinding.py
+++ b/FCBinding.py
@@ -181,9 +181,7 @@ class ModernMenu(RibbonBar):
     # Create an offset for the panelheight
     PanelHeightOffset = 36
     # Create an offset for the whole ribbon height
-    RibbonOffset = (
-        50 + QuickAccessButtonSize * 2
-    )  # Set to zero to hide the panel titles
+    RibbonOffset = 50 + QuickAccessButtonSize * 2  # Set to zero to hide the panel titles
 
     # Set the minimum height for the ribbon
     RibbonMinimalHeight = QuickAccessButtonSize * 2 + 16
@@ -317,13 +315,8 @@ class ModernMenu(RibbonBar):
             ]
         else:
             try:
-                if (
-                    "Views - Ribbon_newPanel"
-                    in self.ribbonStructure["newPanels"]["Global"]
-                ):
-                    del self.ribbonStructure["newPanels"]["Global"][
-                        "Views - Ribbon_newPanel"
-                    ]
+                if "Views - Ribbon_newPanel" in self.ribbonStructure["newPanels"]["Global"]:
+                    del self.ribbonStructure["newPanels"]["Global"]["Views - Ribbon_newPanel"]
             except Exception:
                 pass
         # # Add a toolbar "tools"
@@ -333,14 +326,11 @@ class ModernMenu(RibbonBar):
         try:
             NeedsUpdating = False
             if "Tools_newPanel" in self.ribbonStructure["newPanels"]["Global"]:
-                for item in self.ribbonStructure["newPanels"]["Global"][
-                    "Tools_newPanel"
-                ]:
+                for item in self.ribbonStructure["newPanels"]["Global"]["Tools_newPanel"]:
                     if item[1] != "Standard":
                         NeedsUpdating = True
             if (
-                "Tools_newPanel" not in self.ribbonStructure["newPanels"]["Global"]
-                and UseToolsPanel is True
+                "Tools_newPanel" not in self.ribbonStructure["newPanels"]["Global"] and UseToolsPanel is True
             ) or NeedsUpdating is True:
                 StandardFunctions.add_keys_nested_dict(
                     self.ribbonStructure,
@@ -409,9 +399,7 @@ class ModernMenu(RibbonBar):
 
         # Get the address of the repository address
         PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
-        self.ReproAdress = StandardFunctions.ReturnXML_Value(
-            PackageXML, "url", "type", "repository"
-        )
+        self.ReproAdress = StandardFunctions.ReturnXML_Value(PackageXML, "url", "type", "repository")
         if self.ReproAdress != "" or self.ReproAdress is not None:
             print(translate("FreeCAD Ribbon", "FreeCAD Ribbon: ") + self.ReproAdress)
 
@@ -421,9 +409,7 @@ class ModernMenu(RibbonBar):
                 for WorkBenchName in self.ribbonStructure["newPanels"]:
                     for NewPanel in self.ribbonStructure["newPanels"][WorkBenchName]:
                         # Get the commands from the custom panel
-                        Commands = self.ribbonStructure["newPanels"][WorkBenchName][
-                            NewPanel
-                        ]
+                        Commands = self.ribbonStructure["newPanels"][WorkBenchName][NewPanel]
 
                         # Get the command and its original toolbar
                         for CommandItem in Commands:
@@ -445,15 +431,9 @@ class ModernMenu(RibbonBar):
         # Activate the workbenches used in the dropdown buttons otherwise the button stays empty
         try:
             if "dropdownButtons" in self.ribbonStructure:
-                for DropDownCommand, Commands in self.ribbonStructure[
-                    "dropdownButtons"
-                ].items():
+                for DropDownCommand, Commands in self.ribbonStructure["dropdownButtons"].items():
                     for CommandItem in Commands:
-                        if (
-                            CommandItem[1] != "General"
-                            and CommandItem[1] != "Global"
-                            and CommandItem[1] != "Standard"
-                        ):
+                        if CommandItem[1] != "General" and CommandItem[1] != "Global" and CommandItem[1] != "Standard":
                             # Activate the workbench if not loaded
                             Gui.activateWorkbench(CommandItem[1])
         except Exception as e:
@@ -472,15 +452,11 @@ class ModernMenu(RibbonBar):
             Branch = "main"
             File = "package.xml"
             ElementName = "version"
-            LatestVersion = StandardFunctions.ReturnXML_Value_Git(
-                User, Repo, Branch, File, ElementName
-            )
+            LatestVersion = StandardFunctions.ReturnXML_Value_Git(User, Repo, Branch, File, ElementName)
             if LatestVersion is not None:
                 # Get the current version
                 PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
-                CurrentVersion = StandardFunctions.ReturnXML_Value(
-                    PackageXML, "version"
-                )
+                CurrentVersion = StandardFunctions.ReturnXML_Value(PackageXML, "version")
                 # Check if you are on a developer version. If so set developer version
                 if CurrentVersion.lower().endswith("x"):
                     self.DeveloperVersion = CurrentVersion
@@ -513,29 +489,15 @@ class ModernMenu(RibbonBar):
         StyleSheet = Path(Parameters_Ribbon.STYLESHEET).read_text()
         # modify the stylesheet to set the border and background for a toolbar and menu
         hexColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
-        hexColorTab = StyleMapping_Ribbon.ReturnStyleItem(
-            "Background_Color", True, True
-        )
-        if (
-            hexColor is not None
-            and hexColor != ""
-            and Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True
-        ):
+        hexColorTab = StyleMapping_Ribbon.ReturnStyleItem("Background_Color", True, True)
+        if hexColor is not None and hexColor != "" and Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True:
             # Set the quickaccess toolbar background color. This fixes a transparant toolbar.
-            self.quickAccessToolBar().setStyleSheet(
-                "QToolBar {background: " + hexColor + ";}"
-            )
+            self.quickAccessToolBar().setStyleSheet("QToolBar {background: " + hexColor + ";}")
             self.tabBar().setStyleSheet("background: " + hexColorTab + ";")
             # Set the background color. This fixes transparant backgrounds when FreeCAD has no stylesheet
-            StyleSheet_Addition = (
-                "\n\nQToolButton {background: solid " + hexColor + ";}"
-            )
+            StyleSheet_Addition = "\n\nQToolButton {background: solid " + hexColor + ";}"
             StyleSheet_Addition_2 = (
-                "\n\nRibbonBar {border: none;background: solid "
-                + hexColor
-                + ";color: "
-                + hexColor
-                + ";}"
+                "\n\nRibbonBar {border: none;background: solid " + hexColor + ";color: " + hexColor + ";}"
             )
             StyleSheet = StyleSheet_Addition_2 + StyleSheet + StyleSheet_Addition
         self.setStyleSheet(StyleSheet)
@@ -545,13 +507,9 @@ class ModernMenu(RibbonBar):
             StyleSheet_Addition_3 = (
                 """QTabBar::tab {
                     background: """
-                + StyleMapping_Ribbon.ReturnStyleItem(
-                    "Background_Color_Hover", True, True
-                )
+                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color_Hover", True, True)
                 + """;color: """
-                + StyleMapping_Ribbon.ReturnStyleItem(
-                    "Background_Color_Hover", True, True
-                )
+                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color_Hover", True, True)
                 + """;min-width: """
                 + str(self.TabBar_Size)
                 + """px;
@@ -624,9 +582,7 @@ class ModernMenu(RibbonBar):
         self.tabBar().tabBarClicked.connect(self.onTabBarClicked)
 
         # override the default scroll behavior with a custom function
-        self.tabBar().wheelEvent = lambda event_tabBar: self.wheelEvent_TabBar(
-            event_tabBar
-        )
+        self.tabBar().wheelEvent = lambda event_tabBar: self.wheelEvent_TabBar(event_tabBar)
         self.wheelEvent = lambda event_CC: self.wheelEvent_CC(event_CC)
         self.tabBar().setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.currentCategory().setFocusPolicy(Qt.FocusPolicy.StrongFocus)
@@ -639,20 +595,12 @@ class ModernMenu(RibbonBar):
         ScrollLeftButton_Tab: QToolButton = self.tabBar().findChildren(QToolButton)[0]
         ScrollRightButton_Tab: QToolButton = self.tabBar().findChildren(QToolButton)[1]
         # get the icons
-        ScrollLeftButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem(
-            "ScrollLeftButton_Tab"
-        )
-        ScrollRightButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem(
-            "ScrollRightButton_Tab"
-        )
+        ScrollLeftButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab")
+        ScrollRightButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab")
         # Set the icons
         StyleSheet = "QToolButton {image: none;margin-top:6px;margin-bottom:6px;};QToolButton::arrow {image: none};"
         BackgroundColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
-        if (
-            int(App.Version()[0]) == 0
-            and int(App.Version()[1]) <= 21
-            and BackgroundColor is not None
-        ):
+        if int(App.Version()[0]) == 0 and int(App.Version()[1]) <= 21 and BackgroundColor is not None:
             StyleSheet = (
                 """QToolButton {image: none;background: """
                 + BackgroundColor
@@ -662,9 +610,7 @@ class ModernMenu(RibbonBar):
             ScrollLeftButton_Tab.setStyleSheet(StyleSheet)
             ScrollLeftButton_Tab.setIcon(ScrollLeftButton_Tab_Icon)
         else:
-            ScrollRightButton_Tab.setToolButtonStyle(
-                Qt.ToolButtonStyle.ToolButtonTextOnly
-            )
+            ScrollRightButton_Tab.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
         if ScrollRightButton_Tab_Icon is not None:
             ScrollRightButton_Tab.setStyleSheet(StyleSheet)
             ScrollRightButton_Tab.setIcon(ScrollRightButton_Tab_Icon)
@@ -672,13 +618,9 @@ class ModernMenu(RibbonBar):
             ScrollRightButton_Tab.setArrowType(Qt.ArrowType.RightArrow)
 
         # Remove persistant toolbars
-        PersistentToolbars = App.ParamGet(
-            "User parameter:Tux/PersistentToolbars/User"
-        ).GetGroups()
+        PersistentToolbars = App.ParamGet("User parameter:Tux/PersistentToolbars/User").GetGroups()
         for Group in PersistentToolbars:
-            Parameter = App.ParamGet(
-                "User parameter:Tux/PersistentToolbars/User/" + Group
-            )
+            Parameter = App.ParamGet("User parameter:Tux/PersistentToolbars/User/" + Group)
             Parameter.SetString("Top", "")
             Parameter.SetString("Left", "")
             Parameter.SetString("Right", "")
@@ -689,9 +631,7 @@ class ModernMenu(RibbonBar):
         # Application menu
         ShortcutKey = "Alt+A"
         try:
-            CustomShortCuts = App.ParamGet(
-                "User parameter:BaseApp/Preferences/Shortcut"
-            )
+            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
             if "Ribbon_Menu" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Menu")
         except Exception:
@@ -708,10 +648,7 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().enterEvent = lambda enter: self.leaveEvent(enter)
 
         # Rearrange the tabbar and toolbars
-        if (
-            Parameters_Ribbon.TOOLBAR_POSITION == 0
-            or Parameters_Ribbon.TOOLBAR_POSITION == 1
-        ):
+        if Parameters_Ribbon.TOOLBAR_POSITION == 0 or Parameters_Ribbon.TOOLBAR_POSITION == 1:
             # Get the widgets
             _quickAccessToolBarWidget = self.quickAccessToolBar()
             _titleLabel = self._titleWidget._titleLabel
@@ -729,38 +666,24 @@ class ModernMenu(RibbonBar):
                 _titleLabel.setAlignment(Qt.AlignmentFlag.AlignCenter)
                 _titleLabel.setFont(font)
                 # Set the label text to FreeCAD's version
-                text = (
-                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
-                )
+                text = f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
                 _titleLabel.setText(text)
                 # Create a spacer to set the tab
                 spacer = QWidget()
-                spacer.setSizePolicy(
-                    QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
-                )
+                spacer.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
                 spacer.setFixedWidth(3)
                 self._titleWidget._tabBarLayout.setContentsMargins(3, 3, 3, 0)
                 self._titleWidget._tabBarLayout.addWidget(
                     _quickAccessToolBarWidget, 0, 0, 1, 2, Qt.AlignmentFlag.AlignVCenter
                 )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _titleLabel, 0, 1, 1, 1, Qt.AlignmentFlag.AlignVCenter
-                )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _rightToolBar, 0, 2, 1, 2, Qt.AlignmentFlag.AlignVCenter
-                )
-                self._titleWidget._tabBarLayout.addWidget(
-                    spacer, 1, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter
-                )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _tabBar, 1, 1, 1, 4, Qt.AlignmentFlag.AlignVCenter
-                )
+                self._titleWidget._tabBarLayout.addWidget(_titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(_rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(spacer, 1, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(_tabBar, 1, 1, 1, 4, Qt.AlignmentFlag.AlignVCenter)
                 # Change the offsets
                 self.RibbonMinimalHeight = self.QuickAccessButtonSize * 2 + 20
                 self.RibbonOffset = 54 + self.QuickAccessButtonSize * 2
-                self._titleWidget._tabBarLayout.setRowMinimumHeight(
-                    0, self.QuickAccessButtonSize
-                )
+                self._titleWidget._tabBarLayout.setRowMinimumHeight(0, self.QuickAccessButtonSize)
                 self._titleWidget._tabBarLayout.setRowMinimumHeight(1, self.TabBar_Size)
                 # self.setTitle("FreeCAD")
             if Parameters_Ribbon.TOOLBAR_POSITION == 1:  # Toolbars inline with tabbar
@@ -768,21 +691,13 @@ class ModernMenu(RibbonBar):
                 self._titleWidget._tabBarLayout.addWidget(
                     _quickAccessToolBarWidget, 0, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter
                 )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _tabBar, 0, 1, 1, 1, Qt.AlignmentFlag.AlignVCenter
-                )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter
-                )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter
-                )
+                self._titleWidget._tabBarLayout.addWidget(_tabBar, 0, 1, 1, 1, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(_titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(_rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter)
                 # Change the offsets
                 self.RibbonMinimalHeight = self.QuickAccessButtonSize + 10
                 self.RibbonOffset = 46 + self.QuickAccessButtonSize
-                self._titleWidget._tabBarLayout.setRowMinimumHeight(
-                    0, self.QuickAccessButtonSize
-                )
+                self._titleWidget._tabBarLayout.setRowMinimumHeight(0, self.QuickAccessButtonSize)
 
         # Install an event filter to catch events from the main window and act on it.
         mw.installEventFilter(EventInspector(mw))
@@ -813,10 +728,7 @@ class ModernMenu(RibbonBar):
         TB.show()
         # In FreeCAD 1.0, Overlays are introduced. These have also an enterEvent which results in strange behavior
         # Therefore this function is only activated when FreeCAD's overlay function is disabled.
-        if (
-            Parameters_Ribbon.SHOW_ON_HOVER is True
-            and Parameters_Ribbon.USE_FC_OVERLAY is False
-        ):
+        if Parameters_Ribbon.SHOW_ON_HOVER is True and Parameters_Ribbon.USE_FC_OVERLAY is False:
             self.UnfoldRibbon()
             return
 
@@ -828,9 +740,7 @@ class ModernMenu(RibbonBar):
     # implementation to add actions to the Filemenu. Needed for the accessories menu
     def addAction(self, action: QAction):
         menu = self.findChild(RibbonMenu, "Ribbon")
-        StyleSheet_Menu = (
-            "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
-        )
+        StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
         menu.setStyleSheet(StyleSheet_Menu)
         if menu is None:
             menu = self.addFileMenu()
@@ -911,9 +821,7 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().setContentsMargins(0, 0, 9, 0)
         # Set the size of the menu button
         self.applicationOptionButton().setFixedSize(
-            self.QuickAccessButtonSize
-            + FontMetrics.boundingRect(Text.text()).width()
-            + 12,
+            self.QuickAccessButtonSize + FontMetrics.boundingRect(Text.text()).width() + 12,
             self.QuickAccessButtonSize,
         )
         # Set the icon
@@ -922,24 +830,19 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().setStyleSheet(
             StyleMapping_Ribbon.ReturnStyleSheet(
                 "applicationbutton",
-                padding_right=str(FontMetrics.horizontalAdvance(Text.text(), -1) + 12)
-                + "px",
+                padding_right=str(FontMetrics.horizontalAdvance(Text.text(), -1) + 12) + "px",
                 radius="4px",
             )
         )
         # Add the default tooltip
-        self.applicationOptionButton().setToolTip(
-            translate("FreeCAD Ribbon", "FreeCAD Ribbon")
-        )
+        self.applicationOptionButton().setToolTip(translate("FreeCAD Ribbon", "FreeCAD Ribbon"))
 
         # add the menus from the menubar to the application button
         self.ApplicationMenus()
 
         # add quick access buttons
         i = 1  # Start value for button count. Used for width of quickaccess toolbar
-        toolBarWidth = (
-            (self.QuickAccessButtonSize * self.sizeFactor) * i
-        ) + self.applicationOptionButton().width()
+        toolBarWidth = ((self.QuickAccessButtonSize * self.sizeFactor) * i) + self.applicationOptionButton().width()
         for commandName in self.ribbonStructure["quickAccessCommands"]:
             i = i + 1
             # Define a width
@@ -971,11 +874,7 @@ class ModernMenu(RibbonBar):
                         height = self.QuickAccessButtonSize
                         button.setFixedSize(width, height)
                         # Set the stylesheet
-                        button.setStyleSheet(
-                            StyleMapping_Ribbon.ReturnStyleSheet(
-                                "toolbutton", "2px", f"{padding}px"
-                            )
-                        )
+                        button.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", f"{padding}px"))
                     elif len(QuickAction) > 1:
                         # set the padding for a dropdown button
                         padding = self.PaddingRight
@@ -987,15 +886,9 @@ class ModernMenu(RibbonBar):
                         height = self.QuickAccessButtonSize
                         button.setFixedSize(width, height)
                         # Set the PopupMode
-                        button.setPopupMode(
-                            QToolButton.ToolButtonPopupMode.InstantPopup
-                        )
+                        button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
                         # Set the stylesheet
-                        button.setStyleSheet(
-                            StyleMapping_Ribbon.ReturnStyleSheet(
-                                "toolbutton", "2px", f"{padding}px"
-                            )
-                        )
+                        button.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", f"{padding}px"))
 
                 # If it is a custom dropdown, add the actions one by one.
                 if commandName.endswith("_ddb") is True:
@@ -1017,9 +910,7 @@ class ModernMenu(RibbonBar):
 
                     # Set the stylesheet
                     button.setStyleSheet(
-                        StyleMapping_Ribbon.ReturnStyleSheet(
-                            "toolbutton", "2px", padding_right=f"{padding}px"
-                        )
+                        StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", padding_right=f"{padding}px")
                     )
 
                 # Set the height
@@ -1031,9 +922,7 @@ class ModernMenu(RibbonBar):
                 if len(button.actions()) > 0:
                     self.addQuickAccessButton(button)
                 else:
-                    StandardFunctions.Print(
-                        f"{commandName} did not contain any actions!", "Log"
-                    )
+                    StandardFunctions.Print(f"{commandName} did not contain any actions!", "Log")
 
                 toolBarWidth = toolBarWidth + width
             except Exception as e:
@@ -1049,9 +938,7 @@ class ModernMenu(RibbonBar):
         # Set the width of the quickaccess toolbar.
         self.quickAccessToolBar().setMinimumWidth(toolBarWidth)
         # Set the size policy
-        self.quickAccessToolBar().setSizePolicy(
-            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.MinimumExpanding
-        )
+        self.quickAccessToolBar().setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.MinimumExpanding)
         # needed for excluding from hiding toolbars
         self.quickAccessToolBar().setObjectName("quickAccessToolBar")
         self.quickAccessToolBar().setWindowTitle("quickAccessToolBar")
@@ -1063,23 +950,17 @@ class ModernMenu(RibbonBar):
         self.tabBar().setFont(font)
 
         self.tabBar().setIconSize(QSize(self.TabBar_Size - 6, self.TabBar_Size - 6))
-        self.tabBar().setStyleSheet(
-            "margin: 0px;padding: 0px;height: " + str(self.TabBar_Size) + ";"
-        )
+        self.tabBar().setStyleSheet("margin: 0px;padding: 0px;height: " + str(self.TabBar_Size) + ";")
 
         # Correct colors when no stylesheet is selected for FreeCAD.
         self.quickAccessToolBar().setStyleSheet("")
         if Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True:
-            FreeCAD_preferences = App.ParamGet(
-                "User parameter:BaseApp/Preferences/MainWindow"
-            )
+            FreeCAD_preferences = App.ParamGet("User parameter:BaseApp/Preferences/MainWindow")
             currentStyleSheet = FreeCAD_preferences.GetString("StyleSheet")
             if currentStyleSheet == "":
                 hexColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
                 # Set the quickaccess toolbar background color
-                self.quickAccessToolBar().setStyleSheet(
-                    "background-color: " + hexColor + ";"
-                )
+                self.quickAccessToolBar().setStyleSheet("background-color: " + hexColor + ";")
 
         # Get the order of workbenches from Parameters
         WorkbenchOrderedList: list = Parameters_Ribbon.TAB_ORDER.split(",")
@@ -1095,10 +976,7 @@ class ModernMenu(RibbonBar):
         # There is an issue with the internal assembly wb showing the wrong panel
         # when assembly4 wb is installed and positioned for the internal assembly wb
         for i in range(len(WorkbenchOrderedList)):
-            if (
-                WorkbenchOrderedList[i] == "Assembly4Workbench"
-                or WorkbenchOrderedList[i] == "Assembly3Workbench"
-            ):
+            if WorkbenchOrderedList[i] == "Assembly4Workbench" or WorkbenchOrderedList[i] == "Assembly3Workbench":
                 try:
                     index_1 = WorkbenchOrderedList.index(WorkbenchOrderedList[i])
                     index_2 = WorkbenchOrderedList.index("AssemblyWorkbench")
@@ -1138,14 +1016,10 @@ class ModernMenu(RibbonBar):
                             icon: QIcon = self.ReturnWorkbenchIcon(workbenchName)
                             self.tabBar().setTabIcon(len(self.categories()) - 1, icon)
                         if Parameters_Ribbon.TABBAR_STYLE == 2:
-                            self.tabBar().setTabIcon(
-                                len(self.categories()) - 1, QIcon()
-                            )
+                            self.tabBar().setTabIcon(len(self.categories()) - 1, QIcon())
 
                         # Set the tab data
-                        self.tabBar().setTabData(
-                            len(self.categories()) - 1, workbenchName
-                        )
+                        self.tabBar().setTabData(len(self.categories()) - 1, workbenchName)
 
                         # Set the tooltip
                         MenuText = workbench.MenuText
@@ -1154,20 +1028,14 @@ class ModernMenu(RibbonBar):
                             ToolTipText.lower() != MenuText.lower() + " workbench"
                             and MenuText.lower() != ToolTipText.lower()
                         ):
-                            MenuText = (
-                                f"<b>{workbench.MenuText}</b><br>{workbench.ToolTip}"
-                            )
+                            MenuText = f"<b>{workbench.MenuText}</b><br>{workbench.ToolTip}"
                         else:
                             MenuText = f"<b>{MenuText}<b>"
 
-                        self.tabBar().setTabToolTip(
-                            len(self.categories()) - 1, MenuText
-                        )
+                        self.tabBar().setTabToolTip(len(self.categories()) - 1, MenuText)
 
         # Set the size of the collapseRibbonButton
-        self.collapseRibbonButton().setFixedSize(
-            self.RightToolBarButtonSize, self.RightToolBarButtonSize
-        )
+        self.collapseRibbonButton().setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
 
         # add the searchbar if available
         SearchBarWidth = self.AddSearchBar()
@@ -1185,18 +1053,10 @@ class ModernMenu(RibbonBar):
         if self.OverlayMenu is not None:
             OverlayMenu = QToolButton()
             OverlayMenu.setIcon(QIcon(os.path.join(pathIcons, "Draft_Layer.svg")))
-            OverlayMenu.setToolTip(
-                translate("FreeCAD Ribbon", "Overlay functions") + "..."
-            )
+            OverlayMenu.setToolTip(translate("FreeCAD Ribbon", "Overlay functions") + "...")
             OverlayMenu.setMenu(self.OverlayMenu)
-            OverlayMenu.setFixedSize(
-                self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
-            )
-            OverlayMenu.setStyleSheet(
-                StyleMapping_Ribbon.ReturnStyleSheet(
-                    control="toolbutton", padding_right="12px"
-                )
-            )
+            OverlayMenu.setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
+            OverlayMenu.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px"))
             OverlayMenu.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
             Font = OverlayMenu.font()
             Font.setPixelSize(Parameters_Ribbon.FONTSIZE_MENUS)
@@ -1224,47 +1084,31 @@ class ModernMenu(RibbonBar):
         SettingsMenu.addAction(self.RibbonMenu.menuAction())
         SettingsMenu.setIcon(Gui.getIcon("Std_DlgParameter.svg"))
         SettingsMenu.setToolTip(translate("FreeCAD Ribbon", "Preferences") + "...")
-        SettingsMenu.setFixedSize(
-            self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
-        )
-        SettingsMenu.setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet(
-                control="toolbutton", padding_right="12px"
-            )
-        )
+        SettingsMenu.setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
+        SettingsMenu.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px"))
         SettingsMenu.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         # add the settingsmenu to the right toolbar
         self.rightToolBar().addWidget(SettingsMenu)
 
         # Set the helpbutton
         self.helpRibbonButton().setEnabled(True)
-        self.helpRibbonButton().setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
-        )
+        self.helpRibbonButton().setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self.helpRibbonButton().setToolTip(translate("FreeCAD Ribbon", "Help") + "...")
         # Get the default help action from FreeCAD
         helpMenu = mw.findChildren(QMenu, "&Help")[0]
         helpAction = helpMenu.actions()[0]
         self.helpRibbonButton().setIcon(helpAction.icon())
         self.helpRibbonButton().setMenu(self.HelpMenu)
-        self.helpRibbonButton().setFixedSize(
-            self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
-        )
+        self.helpRibbonButton().setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
         self.helpRibbonButton().setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet(
-                control="toolbutton", padding_right="12px"
-            )
+            StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px")
         )
-        self.helpRibbonButton().setPopupMode(
-            QToolButton.ToolButtonPopupMode.InstantPopup
-        )
+        self.helpRibbonButton().setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
 
         # Add a button the enable or disable AutoHide
         pinButton = QToolButton()
         pinButton.setCheckable(True)
-        pinButton.setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
-        )
+        pinButton.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         pinButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
         # Set the correct icon
         if Parameters_Ribbon.AUTOHIDE_RIBBON is True:
@@ -1282,14 +1126,10 @@ class ModernMenu(RibbonBar):
             pinButton.setChecked(False)
         if Parameters_Ribbon.AUTOHIDE_RIBBON is False:
             pinButton.setChecked(True)
-        pinButton.setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px")
-        )
+        pinButton.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px"))
         ShortcutKey = "Alt+T"
         try:
-            CustomShortCuts = App.ParamGet(
-                "User parameter:BaseApp/Preferences/Shortcut"
-            )
+            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
             if "Ribbon_Pin" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Pin")
             if ShortcutKey != "" and ShortcutKey is not None:
@@ -1297,16 +1137,13 @@ class ModernMenu(RibbonBar):
         except Exception:
             pass
         # Set the tooltip
-        ToolTip = translate(
-            "FreeCAD Ribbon", "Click to toggle the autohide function on or off"
-        )
+        ToolTip = translate("FreeCAD Ribbon", "Click to toggle the autohide function on or off")
         if ShortcutKey != "none":
             ToolTip = ToolTip + f"<br></br><i>{ShortcutKey}</i>"
         pinButton.setToolTip(
             translate(
                 "FreeCAD Ribbon",
-                "Click to toggle the autohide function on or off"
-                + f"<br></br><i>{ShortcutKey}</i>",
+                "Click to toggle the autohide function on or off" + f"<br></br><i>{ShortcutKey}</i>",
             )
         )
 
@@ -1340,13 +1177,9 @@ class ModernMenu(RibbonBar):
                     padding_right="3px",
                 )
             )
-            MinimzeButton.setIcon(
-                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[3]
-            )
+            MinimzeButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[3])
             MinimzeButton.clicked.connect(self.MinimizeFreeCAD)
-            MinimzeButton.setFixedSize(
-                self.RightToolBarButtonSize, self.RightToolBarButtonSize
-            )
+            MinimzeButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
             self.rightToolBar().addWidget(MinimzeButton)
             # Restore button
             RestoreButton = QToolButton()
@@ -1361,13 +1194,9 @@ class ModernMenu(RibbonBar):
                     padding_right="3px",
                 )
             )
-            RestoreButton.setIcon(
-                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2]
-            )
+            RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2])
             RestoreButton.clicked.connect(self.RestoreFreeCAD)
-            RestoreButton.setFixedSize(
-                self.RightToolBarButtonSize, self.RightToolBarButtonSize
-            )
+            RestoreButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
             self.rightToolBar().addWidget(RestoreButton)
             # Close button
             CloseButton = QToolButton()
@@ -1382,29 +1211,19 @@ class ModernMenu(RibbonBar):
                     HoverColor="#e62424",
                 )
             )
-            CloseButton.setIcon(
-                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[0]
-            )
+            CloseButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[0])
             CloseButton.clicked.connect(self.CloseFreeCAD)
-            CloseButton.setFixedSize(
-                self.RightToolBarButtonSize, self.RightToolBarButtonSize
-            )
+            CloseButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
             self.rightToolBar().addWidget(CloseButton)
 
         # Set the width of the right toolbar
-        RightToolbarWidth = (
-            SearchBarWidth
-            + 3 * (self.RightToolBarButtonSize + 16)
-            + self.RightToolBarButtonSize
-        )
+        RightToolbarWidth = SearchBarWidth + 3 * (self.RightToolBarButtonSize + 16) + self.RightToolBarButtonSize
         if Parameters_Ribbon.USE_FC_OVERLAY is True:
             RightToolbarWidth = SearchBarWidth + 2 * (self.RightToolBarButtonSize + 16)
         self.rightToolBar().setMinimumWidth(RightToolbarWidth)
         self.setRightToolBarHeight(self.RibbonMinimalHeight)
         # Set the size policy
-        self.rightToolBar().setSizePolicy(
-            QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding
-        )
+        self.rightToolBar().setSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding)
         self.rightToolBar().setSizeIncrement(1, 1)
         # Set the objectName for the right toolbar. needed for excluding from hiding.
         self.rightToolBar().setObjectName("rightToolBar")
@@ -1422,17 +1241,11 @@ class ModernMenu(RibbonBar):
 
                 sea = SearchBoxLight.SearchBoxLight(
                     getItemGroups=lambda: __import__("GetItemGroups").getItemGroups(),
-                    getToolTip=lambda groupId, setParent: __import__(
-                        "GetItemGroups"
-                    ).getToolTip(groupId, setParent),
-                    getItemDelegate=lambda: __import__(
-                        "IndentedItemDelegate"
-                    ).IndentedItemDelegate(),
+                    getToolTip=lambda groupId, setParent: __import__("GetItemGroups").getToolTip(groupId, setParent),
+                    getItemDelegate=lambda: __import__("IndentedItemDelegate").IndentedItemDelegate(),
                 )
                 sea.resultSelected.connect(
-                    lambda index, groupId: __import__("GetItemGroups").onResultSelected(
-                        index, groupId
-                    )
+                    lambda index, groupId: __import__("GetItemGroups").onResultSelected(index, groupId)
                 )
                 sea.setFixedSize(width, self.RightToolBarButtonSize)
                 BeforeAction = self.rightToolBar().actions()[1]
@@ -1450,18 +1263,13 @@ class ModernMenu(RibbonBar):
         MenuBar = mw.menuBar()
 
         # Set a stylesheet specific for the menubar. Otherwise the fontsize of the menus will not be applied
-        StyleSheet_MenuBar = (
-            "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
-        )
+        StyleSheet_MenuBar = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
         MenuBar.setStyleSheet(StyleSheet_MenuBar)
         # # Add the actions of the menubar to the application menu
         for child in MenuBar.actions():
             if child.objectName() != "&Help" and child.objectName != "AccessoriesMenu":
                 ApplictionMenu.addAction(child)
-            if (
-                child.objectName == "AccessoriesMenu"
-                and self.AccessoriesMenu is not None
-            ):
+            if child.objectName == "AccessoriesMenu" and self.AccessoriesMenu is not None:
                 ApplictionMenu.addMenu(self.AccessoriesMenu)
 
         # if you on macOS, add the ribbon menus to the menubar
@@ -1490,9 +1298,7 @@ class ModernMenu(RibbonBar):
             color = StyleMapping_Ribbon.ReturnStyleItem("DevelopColor")
             Label = QLabel()
             Label.setText("Development version")
-            Label.setStyleSheet(
-                f"color: {color};border: 1px solid {color};border-radius: 2px;"
-            )
+            Label.setStyleSheet(f"color: {color};border: 1px solid {color};border-radius: 2px;")
             ApplictionMenu.addWidget(Label)
         # if there is an update, add a button that opens the addon manager
         if self.UpdateVersion != "" and self.DeveloperVersion == "":
@@ -1531,17 +1337,12 @@ class ModernMenu(RibbonBar):
                 self.AccessoriesMenu.addActions(subMenus)
 
         # Create the overlay menu when the native overlay function is not used
-        if (
-            Parameters_Ribbon.USE_FC_OVERLAY is False
-            and Parameters_Ribbon.USE_OVERLAY is True
-        ):
+        if Parameters_Ribbon.USE_FC_OVERLAY is False and Parameters_Ribbon.USE_OVERLAY is True:
             OverlayMenu = QMenu(translate("FreeCAD Ribbon", "Overlay") + "...", self)
             OverlayMenu.setToolTipsVisible(True)
 
             # Toggle overlay for all -----------------------------------------------------
-            OverlayButton_All = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle overlay for all")
-            )
+            OverlayButton_All = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle overlay for all"))
             OverlayButton_All.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1552,9 +1353,7 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "F4"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayAll" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayAll")
             except Exception as e:
@@ -1564,9 +1363,7 @@ class ModernMenu(RibbonBar):
             OverlayButton_All.setShortcut(ShortcutKey)
 
             # Toggle transparancy for all -----------------------------------------------------
-            TransparancyButton_All = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle transparancy")
-            )
+            TransparancyButton_All = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle transparancy"))
             TransparancyButton_All.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1577,13 +1374,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Shift+F4"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayTransparentAll" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString(
-                        "Std_DockOverlayTransparentAll"
-                    )
+                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayTransparentAll")
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1592,9 +1385,7 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle overlay for active panel-----------------------------------------------------
-            OverlayButton_Active = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle overlay")
-            )
+            OverlayButton_Active = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle overlay"))
             OverlayButton_Active.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1605,9 +1396,7 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "F3"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayToggle" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggle")
             except Exception as e:
@@ -1617,9 +1406,7 @@ class ModernMenu(RibbonBar):
             OverlayButton_Active.setShortcut(ShortcutKey)
 
             # Toggle transparancy for active panel-----------------------------------------------------
-            TransparancyButton = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle transparant mode")
-            )
+            TransparancyButton = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle transparant mode"))
             TransparancyButton.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1630,13 +1417,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Shift+F3"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayToggleTransparent" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString(
-                        "Std_DockOverlayToggleTransparent"
-                    )
+                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleTransparent")
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1645,25 +1428,15 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle mouse bypass-----------------------------------------------------
-            ToggleMouseByPass = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Bypass mouse events")
-            )
-            ToggleMouseByPass.setToolTip(
-                translate(
-                    "FreeCAD Ribbon", "Bypass mouse events in docked overlay windows"
-                )
-            )
+            ToggleMouseByPass = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Bypass mouse events"))
+            ToggleMouseByPass.setToolTip(translate("FreeCAD Ribbon", "Bypass mouse events in docked overlay windows"))
             ToggleMouseByPass.triggered.connect(self.ToggleMouseByPass)
             # Get the shortcut from the original command
             ShortcutKey = "T,T"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayMouseTransparent" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString(
-                        "Std_DockOverlayMouseTransparent"
-                    )
+                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayMouseTransparent")
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1672,9 +1445,7 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle overlay for left panels-----------------------------------------------------
-            OverlayButton_Left = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle left")
-            )
+            OverlayButton_Left = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle left"))
             OverlayButton_Left.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1685,9 +1456,7 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+left"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayToggleLeft" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleLeft")
             except Exception as e:
@@ -1696,9 +1465,7 @@ class ModernMenu(RibbonBar):
                 ShortcutKey = "Ctrl+left"
             OverlayButton_Left.setShortcut(ShortcutKey)
             # Toggle overlay for right panels-----------------------------------------------------
-            OverlayButton_Right = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle right")
-            )
+            OverlayButton_Right = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle right"))
             OverlayButton_Right.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1709,22 +1476,16 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+right"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayToggleRight" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString(
-                        "Std_DockOverlayToggleRight"
-                    )
+                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleRight")
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
                 ShortcutKey = "Ctrl+right"
             OverlayButton_Right.setShortcut(ShortcutKey)
             # Toggle overlay for Bottom panels-----------------------------------------------------
-            OverlayButton_Bottom = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle bottom")
-            )
+            OverlayButton_Bottom = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle bottom"))
             OverlayButton_Bottom.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1735,13 +1496,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+down"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayToggleBottom" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString(
-                        "Std_DockOverlayToggleBottom"
-                    )
+                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleBottom")
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1752,23 +1509,15 @@ class ModernMenu(RibbonBar):
             self.OverlayMenu = OverlayMenu
 
         # Create a ribbon menu
-        RibbonMenu = QMenu(
-            translate("FreeCAD Ribbon", "Ribbon UI preferences") + " ...", self
-        )
+        RibbonMenu = QMenu(translate("FreeCAD Ribbon", "Ribbon UI preferences") + " ...", self)
         RibbonMenu.setToolTipsVisible(True)
         # Add the ribbon design button
-        DesignButton = RibbonMenu.addAction(
-            translate("FreeCAD Ribbon", "Ribbon layout")
-        )
-        DesignButton.setToolTip(
-            translate("FreeCAD Ribbon", "Design the ribbon to your preference")
-        )
+        DesignButton = RibbonMenu.addAction(translate("FreeCAD Ribbon", "Ribbon layout"))
+        DesignButton.setToolTip(translate("FreeCAD Ribbon", "Design the ribbon to your preference"))
         DesignButton.triggered.connect(self.loadDesignMenu)
         ShortcutKey = "Alt+L"
         try:
-            CustomShortCuts = App.ParamGet(
-                "User parameter:BaseApp/Preferences/Shortcut"
-            )
+            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
             if "Ribbon_Layout" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Layout")
         except Exception:
@@ -1777,19 +1526,13 @@ class ModernMenu(RibbonBar):
             DesignButton.setShortcut(ShortcutKey)
             self.LayoutMenuShortCut = ShortcutKey
         # Add the preference button
-        PreferenceButton = RibbonMenu.addAction(
-            translate("FreeCAD Ribbon", "Preferences")
-        )
-        PreferenceButton.setToolTip(
-            translate("FreeCAD Ribbon", "Set preferences for the Ribbon UI")
-        )
+        PreferenceButton = RibbonMenu.addAction(translate("FreeCAD Ribbon", "Preferences"))
+        PreferenceButton.setToolTip(translate("FreeCAD Ribbon", "Set preferences for the Ribbon UI"))
         PreferenceButton.setMenuRole(QAction.MenuRole.NoRole)
         PreferenceButton.triggered.connect(self.loadSettingsMenu)
         ShortcutKey = "Alt+P"
         try:
-            CustomShortCuts = App.ParamGet(
-                "User parameter:BaseApp/Preferences/Shortcut"
-            )
+            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
             if "Ribbon_Preferences" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Preferences")
         except Exception:
@@ -1801,12 +1544,8 @@ class ModernMenu(RibbonBar):
         if os.path.exists(ScriptDir) is True:
             ListScripts = os.listdir(ScriptDir)
             if len(ListScripts) > 0:
-                ScriptButtonMenu = RibbonMenu.addMenu(
-                    translate("FreeCAD Ribbon", "Scripts")
-                )
-                ScriptButtonMenu.setToolTip(
-                    translate("FreeCAD Ribbon", "Scripts to help setup the ribbon.")
-                )
+                ScriptButtonMenu = RibbonMenu.addMenu(translate("FreeCAD Ribbon", "Scripts"))
+                ScriptButtonMenu.setToolTip(translate("FreeCAD Ribbon", "Scripts to help setup the ribbon."))
                 for i in range(len(ListScripts)):
                     ScriptButtonMenu.addAction(
                         ListScripts[i],
@@ -1838,11 +1577,7 @@ class ModernMenu(RibbonBar):
 
         # Add the ribbon helpbutton under the FreeCAD
         RibbonHelpButton = QAction(translate("FreeCAD Ribbon", "Ribbon UI help"))
-        RibbonHelpButton.setToolTip(
-            translate(
-                "FreeCAD Ribbon", "Open the help page for the Ribbon UI in your browser"
-            )
-        )
+        RibbonHelpButton.setToolTip(translate("FreeCAD Ribbon", "Open the help page for the Ribbon UI in your browser"))
         RibbonHelpButton.setIcon(HelpIcon)
         RibbonHelpButton.triggered.connect(self.on_RibbonHelpButton_clicked)
         HelpMenu.insertAction(actions[1], RibbonHelpButton)
@@ -1865,15 +1600,11 @@ class ModernMenu(RibbonBar):
         PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
         version = StandardFunctions.ReturnXML_Value(PackageXML, "version")
         # Create the ribbon about button
-        AboutButton_Ribbon = AboutMenu.addAction(
-            translate("FreeCAD Ribbon", "About Ribbon UI ") + version
-        )
+        AboutButton_Ribbon = AboutMenu.addAction(translate("FreeCAD Ribbon", "About Ribbon UI ") + version)
         AboutButton_Ribbon.setIcon(AboutIcon)
         AboutButton_Ribbon.triggered.connect(self.on_AboutButton_clicked)
         # Create the what's new button
-        WhatsNewButton_Ribbon = AboutMenu.addAction(
-            translate("FreeCAD Ribbon", "What's new?")
-        )
+        WhatsNewButton_Ribbon = AboutMenu.addAction(translate("FreeCAD Ribbon", "What's new?"))
         WhatsNewButton_Ribbon.triggered.connect(self.on_WhatsNewButton_clicked)
         # add the aboutmenu to the help menu
         HelpMenu.addMenu(AboutMenu)
@@ -1920,9 +1651,7 @@ class ModernMenu(RibbonBar):
             Parameters_Ribbon.Settings.SetBoolSetting("AutoHideRibbon", True)
             Parameters_Ribbon.AUTOHIDE_RIBBON = True
 
-            pinButton: QToolButton = self.rightToolBar().findChildren(
-                QToolButton, "Pin Ribbon"
-            )[0]
+            pinButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "Pin Ribbon")[0]
             pinButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed"))
 
             # Make sure that the ribbon remains visible
@@ -1934,9 +1663,7 @@ class ModernMenu(RibbonBar):
             Parameters_Ribbon.Settings.SetBoolSetting("AutoHideRibbon", False)
             Parameters_Ribbon.AUTOHIDE_RIBBON = False
 
-            pinButton: QToolButton = self.rightToolBar().findChildren(
-                QToolButton, "Pin Ribbon"
-            )[0]
+            pinButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "Pin Ribbon")[0]
             pinButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_open"))
 
             # Make sure that the ribbon remains visible
@@ -1981,9 +1708,7 @@ class ModernMenu(RibbonBar):
         # Set the text color depending in tabstyle
         if Parameters_Ribbon.TABBAR_STYLE != 1:
             self.tabBar().setStyleSheet(
-                "QTabBar::tab {color: "
-                + StyleMapping_Ribbon.ReturnStyleItem("FontColor")
-                + ";}"
+                "QTabBar::tab {color: " + StyleMapping_Ribbon.ReturnStyleItem("FontColor") + ";}"
             )
         if Parameters_Ribbon.TABBAR_STYLE == 1:
             self.tabBar().setStyleSheet(
@@ -2064,20 +1789,16 @@ class ModernMenu(RibbonBar):
         # Get the custom panels and add them to the list of toolbars
         try:
             if workbenchName in self.ribbonStructure["customToolbars"]:
-                for CustomPanel in self.ribbonStructure["customToolbars"][
-                    workbenchName
-                ]:
+                for CustomPanel in self.ribbonStructure["customToolbars"][workbenchName]:
                     ListToolbars.append(CustomPanel)
 
                     # remove the original toolbars from the list
-                    Commands = self.ribbonStructure["customToolbars"][workbenchName][
-                        CustomPanel
-                    ]["commands"]
+                    Commands = self.ribbonStructure["customToolbars"][workbenchName][CustomPanel]["commands"]
                     for Command in Commands:
                         try:
-                            OriginalToolbar = self.ribbonStructure["customToolbars"][
-                                workbenchName
-                            ][CustomPanel]["commands"][Command]
+                            OriginalToolbar = self.ribbonStructure["customToolbars"][workbenchName][CustomPanel][
+                                "commands"
+                            ][Command]
                             ListToolbars.remove(OriginalToolbar)
                         except Exception:
                             continue
@@ -2097,9 +1818,7 @@ class ModernMenu(RibbonBar):
 
         try:
             # Get the order of toolbars
-            ToolbarOrder: list = self.ribbonStructure["workbenches"][workbenchName][
-                "toolbars"
-            ]["order"]
+            ToolbarOrder: list = self.ribbonStructure["workbenches"][workbenchName]["toolbars"]["order"]
 
             # Sort the list of toolbars according the toolbar order
             def SortToolbars(toolbar):
@@ -2163,51 +1882,30 @@ class ModernMenu(RibbonBar):
 
             # add separators to the command list.
             if workbenchName in self.ribbonStructure["workbenches"]:
-                if (
-                    toolbar != ""
-                    and toolbar
-                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
-                ):
-                    if (
-                        "order"
-                        in self.ribbonStructure["workbenches"][workbenchName][
-                            "toolbars"
-                        ][toolbar]
-                    ):
+                if toolbar != "" and toolbar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]:
+                    if "order" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]:
                         for j in range(
-                            len(
-                                self.ribbonStructure["workbenches"][workbenchName][
-                                    "toolbars"
-                                ][toolbar]["order"]
-                            )
+                            len(self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"])
                         ):
                             if (
                                 "separator"
-                                in self.ribbonStructure["workbenches"][workbenchName][
-                                    "toolbars"
-                                ][toolbar]["order"][j].lower()
+                                in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"][
+                                    j
+                                ].lower()
                             ):
                                 separator = QToolButton()
                                 separator.setText(
-                                    self.ribbonStructure["workbenches"][workbenchName][
-                                        "toolbars"
-                                    ][toolbar]["order"][j]
+                                    self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"][j]
                                 )
                                 allButtons.insert(j, separator)
 
             if workbenchName in self.ribbonStructure["workbenches"]:
                 # order buttons like defined in ribbonStructure
                 if (
-                    toolbar
-                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
-                    and "order"
-                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][
-                        toolbar
-                    ]
+                    toolbar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
+                    and "order" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]
                 ):
-                    OrderList: list = self.ribbonStructure["workbenches"][
-                        workbenchName
-                    ]["toolbars"][toolbar]["order"]
+                    OrderList: list = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"]
 
                     # XXX check that positionsList consists of strings only
                     def sortButtons(button: QToolButton):
@@ -2216,9 +1914,7 @@ class ModernMenu(RibbonBar):
                         # Get the menu text
                         if len(button.actions()) > 0:
                             action = button.actions()[0]
-                            Text = StandardFunctions.CommandInfoCorrections(
-                                action.data()
-                            )["menuText"]
+                            Text = StandardFunctions.CommandInfoCorrections(action.data())["menuText"]
 
                         if Text == "":
                             return -1
@@ -2238,8 +1934,12 @@ class ModernMenu(RibbonBar):
                 []
             )  # if buttons are used in multiple workbenches, they can show up double. (Sketcher_NewSketch)
             # for button in allButtons:
-            NoSmallButtons_spacer = 0  # needed to count the number of small buttons in a column. (bug fix with adding separators)
-            NoMediumButtons_spacer = 0  # needed to count the number of medium buttons in a column. (bug fix with adding separators)
+            NoSmallButtons_spacer = (
+                0  # needed to count the number of small buttons in a column. (bug fix with adding separators)
+            )
+            NoMediumButtons_spacer = (
+                0  # needed to count the number of medium buttons in a column. (bug fix with adding separators)
+            )
 
             # Define number of rows used per button size
             LargeButtonRows = 3
@@ -2262,9 +1962,9 @@ class ModernMenu(RibbonBar):
                 buttonSize = "small"
                 try:
                     action = button.defaultAction()
-                    buttonSize = self.ribbonStructure["workbenches"][workbenchName][
-                        "toolbars"
-                    ][toolbar]["commands"][action.data()]["size"]
+                    buttonSize = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["commands"][
+                        action.data()
+                    ]["size"]
                     if buttonSize == "small":
                         NoSmallButtons_spacer += 1
                     if buttonSize == "medium":
@@ -2355,28 +2055,22 @@ class ModernMenu(RibbonBar):
                             try:
                                 # If the text is not from a hardcoded dropdown:
                                 if len(action.data().split(", ")) <= 1:
-                                    text = StandardFunctions.CommandInfoCorrections(
-                                        action.data()
-                                    )["ActionText"]
+                                    text = StandardFunctions.CommandInfoCorrections(action.data())["ActionText"]
                             except Exception:
                                 pass
 
                             # try to get alternative text from ribbonStructure
                             try:
-                                textJSON = self.ribbonStructure["workbenches"][
-                                    workbenchName
-                                ]["toolbars"][toolbar]["commands"][action.data()][
-                                    "text"
-                                ]
+                                textJSON = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                    "commands"
+                                ][action.data()]["text"]
 
                                 # There is a bug in freecad with the comp-sketch menu hase the wrong text
                                 if (
                                     action.data() == "PartDesign_CompSketches"
-                                    and self.ribbonStructure["workbenches"][
-                                        workbenchName
-                                    ]["toolbars"][toolbar]["commands"][action.data()][
-                                        "text"
-                                    ]
+                                    and self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                        "commands"
+                                    ][action.data()]["text"]
                                     == "Create datum"
                                 ):
                                     textJSON = "Create sketch"
@@ -2387,19 +2081,13 @@ class ModernMenu(RibbonBar):
                                     # if it is a normal command:
                                     if len(action.data().split(", ")) <= 1:
                                         Command = Gui.Command.get(CommandName)
-                                        MenuName = CommandInfoCorrections(CommandName)[
-                                            "menuText"
-                                        ].replace("&", "")
+                                        MenuName = CommandInfoCorrections(CommandName)["menuText"].replace("&", "")
                                         if CommandName == action.data():
                                             if (
                                                 MenuName
-                                                != self.ribbonStructure["workbenches"][
-                                                    workbenchName
-                                                ]["toolbars"][toolbar]["commands"][
-                                                    action.data()
-                                                ][
-                                                    "text"
-                                                ]
+                                                != self.ribbonStructure["workbenches"][workbenchName]["toolbars"][
+                                                    toolbar
+                                                ]["commands"][action.data()]["text"]
                                                 and MenuName != ""
                                                 and textJSON != ""
                                             ):
@@ -2409,13 +2097,9 @@ class ModernMenu(RibbonBar):
                                         MenuName = action.text()
                                         if (
                                             MenuName
-                                            != self.ribbonStructure["workbenches"][
-                                                workbenchName
-                                            ]["toolbars"][toolbar]["commands"][
-                                                action.data()
-                                            ][
-                                                "text"
-                                            ]
+                                            != self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                                "commands"
+                                            ][action.data()]["text"]
                                             and MenuName != ""
                                             and textJSON != ""
                                         ):
@@ -2440,9 +2124,9 @@ class ModernMenu(RibbonBar):
                                 CommandName = button.text()
 
                             try:
-                                pixmap = self.ribbonStructure["workbenches"][
-                                    workbenchName
-                                ]["toolbars"][toolbar]["commands"][CommandName]["icon"]
+                                pixmap = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                    "commands"
+                                ][CommandName]["icon"]
                             except Exception:
                                 pass
                             actionIcon = self.ReturnCommandIcon(action.data(), pixmap)
@@ -2451,24 +2135,18 @@ class ModernMenu(RibbonBar):
 
                             # try to get alternative icon from ribbonStructure
                             try:
-                                icon_Json = self.ribbonStructure["workbenches"][
-                                    workbenchName
-                                ]["toolbars"][toolbar]["commands"][CommandName]["icon"]
+                                icon_Json = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                    "commands"
+                                ][CommandName]["icon"]
                                 if icon_Json != "":
                                     action.setIcon(Gui.getIcon(icon_Json))
                             except KeyError:
                                 pass
 
                             # If the icon is still none, try to retrieve it from the data file
-                            if action.icon() is None or (
-                                action.icon() is not None and action.icon().isNull()
-                            ):
-                                StandardFunctions.Print(
-                                    f"An icon retrieved from data file for '{CommandName}'"
-                                )
-                                DataFile = os.path.join(
-                                    os.path.dirname(__file__), "RibbonDataFile.dat"
-                                )
+                            if action.icon() is None or (action.icon() is not None and action.icon().isNull()):
+                                StandardFunctions.Print(f"An icon retrieved from data file for '{CommandName}'")
+                                DataFile = os.path.join(os.path.dirname(__file__), "RibbonDataFile.dat")
 
                                 if os.path.exists(DataFile) is True:
                                     Data = {}
@@ -2482,11 +2160,7 @@ class ModernMenu(RibbonBar):
                                             # This works only for FreeCAD Commands
                                             CommandName_Icon = action.data()
                                             if CommandName_Icon == IconItem[0]:
-                                                Icon: QIcon = (
-                                                    Serialize_Ribbon.deserializeIcon(
-                                                        IconItem[1]
-                                                    )
-                                                )
+                                                Icon: QIcon = Serialize_Ribbon.deserializeIcon(IconItem[1])
                                                 action.setIcon(Icon)
                                     except Exception as e:
                                         if Parameters_Ribbon.DEBUG_MODE is True:
@@ -2498,9 +2172,9 @@ class ModernMenu(RibbonBar):
 
                             # get button size from ribbonStructure
                             try:
-                                buttonSize = self.ribbonStructure["workbenches"][
-                                    workbenchName
-                                ]["toolbars"][toolbar]["commands"][CommandName]["size"]
+                                buttonSize = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                    "commands"
+                                ][CommandName]["size"]
                                 if buttonSize == "":
                                     buttonSize = "small"
                             except KeyError:
@@ -2517,10 +2191,7 @@ class ModernMenu(RibbonBar):
                             action.setText(action.text().replace("&", ""))
                             if buttonSize == "small":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_SMALL
-                                if (
-                                    IconOnly is True
-                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
-                                ):
+                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2559,10 +2230,7 @@ class ModernMenu(RibbonBar):
 
                             elif buttonSize == "medium":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_MEDIUM
-                                if (
-                                    IconOnly is True
-                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
-                                ):
+                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2599,10 +2267,7 @@ class ModernMenu(RibbonBar):
                                 )  # Set fixedheight to false. This is set in the custom widgets
                             elif buttonSize == "large":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_LARGE
-                                if (
-                                    IconOnly is True
-                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
-                                ):
+                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2640,23 +2305,17 @@ class ModernMenu(RibbonBar):
                             else:
                                 if Parameters_Ribbon.DEBUG_MODE is True:
                                     if buttonSize != "none":
-                                        print(
-                                            f"{action.text()} is ignored. Its size was: {buttonSize}"
-                                        )
+                                        print(f"{action.text()} is ignored. Its size was: {buttonSize}")
                                 pass
 
                             if btn.menu() is not None:
-                                btn.popupMode(
-                                    QToolButton.ToolButtonPopupMode.MenuButtonPopup
-                                )
+                                btn.popupMode(QToolButton.ToolButtonPopupMode.MenuButtonPopup)
 
                             # Set the background always to background color.
                             # Styling is managed in the custom button class
                             StyleSheet_Addition_Button = (
                                 "QToolButton, QToolButton:hover {background-color: "
-                                + StyleMapping_Ribbon.ReturnStyleItem(
-                                    "Background_Color"
-                                )
+                                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
                                 + ";border: none"
                                 + ";}"
                             )
@@ -2671,10 +2330,7 @@ class ModernMenu(RibbonBar):
                             continue
 
             # Change the name of the view panels to "View"
-            if (
-                panel.title() in "Views - Ribbon_newPanel"
-                or panel.title() in "Individual views"
-            ):
+            if panel.title() in "Views - Ribbon_newPanel" or panel.title() in "Individual views":
                 panel.setTitle(" Views ")
             else:
                 # Remove possible workbench names from the titles
@@ -2714,9 +2370,7 @@ class ModernMenu(RibbonBar):
             actionList = []
             for i in range(len(ButtonList)):
                 button = ButtonList[i]
-                StyleSheet_Menu = (
-                    "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
-                )
+                StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
                 button.setStyleSheet(StyleSheet_Menu)
                 if len(button.actions()) == 1:
                     actionList.append(button.actions()[0])
@@ -2724,20 +2378,14 @@ class ModernMenu(RibbonBar):
                     actionList.append(button.actions())
             OptionButton = panel.panelOptionButton()
             if len(actionList) > 0:
-                Menu = CustomControls.CustomOptionMenu(
-                    OptionButton.menu(), actionList, self
-                )
+                Menu = CustomControls.CustomOptionMenu(OptionButton.menu(), actionList, self)
                 OptionButton.setMenu(Menu)
-                StyleSheet_Menu = (
-                    "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
-                )
+                StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
                 Menu.setStyleSheet(StyleSheet_Menu)
                 # Set the behavior of the option button
                 OptionButton.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
                 # Remove the image to avoid double arrows
-                OptionButton.setStyleSheet(
-                    "RibbonPanelOptionButton::menu-indicator {image: none;}"
-                )
+                OptionButton.setStyleSheet("RibbonPanelOptionButton::menu-indicator {image: none;}")
                 Menu = OptionButton.menu()
 
                 # Set the icon
@@ -2746,9 +2394,7 @@ class ModernMenu(RibbonBar):
                     OptionButton.setIcon(OptionButton_Icon)
                 else:
                     OptionButton.setArrowType(Qt.ArrowType.DownArrow)
-                    OptionButton.setToolButtonStyle(
-                        Qt.ToolButtonStyle.ToolButtonTextBesideIcon
-                    )
+                    OptionButton.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
                     OptionButton.setText("more...")
             if len(actionList) == 0:
                 panel.panelOptionButton().hide()
@@ -2757,21 +2403,13 @@ class ModernMenu(RibbonBar):
 
         # Set the previous/next buttons
         category = self.currentCategory()
-        ScrollLeftButton_Category: RibbonCategoryLayoutButton = category.findChildren(
-            RibbonCategoryLayoutButton
-        )[0]
-        ScrollRightButton_Category: RibbonCategoryLayoutButton = category.findChildren(
-            RibbonCategoryLayoutButton
-        )[1]
+        ScrollLeftButton_Category: RibbonCategoryLayoutButton = category.findChildren(RibbonCategoryLayoutButton)[0]
+        ScrollRightButton_Category: RibbonCategoryLayoutButton = category.findChildren(RibbonCategoryLayoutButton)[1]
         ScrollLeftButton_Category.setMinimumWidth(self.iconSize * 0.5)
         ScrollRightButton_Category.setMinimumWidth(self.iconSize * 0.5)
         # get the icons
-        ScrollLeftButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem(
-            "ScrollLeftButton_Category"
-        )
-        ScrollRightButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem(
-            "ScrollRightButton_Category"
-        )
+        ScrollLeftButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category")
+        ScrollRightButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category")
         # Set the icons
         if ScrollLeftButton_Category_Icon is not None:
             ScrollLeftButton_Category.setIcon(ScrollLeftButton_Category_Icon)
@@ -2785,37 +2423,23 @@ class ModernMenu(RibbonBar):
         ScrollLeftButton_Category.setFixedHeight(Parameters_Ribbon.ICON_SIZE_SMALL * 3)
         ScrollRightButton_Category.setFixedHeight(Parameters_Ribbon.ICON_SIZE_SMALL * 3)
         # Set the stylesheet
-        ScrollLeftButton_Category.setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton")
-        )
-        ScrollRightButton_Category.setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton")
-        )
+        ScrollLeftButton_Category.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton"))
+        ScrollRightButton_Category.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton"))
         # Connect the custom click event
-        ScrollLeftButton_Category.mousePressEvent = (
-            lambda clickLeft: self.on_ScrollButton_Category_clicked(
-                clickLeft, ScrollLeftButton_Category
-            )
+        ScrollLeftButton_Category.mousePressEvent = lambda clickLeft: self.on_ScrollButton_Category_clicked(
+            clickLeft, ScrollLeftButton_Category
         )
-        ScrollRightButton_Category.mousePressEvent = (
-            lambda clickRight: self.on_ScrollButton_Category_clicked(
-                clickRight, ScrollRightButton_Category
-            )
+        ScrollRightButton_Category.mousePressEvent = lambda clickRight: self.on_ScrollButton_Category_clicked(
+            clickRight, ScrollRightButton_Category
         )
 
         # Set the maximum height to a high value to prevent from the ribbon to be clipped off
-        self.currentCategory().setMinimumHeight(
-            self.RibbonHeight - self.RibbonMinimalHeight - 3
-        )
-        self.currentCategory().setMaximumHeight(
-            self.RibbonHeight - self.RibbonMinimalHeight - 3
-        )
+        self.currentCategory().setMinimumHeight(self.RibbonHeight - self.RibbonMinimalHeight - 3)
+        self.currentCategory().setMaximumHeight(self.RibbonHeight - self.RibbonMinimalHeight - 3)
         self.setRibbonHeight(self.RibbonHeight)
         return
 
-    def on_ScrollButton_Category_clicked(
-        self, event, ScrollButton: RibbonCategoryLayoutButton
-    ):
+    def on_ScrollButton_Category_clicked(self, event, ScrollButton: RibbonCategoryLayoutButton):
         for i in range(Parameters_Ribbon.RIBBON_CLICKSPEED):
             ScrollButton.click()
         return
@@ -2836,10 +2460,7 @@ class ModernMenu(RibbonBar):
             parentWidget = toolbar.parentWidget()
             toolbar.setHidden(True)
             # hide toolbars that are not in the statusBar and show toolbars that are in the statusbar.
-            if (
-                parentWidget.objectName() == "statusBar"
-                or parentWidget.objectName() == "StatusBarArea"
-            ):
+            if parentWidget.objectName() == "statusBar" or parentWidget.objectName() == "StatusBarArea":
                 toolbar.setEnabled(True)
                 toolbar.setVisible(True)
             # # # Show specific toolbars and go to the next
@@ -2863,11 +2484,7 @@ class ModernMenu(RibbonBar):
         return
 
     def FoldRibbon(self, Ignore=False):
-        if (
-            Parameters_Ribbon.AUTOHIDE_RIBBON is True
-            and self.isLoaded is True
-            and Ignore is False
-        ):
+        if Parameters_Ribbon.AUTOHIDE_RIBBON is True and self.isLoaded is True and Ignore is False:
             if len(mw.findChildren(QDockWidget, "Ribbon")) > 0:
                 TB: QDockWidget = mw.findChildren(QDockWidget, "Ribbon")[0]
                 TB.setMinimumHeight(self.RibbonMinimalHeight)
@@ -2887,10 +2504,7 @@ class ModernMenu(RibbonBar):
 
                     for Group in CustomToolbars:
                         Parameter = App.ParamGet(
-                            "User parameter:BaseApp/Workbench/"
-                            + WorkBenchName
-                            + "/Toolbar/"
-                            + Group
+                            "User parameter:BaseApp/Workbench/" + WorkBenchName + "/Toolbar/" + Group
                         )
                         Name = Parameter.GetString("Name")
                         Toolbars.append([Name, WorkBenchName])
@@ -2899,14 +2513,10 @@ class ModernMenu(RibbonBar):
 
     def List_ReturnCustomToolbars_Global(self):
         Toolbars = []
-        CustomToolbars: list = App.ParamGet(
-            "User parameter:BaseApp/Workbench/Global/Toolbar"
-        ).GetGroups()
+        CustomToolbars: list = App.ParamGet("User parameter:BaseApp/Workbench/Global/Toolbar").GetGroups()
 
         for Group in CustomToolbars:
-            Parameter = App.ParamGet(
-                "User parameter:BaseApp/Workbench/Global/Toolbar/" + Group
-            )
+            Parameter = App.ParamGet("User parameter:BaseApp/Workbench/Global/Toolbar/" + Group)
             Name = Parameter.GetString("Name")
             Toolbars.append([Name, "Global"])
 
@@ -2917,9 +2527,7 @@ class ModernMenu(RibbonBar):
 
         try:
             # Get the commands from the custom panel
-            Commands = self.ribbonStructure["customToolbars"][WorkBenchName][
-                CustomToolbar
-            ]["commands"]
+            Commands = self.ribbonStructure["customToolbars"][WorkBenchName][CustomToolbar]["commands"]
 
             # Get the command and its original toolbar
             for key, value in list(Commands.items()):
@@ -2928,9 +2536,7 @@ class ModernMenu(RibbonBar):
                     # Get the english menutext
                     MenuName = CommandInfoCorrections(CommandName)["menuText"]
                     # Get the translated menutext
-                    MenuNameTtranslated = CommandInfoCorrections(CommandName)[
-                        "ActionText"
-                    ]
+                    MenuNameTtranslated = CommandInfoCorrections(CommandName)["ActionText"]
 
                     if MenuName == key:
                         try:
@@ -2945,16 +2551,11 @@ class ModernMenu(RibbonBar):
                                     if Toolbutton.text() == Child.text():
                                         IsInList = True
 
-                                if (
-                                    Child.text() == MenuNameTtranslated
-                                    and IsInList is False
-                                ):
+                                if Child.text() == MenuNameTtranslated and IsInList is False:
                                     ButtonList.append(Child)
                         except Exception as e:
                             if Parameters_Ribbon.DEBUG_MODE is True:
-                                StandardFunctions.Print(
-                                    f"{e.with_traceback(e.__traceback__)}, 3", "Warning"
-                                )
+                                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}, 3", "Warning")
                             continue
         except Exception:
             pass
@@ -2968,9 +2569,7 @@ class ModernMenu(RibbonBar):
             if WorkBenchName in self.ribbonStructure["newPanels"]:
                 if NewPanel in self.ribbonStructure["newPanels"][WorkBenchName]:
                     # Get the commands from the custom panel
-                    Commands = self.ribbonStructure["newPanels"][WorkBenchName][
-                        NewPanel
-                    ]
+                    Commands = self.ribbonStructure["newPanels"][WorkBenchName][NewPanel]
 
                     # Get the command and its original toolbar
                     for CommandItem in Commands:
@@ -2989,9 +2588,7 @@ class ModernMenu(RibbonBar):
                                     CommandActionList = Command.getAction()
                                 if Command is None:
                                     if Parameters_Ribbon.DEBUG_MODE is True:
-                                        StandardFunctions.Print(
-                                            f"{CommandName} was None", "Warning"
-                                        )
+                                        StandardFunctions.Print(f"{CommandName} was None", "Warning")
                             # If the commandname can be splitted, it is a FreeCAD dropdown
                             if len(CommandName.split(", ")) > 1:
                                 CommandActionList = self.LoadDropDownAction(CommandName)
@@ -3002,14 +2599,10 @@ class ModernMenu(RibbonBar):
                                 # if there is only one action, add it directly
                                 if len(CommandActionList) == 1:
                                     NewToolbutton.addAction(CommandActionList[0])
-                                    NewToolbutton.setDefaultAction(
-                                        NewToolbutton.actions()[0]
-                                    )
+                                    NewToolbutton.setDefaultAction(NewToolbutton.actions()[0])
                                     # If the commandname is from a FreeCAD dropdown, set the commandname as text
                                     if len(CommandName.split(", ")) > 1:
-                                        NewToolbutton.setText(
-                                            NewToolbutton.actions()[0].text()
-                                        )
+                                        NewToolbutton.setText(NewToolbutton.actions()[0].text())
                                 # if there are more actions, create a menu
                                 elif len(CommandActionList) > 1:
                                     menu = QMenu()
@@ -3027,9 +2620,7 @@ class ModernMenu(RibbonBar):
                                 # Set the text for the toolbutton
                                 if len(CommandName.split(", ")) <= 1:
                                     NewToolbutton.setText(
-                                        CommandInfoCorrections(CommandName)[
-                                            "menuText"
-                                        ].replace("&", "")
+                                        CommandInfoCorrections(CommandName)["menuText"].replace("&", "")
                                     )
                                 # # If the commandname is from a FreeCAD dropdown, set the commandname as text
                                 # if len(CommandName.split(", ")) > 1:
@@ -3046,9 +2637,7 @@ class ModernMenu(RibbonBar):
                                 # if there is only one action, add it directly
                                 if len(CommandActionList) == 1:
                                     NewToolbutton.addAction(CommandActionList[0])
-                                    NewToolbutton.setDefaultAction(
-                                        NewToolbutton.actions()[0]
-                                    )
+                                    NewToolbutton.setDefaultAction(NewToolbutton.actions()[0])
                                 # if there are more actions, create a menu
                                 if len(CommandActionList) > 1:
                                     menu = QMenu()
@@ -3071,9 +2660,7 @@ class ModernMenu(RibbonBar):
 
         except Exception as e:
             if Parameters_Ribbon.DEBUG_MODE is True:
-                StandardFunctions.Print(
-                    f"{e.with_traceback(e.__traceback__)}, 4", "Warning"
-                )
+                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}, 4", "Warning")
             pass
         return ButtonList
 
@@ -3114,14 +2701,12 @@ class ModernMenu(RibbonBar):
         # Check whichs is has the most height: 3 small buttons, 2 medium buttons or 1 large button
         # and set the height accordingly
         if (
-            Parameters_Ribbon.ICON_SIZE_SMALL * 3
-            >= Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
+            Parameters_Ribbon.ICON_SIZE_SMALL * 3 >= Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
             and Parameters_Ribbon.ICON_SIZE_SMALL * 3 >= LargeButtonHeight
         ):
             ribbonHeight = ribbonHeight + Parameters_Ribbon.ICON_SIZE_SMALL * 3 + 6
         elif (
-            Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
-            >= Parameters_Ribbon.ICON_SIZE_SMALL * 3
+            Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 >= Parameters_Ribbon.ICON_SIZE_SMALL * 3
             and Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 >= LargeButtonHeight
         ):
             ribbonHeight = ribbonHeight + Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 + 4
@@ -3234,18 +2819,10 @@ class ModernMenu(RibbonBar):
             Enable = False
 
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
-        )
-        OverlayParam_Right = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
-        )
-        OverlayParam_Top = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayTop"
-        )
-        OverlayParam_Bottom = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
-        )
+        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
+        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
+        OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
+        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
 
         # If overlay is enabled, go here
         PanelsLeft = []
@@ -3328,16 +2905,10 @@ class ModernMenu(RibbonBar):
         OverlayParam_Right = None
         OverlayParam_Bottom = None
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
-        )
-        OverlayParam_Right = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
-        )
+        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
+        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
-        )
+        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
 
         # Ge the focused dockwidget
         FocusWidget = mw.focusWidget().parent().objectName()
@@ -3383,32 +2954,22 @@ class ModernMenu(RibbonBar):
             RightPanels = OverlayParam_Right.GetString("Widgets")
             if FocusWidget in RightPanels:
                 RightPanels = OverlayParam_Left.GetString("Widgets")
-                RightPanels = RightPanels.replace(f"{FocusWidget}", "").replace(
-                    ",,", ","
-                )
+                RightPanels = RightPanels.replace(f"{FocusWidget}", "").replace(",,", ",")
                 OverlayParam_Right.SetString("Widgets", f"{RightPanels}")
                 return
             BottomPanels = OverlayParam_Bottom.GetString("Widgets")
             if FocusWidget in BottomPanels:
                 BottomPanels = OverlayParam_Bottom.GetString("Widgets")
-                BottomPanels = BottomPanels.replace(f"{FocusWidget}", "").replace(
-                    ",,", ","
-                )
+                BottomPanels = BottomPanels.replace(f"{FocusWidget}", "").replace(",,", ",")
                 OverlayParam_Bottom.SetString("Widgets", f"{BottomPanels}")
                 return
         return
 
     def CustomTransparancy(self):
-        OverlayParam_Left = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
-        )
-        OverlayParam_Right = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
-        )
+        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
+        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
-        )
+        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
 
         Enable = None
         if OverlayParam_Left.GetBool("Transparent") is False:
@@ -3430,16 +2991,10 @@ class ModernMenu(RibbonBar):
         OverlayParam_Right = None
         OverlayParam_Bottom = None
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
-        )
-        OverlayParam_Right = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
-        )
+        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
+        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
-        )
+        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
 
         # Ge the focused dockwidget
         FocusWidget = mw.focusWidget().parent().objectName()
@@ -3465,21 +3020,15 @@ class ModernMenu(RibbonBar):
         if position == "":
             LeftPanels = OverlayParam_Left.GetString("Widgets")
             if FocusWidget in LeftPanels:
-                OverlayParam_Left.SetBool(
-                    "Transparent", not OverlayParam_Left.GetBool("Transparent")
-                )
+                OverlayParam_Left.SetBool("Transparent", not OverlayParam_Left.GetBool("Transparent"))
                 return
             RightPanels = OverlayParam_Right.GetString("Widgets")
             if FocusWidget in RightPanels:
-                OverlayParam_Right.SetBool(
-                    "Transparent", not OverlayParam_Right.GetBool("Transparent")
-                )
+                OverlayParam_Right.SetBool("Transparent", not OverlayParam_Right.GetBool("Transparent"))
                 return
             BottomPanels = OverlayParam_Bottom.GetString("Widgets")
             if FocusWidget in BottomPanels:
-                OverlayParam_Bottom.SetBool(
-                    "Transparent", not OverlayParam_Bottom.GetBool("Transparent")
-                )
+                OverlayParam_Bottom.SetBool("Transparent", not OverlayParam_Bottom.GetBool("Transparent"))
                 return
         return
 
@@ -3487,9 +3036,7 @@ class ModernMenu(RibbonBar):
         actionList = []
 
         try:
-            for DropDownCommand, Commands in self.ribbonStructure[
-                "dropdownButtons"
-            ].items():
+            for DropDownCommand, Commands in self.ribbonStructure["dropdownButtons"].items():
                 if CommandName == DropDownCommand:
                     for CommandItem in Commands:
                         Command = Gui.Command.get(CommandItem[0])
@@ -3500,9 +3047,7 @@ class ModernMenu(RibbonBar):
             return actionList
         except Exception as e:
             if Parameters_Ribbon.DEBUG_MODE is True:
-                StandardFunctions.Print(
-                    f"{e.with_traceback(e.__traceback__)}", "Warning"
-                )
+                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}", "Warning")
             return
 
     def CloseFreeCAD(self):
@@ -3518,9 +3063,7 @@ class ModernMenu(RibbonBar):
         # if self.isLoaded:
         StatusBarState = mw.findChild(QStatusBar, "statusBar").isVisible()
         # Get the style and restore button
-        RestoreButton: QToolButton = self.rightToolBar().findChildren(
-            QToolButton, "RestoreButton"
-        )[0]
+        RestoreButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
         # If the mainwindow is maximized, set the mainwindow to normal, set a size and icon
         if mw.isMaximized() is True:
             try:
@@ -3608,27 +3151,18 @@ class ModernMenu(RibbonBar):
 
     def CheckLanguage(self):
         FreeCAD_preferences = App.ParamGet("User parameter:BaseApp/Preferences/General")
-        if self.ribbonStructure["language"] != FreeCAD_preferences.GetString(
-            "Language"
-        ):
+        if self.ribbonStructure["language"] != FreeCAD_preferences.GetString("Language"):
             if "workbenches" in self.ribbonStructure:
                 for workbenchName in self.ribbonStructure["workbenches"]:
                     if "toolbars" in self.ribbonStructure["workbenches"][workbenchName]:
-                        for ToolBar in self.ribbonStructure["workbenches"][
-                            workbenchName
-                        ]["toolbars"]:
-                            if (
-                                "commands"
-                                in self.ribbonStructure["workbenches"][workbenchName][
-                                    "toolbars"
-                                ][ToolBar]
-                            ):
-                                for Command in self.ribbonStructure["workbenches"][
-                                    workbenchName
-                                ]["toolbars"][ToolBar]["commands"]:
-                                    self.ribbonStructure["workbenches"][workbenchName][
-                                        "toolbars"
-                                    ][ToolBar]["commands"][Command]["text"] = ""
+                        for ToolBar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]:
+                            if "commands" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar]:
+                                for Command in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar][
+                                    "commands"
+                                ]:
+                                    self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar]["commands"][
+                                        Command
+                                    ]["text"] = ""
 
             print("Ribbon UI: Custom text are reset because the language was changed")
         return
@@ -3646,36 +3180,27 @@ class EventInspector(QObject):
             mw.showMaximal()
             Style = mw.style()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
-            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(
-                QToolButton, "RestoreButton"
-            )[0]
+            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
             try:
-                RestoreButton.setIcon(
-                    Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton)
-                )
+                RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton))
             except Exception:
                 pass
             return QObject.eventFilter(self, obj, event)
         # This is a workaround for windows
         # If the window stat changes and the titlebar is hidden, catch the event
         if (
-            event.type() == QEvent.Type.WindowStateChange
-            or event.type() == QEvent.Type.DragMove
+            event.type() == QEvent.Type.WindowStateChange or event.type() == QEvent.Type.DragMove
         ) and Parameters_Ribbon.HIDE_TITLEBAR_FC is True:
             # Get the main window, its style, the ribbon and the restore button
             mw = Gui.getMainWindow()
             Style = mw.style()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
-            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(
-                QToolButton, "RestoreButton"
-            )[0]
+            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
             # If the mainwindow is maximized, set the window state to maximize and set the correct icon
             if mw.isMaximized():
                 try:
                     # RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton))
-                    RestoreButton.setIcon(
-                        StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2]
-                    )
+                    RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2])
                 except Exception:
                     pass
                 return QObject.eventFilter(self, obj, event)
@@ -3683,18 +3208,13 @@ class EventInspector(QObject):
             if mw.isMaximized() is False:
                 try:
                     # RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarMaxButton))
-                    RestoreButton.setIcon(
-                        StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1]
-                    )
+                    RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1])
                 except Exception:
                     pass
                 return QObject.eventFilter(self, obj, event)
         # If the event is a modfied event, update the title
         # This is done when switching from one part to another
-        if (
-            event.type() == QEvent.Type.ModifiedChange
-            and Parameters_Ribbon.TOOLBAR_POSITION == 0
-        ):
+        if event.type() == QEvent.Type.ModifiedChange and Parameters_Ribbon.TOOLBAR_POSITION == 0:
             # Get the mainwindow, the ribbon and the title
             mw = Gui.getMainWindow()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
@@ -3702,9 +3222,7 @@ class EventInspector(QObject):
             # If there is an active document, continue here
             if App.ActiveDocument is not None:
                 # Define the standard title as a prefix
-                Prefix = (
-                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
-                )
+                Prefix = f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
                 # if the title is not equal to the prefix with the active document label,
                 # Get the text from the active tab from the viewport and combine it with the prefix
                 # Set it as the new title
@@ -3715,9 +3233,7 @@ class EventInspector(QObject):
                     RibbonBar.setTitle(Prefix + " - " + CurrentText)
             # If there is no active document, set just the standard title
             if App.ActiveDocument is None:
-                RibbonBar.setTitle(
-                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
-                )
+                RibbonBar.setTitle(f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}")
             return QObject.eventFilter(self, obj, event)
         return False
 

--- a/FCBinding.py
+++ b/FCBinding.py
@@ -181,9 +181,7 @@ class ModernMenu(RibbonBar):
     # Create an offset for the panelheight
     PanelHeightOffset = 36
     # Create an offset for the whole ribbon height
-    RibbonOffset = (
-        50 + QuickAccessButtonSize * 2
-    )  # Set to zero to hide the panel titles
+    RibbonOffset = 50 + QuickAccessButtonSize * 2  # Set to zero to hide the panel titles
 
     # Set the minimum height for the ribbon
     RibbonMinimalHeight = QuickAccessButtonSize * 2 + 16
@@ -317,13 +315,8 @@ class ModernMenu(RibbonBar):
             ]
         else:
             try:
-                if (
-                    "Views - Ribbon_newPanel"
-                    in self.ribbonStructure["newPanels"]["Global"]
-                ):
-                    del self.ribbonStructure["newPanels"]["Global"][
-                        "Views - Ribbon_newPanel"
-                    ]
+                if "Views - Ribbon_newPanel" in self.ribbonStructure["newPanels"]["Global"]:
+                    del self.ribbonStructure["newPanels"]["Global"]["Views - Ribbon_newPanel"]
             except Exception:
                 pass
         # # Add a toolbar "tools"
@@ -333,14 +326,11 @@ class ModernMenu(RibbonBar):
         try:
             NeedsUpdating = False
             if "Tools_newPanel" in self.ribbonStructure["newPanels"]["Global"]:
-                for item in self.ribbonStructure["newPanels"]["Global"][
-                    "Tools_newPanel"
-                ]:
+                for item in self.ribbonStructure["newPanels"]["Global"]["Tools_newPanel"]:
                     if item[1] != "Standard":
                         NeedsUpdating = True
             if (
-                "Tools_newPanel" not in self.ribbonStructure["newPanels"]["Global"]
-                and UseToolsPanel is True
+                "Tools_newPanel" not in self.ribbonStructure["newPanels"]["Global"] and UseToolsPanel is True
             ) or NeedsUpdating is True:
                 StandardFunctions.add_keys_nested_dict(
                     self.ribbonStructure,
@@ -409,9 +399,7 @@ class ModernMenu(RibbonBar):
 
         # Get the address of the repository address
         PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
-        self.ReproAdress = StandardFunctions.ReturnXML_Value(
-            PackageXML, "url", "type", "repository"
-        )
+        self.ReproAdress = StandardFunctions.ReturnXML_Value(PackageXML, "url", "type", "repository")
         if self.ReproAdress != "" or self.ReproAdress is not None:
             print(translate("FreeCAD Ribbon", "FreeCAD Ribbon: ") + self.ReproAdress)
 
@@ -421,9 +409,7 @@ class ModernMenu(RibbonBar):
                 for WorkBenchName in self.ribbonStructure["newPanels"]:
                     for NewPanel in self.ribbonStructure["newPanels"][WorkBenchName]:
                         # Get the commands from the custom panel
-                        Commands = self.ribbonStructure["newPanels"][WorkBenchName][
-                            NewPanel
-                        ]
+                        Commands = self.ribbonStructure["newPanels"][WorkBenchName][NewPanel]
 
                         # Get the command and its original toolbar
                         for CommandItem in Commands:
@@ -445,15 +431,9 @@ class ModernMenu(RibbonBar):
         # Activate the workbenches used in the dropdown buttons otherwise the button stays empty
         try:
             if "dropdownButtons" in self.ribbonStructure:
-                for DropDownCommand, Commands in self.ribbonStructure[
-                    "dropdownButtons"
-                ].items():
+                for DropDownCommand, Commands in self.ribbonStructure["dropdownButtons"].items():
                     for CommandItem in Commands:
-                        if (
-                            CommandItem[1] != "General"
-                            and CommandItem[1] != "Global"
-                            and CommandItem[1] != "Standard"
-                        ):
+                        if CommandItem[1] != "General" and CommandItem[1] != "Global" and CommandItem[1] != "Standard":
                             # Activate the workbench if not loaded
                             Gui.activateWorkbench(CommandItem[1])
         except Exception as e:
@@ -472,15 +452,11 @@ class ModernMenu(RibbonBar):
             Branch = "main"
             File = "package.xml"
             ElementName = "version"
-            LatestVersion = StandardFunctions.ReturnXML_Value_Git(
-                User, Repo, Branch, File, ElementName
-            )
+            LatestVersion = StandardFunctions.ReturnXML_Value_Git(User, Repo, Branch, File, ElementName)
             if LatestVersion is not None:
                 # Get the current version
                 PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
-                CurrentVersion = StandardFunctions.ReturnXML_Value(
-                    PackageXML, "version"
-                )
+                CurrentVersion = StandardFunctions.ReturnXML_Value(PackageXML, "version")
                 # Check if you are on a developer version. If so set developer version
                 if CurrentVersion.lower().endswith("x"):
                     self.DeveloperVersion = CurrentVersion
@@ -513,29 +489,15 @@ class ModernMenu(RibbonBar):
         StyleSheet = Path(Parameters_Ribbon.STYLESHEET).read_text()
         # modify the stylesheet to set the border and background for a toolbar and menu
         hexColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
-        hexColorTab = StyleMapping_Ribbon.ReturnStyleItem(
-            "Background_Color", True, True
-        )
-        if (
-            hexColor is not None
-            and hexColor != ""
-            and Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True
-        ):
+        hexColorTab = StyleMapping_Ribbon.ReturnStyleItem("Background_Color", True, True)
+        if hexColor is not None and hexColor != "" and Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True:
             # Set the quickaccess toolbar background color. This fixes a transparant toolbar.
-            self.quickAccessToolBar().setStyleSheet(
-                "QToolBar {background: " + hexColor + ";}"
-            )
+            self.quickAccessToolBar().setStyleSheet("QToolBar {background: " + hexColor + ";}")
             self.tabBar().setStyleSheet("background: " + hexColorTab + ";")
             # Set the background color. This fixes transparant backgrounds when FreeCAD has no stylesheet
-            StyleSheet_Addition = (
-                "\n\nQToolButton {background: solid " + hexColor + ";}"
-            )
+            StyleSheet_Addition = "\n\nQToolButton {background: solid " + hexColor + ";}"
             StyleSheet_Addition_2 = (
-                "\n\nRibbonBar {border: none;background: solid "
-                + hexColor
-                + ";color: "
-                + hexColor
-                + ";}"
+                "\n\nRibbonBar {border: none;background: solid " + hexColor + ";color: " + hexColor + ";}"
             )
             StyleSheet = StyleSheet_Addition_2 + StyleSheet + StyleSheet_Addition
         self.setStyleSheet(StyleSheet)
@@ -545,13 +507,9 @@ class ModernMenu(RibbonBar):
             StyleSheet_Addition_3 = (
                 """QTabBar::tab {
                     background: """
-                + StyleMapping_Ribbon.ReturnStyleItem(
-                    "Background_Color_Hover", True, True
-                )
+                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color_Hover", True, True)
                 + """;color: """
-                + StyleMapping_Ribbon.ReturnStyleItem(
-                    "Background_Color_Hover", True, True
-                )
+                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color_Hover", True, True)
                 + """;min-width: """
                 + str(self.TabBar_Size)
                 + """px;
@@ -624,9 +582,7 @@ class ModernMenu(RibbonBar):
         self.tabBar().tabBarClicked.connect(self.onTabBarClicked)
 
         # override the default scroll behavior with a custom function
-        self.tabBar().wheelEvent = lambda event_tabBar: self.wheelEvent_TabBar(
-            event_tabBar
-        )
+        self.tabBar().wheelEvent = lambda event_tabBar: self.wheelEvent_TabBar(event_tabBar)
         self.wheelEvent = lambda event_CC: self.wheelEvent_CC(event_CC)
         self.tabBar().setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.currentCategory().setFocusPolicy(Qt.FocusPolicy.StrongFocus)
@@ -639,20 +595,12 @@ class ModernMenu(RibbonBar):
         ScrollLeftButton_Tab: QToolButton = self.tabBar().findChildren(QToolButton)[0]
         ScrollRightButton_Tab: QToolButton = self.tabBar().findChildren(QToolButton)[1]
         # get the icons
-        ScrollLeftButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem(
-            "ScrollLeftButton_Tab"
-        )
-        ScrollRightButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem(
-            "ScrollRightButton_Tab"
-        )
+        ScrollLeftButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab")
+        ScrollRightButton_Tab_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab")
         # Set the icons
         StyleSheet = "QToolButton {image: none;margin-top:6px;margin-bottom:6px;};QToolButton::arrow {image: none};"
         BackgroundColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
-        if (
-            int(App.Version()[0]) == 0
-            and int(App.Version()[1]) <= 21
-            and BackgroundColor is not None
-        ):
+        if int(App.Version()[0]) == 0 and int(App.Version()[1]) <= 21 and BackgroundColor is not None:
             StyleSheet = (
                 """QToolButton {image: none;background: """
                 + BackgroundColor
@@ -662,9 +610,7 @@ class ModernMenu(RibbonBar):
             ScrollLeftButton_Tab.setStyleSheet(StyleSheet)
             ScrollLeftButton_Tab.setIcon(ScrollLeftButton_Tab_Icon)
         else:
-            ScrollRightButton_Tab.setToolButtonStyle(
-                Qt.ToolButtonStyle.ToolButtonTextOnly
-            )
+            ScrollRightButton_Tab.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
         if ScrollRightButton_Tab_Icon is not None:
             ScrollRightButton_Tab.setStyleSheet(StyleSheet)
             ScrollRightButton_Tab.setIcon(ScrollRightButton_Tab_Icon)
@@ -672,13 +618,9 @@ class ModernMenu(RibbonBar):
             ScrollRightButton_Tab.setArrowType(Qt.ArrowType.RightArrow)
 
         # Remove persistant toolbars
-        PersistentToolbars = App.ParamGet(
-            "User parameter:Tux/PersistentToolbars/User"
-        ).GetGroups()
+        PersistentToolbars = App.ParamGet("User parameter:Tux/PersistentToolbars/User").GetGroups()
         for Group in PersistentToolbars:
-            Parameter = App.ParamGet(
-                "User parameter:Tux/PersistentToolbars/User/" + Group
-            )
+            Parameter = App.ParamGet("User parameter:Tux/PersistentToolbars/User/" + Group)
             Parameter.SetString("Top", "")
             Parameter.SetString("Left", "")
             Parameter.SetString("Right", "")
@@ -689,9 +631,7 @@ class ModernMenu(RibbonBar):
         # Application menu
         ShortcutKey = "Alt+A"
         try:
-            CustomShortCuts = App.ParamGet(
-                "User parameter:BaseApp/Preferences/Shortcut"
-            )
+            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
             if "Ribbon_Menu" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Menu")
         except Exception:
@@ -708,10 +648,7 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().enterEvent = lambda enter: self.leaveEvent(enter)
 
         # Rearrange the tabbar and toolbars
-        if (
-            Parameters_Ribbon.TOOLBAR_POSITION == 0
-            or Parameters_Ribbon.TOOLBAR_POSITION == 1
-        ):
+        if Parameters_Ribbon.TOOLBAR_POSITION == 0 or Parameters_Ribbon.TOOLBAR_POSITION == 1:
             # Get the widgets
             _quickAccessToolBarWidget = self.quickAccessToolBar()
             _titleLabel = self._titleWidget._titleLabel
@@ -729,38 +666,24 @@ class ModernMenu(RibbonBar):
                 _titleLabel.setAlignment(Qt.AlignmentFlag.AlignCenter)
                 _titleLabel.setFont(font)
                 # Set the label text to FreeCAD's version
-                text = (
-                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
-                )
+                text = f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
                 _titleLabel.setText(text)
                 # Create a spacer to set the tab
                 spacer = QWidget()
-                spacer.setSizePolicy(
-                    QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
-                )
+                spacer.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
                 spacer.setFixedWidth(3)
                 self._titleWidget._tabBarLayout.setContentsMargins(3, 3, 3, 0)
                 self._titleWidget._tabBarLayout.addWidget(
                     _quickAccessToolBarWidget, 0, 0, 1, 2, Qt.AlignmentFlag.AlignVCenter
                 )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter
-                )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter
-                )
-                self._titleWidget._tabBarLayout.addWidget(
-                    spacer, 1, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter
-                )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _tabBar, 1, 1, 1, 4, Qt.AlignmentFlag.AlignVCenter
-                )
+                self._titleWidget._tabBarLayout.addWidget(_titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(_rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(spacer, 1, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(_tabBar, 1, 1, 1, 4, Qt.AlignmentFlag.AlignVCenter)
                 # Change the offsets
                 self.RibbonMinimalHeight = self.QuickAccessButtonSize * 2 + 20
                 self.RibbonOffset = 54 + self.QuickAccessButtonSize * 2
-                self._titleWidget._tabBarLayout.setRowMinimumHeight(
-                    0, self.QuickAccessButtonSize
-                )
+                self._titleWidget._tabBarLayout.setRowMinimumHeight(0, self.QuickAccessButtonSize)
                 self._titleWidget._tabBarLayout.setRowMinimumHeight(1, self.TabBar_Size)
                 # self.setTitle("FreeCAD")
             if Parameters_Ribbon.TOOLBAR_POSITION == 1:  # Toolbars inline with tabbar
@@ -768,21 +691,13 @@ class ModernMenu(RibbonBar):
                 self._titleWidget._tabBarLayout.addWidget(
                     _quickAccessToolBarWidget, 0, 0, 1, 1, Qt.AlignmentFlag.AlignVCenter
                 )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _tabBar, 0, 1, 1, 1, Qt.AlignmentFlag.AlignVCenter
-                )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter
-                )
-                self._titleWidget._tabBarLayout.addWidget(
-                    _rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter
-                )
+                self._titleWidget._tabBarLayout.addWidget(_tabBar, 0, 1, 1, 1, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(_titleLabel, 0, 2, 1, 1, Qt.AlignmentFlag.AlignVCenter)
+                self._titleWidget._tabBarLayout.addWidget(_rightToolBar, 0, 3, 1, 2, Qt.AlignmentFlag.AlignVCenter)
                 # Change the offsets
                 self.RibbonMinimalHeight = self.QuickAccessButtonSize + 10
                 self.RibbonOffset = 46 + self.QuickAccessButtonSize
-                self._titleWidget._tabBarLayout.setRowMinimumHeight(
-                    0, self.QuickAccessButtonSize
-                )
+                self._titleWidget._tabBarLayout.setRowMinimumHeight(0, self.QuickAccessButtonSize)
 
         # Install an event filter to catch events from the main window and act on it.
         mw.installEventFilter(EventInspector(mw))
@@ -813,10 +728,7 @@ class ModernMenu(RibbonBar):
         TB.show()
         # In FreeCAD 1.0, Overlays are introduced. These have also an enterEvent which results in strange behavior
         # Therefore this function is only activated when FreeCAD's overlay function is disabled.
-        if (
-            Parameters_Ribbon.SHOW_ON_HOVER is True
-            and Parameters_Ribbon.USE_FC_OVERLAY is False
-        ):
+        if Parameters_Ribbon.SHOW_ON_HOVER is True and Parameters_Ribbon.USE_FC_OVERLAY is False:
             self.UnfoldRibbon()
             return
 
@@ -828,9 +740,7 @@ class ModernMenu(RibbonBar):
     # implementation to add actions to the Filemenu. Needed for the accessories menu
     def addAction(self, action: QAction):
         menu = self.findChild(RibbonMenu, "Ribbon")
-        StyleSheet_Menu = (
-            "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
-        )
+        StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
         menu.setStyleSheet(StyleSheet_Menu)
         if menu is None:
             menu = self.addFileMenu()
@@ -911,9 +821,7 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().setContentsMargins(0, 0, 9, 0)
         # Set the size of the menu button
         self.applicationOptionButton().setFixedSize(
-            self.QuickAccessButtonSize
-            + FontMetrics.boundingRect(Text.text()).width()
-            + 12,
+            self.QuickAccessButtonSize + FontMetrics.boundingRect(Text.text()).width() + 12,
             self.QuickAccessButtonSize,
         )
         # Set the icon
@@ -922,24 +830,19 @@ class ModernMenu(RibbonBar):
         self.applicationOptionButton().setStyleSheet(
             StyleMapping_Ribbon.ReturnStyleSheet(
                 "applicationbutton",
-                padding_right=str(FontMetrics.horizontalAdvance(Text.text(), -1) + 12)
-                + "px",
+                padding_right=str(FontMetrics.horizontalAdvance(Text.text(), -1) + 12) + "px",
                 radius="4px",
             )
         )
         # Add the default tooltip
-        self.applicationOptionButton().setToolTip(
-            translate("FreeCAD Ribbon", "FreeCAD Ribbon")
-        )
+        self.applicationOptionButton().setToolTip(translate("FreeCAD Ribbon", "FreeCAD Ribbon"))
 
         # add the menus from the menubar to the application button
         self.ApplicationMenus()
 
         # add quick access buttons
         i = 1  # Start value for button count. Used for width of quickaccess toolbar
-        toolBarWidth = (
-            (self.QuickAccessButtonSize * self.sizeFactor) * i
-        ) + self.applicationOptionButton().width()
+        toolBarWidth = ((self.QuickAccessButtonSize * self.sizeFactor) * i) + self.applicationOptionButton().width()
         for commandName in self.ribbonStructure["quickAccessCommands"]:
             i = i + 1
             # Define a width
@@ -971,11 +874,7 @@ class ModernMenu(RibbonBar):
                         height = self.QuickAccessButtonSize
                         button.setFixedSize(width, height)
                         # Set the stylesheet
-                        button.setStyleSheet(
-                            StyleMapping_Ribbon.ReturnStyleSheet(
-                                "toolbutton", "2px", f"{padding}px"
-                            )
-                        )
+                        button.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", f"{padding}px"))
                     elif len(QuickAction) > 1:
                         # set the padding for a dropdown button
                         padding = self.PaddingRight
@@ -987,15 +886,9 @@ class ModernMenu(RibbonBar):
                         height = self.QuickAccessButtonSize
                         button.setFixedSize(width, height)
                         # Set the PopupMode
-                        button.setPopupMode(
-                            QToolButton.ToolButtonPopupMode.InstantPopup
-                        )
+                        button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
                         # Set the stylesheet
-                        button.setStyleSheet(
-                            StyleMapping_Ribbon.ReturnStyleSheet(
-                                "toolbutton", "2px", f"{padding}px"
-                            )
-                        )
+                        button.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", f"{padding}px"))
 
                 # If it is a custom dropdown, add the actions one by one.
                 if commandName.endswith("_ddb") is True:
@@ -1017,9 +910,7 @@ class ModernMenu(RibbonBar):
 
                     # Set the stylesheet
                     button.setStyleSheet(
-                        StyleMapping_Ribbon.ReturnStyleSheet(
-                            "toolbutton", "2px", padding_right=f"{padding}px"
-                        )
+                        StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px", padding_right=f"{padding}px")
                     )
 
                 # Set the height
@@ -1031,9 +922,7 @@ class ModernMenu(RibbonBar):
                 if len(button.actions()) > 0:
                     self.addQuickAccessButton(button)
                 else:
-                    StandardFunctions.Print(
-                        f"{commandName} did not contain any actions!", "Log"
-                    )
+                    StandardFunctions.Print(f"{commandName} did not contain any actions!", "Log")
 
                 toolBarWidth = toolBarWidth + width
             except Exception as e:
@@ -1049,9 +938,7 @@ class ModernMenu(RibbonBar):
         # Set the width of the quickaccess toolbar.
         self.quickAccessToolBar().setMinimumWidth(toolBarWidth)
         # Set the size policy
-        self.quickAccessToolBar().setSizePolicy(
-            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.MinimumExpanding
-        )
+        self.quickAccessToolBar().setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.MinimumExpanding)
         # needed for excluding from hiding toolbars
         self.quickAccessToolBar().setObjectName("quickAccessToolBar")
         self.quickAccessToolBar().setWindowTitle("quickAccessToolBar")
@@ -1063,23 +950,17 @@ class ModernMenu(RibbonBar):
         self.tabBar().setFont(font)
 
         self.tabBar().setIconSize(QSize(self.TabBar_Size - 6, self.TabBar_Size - 6))
-        self.tabBar().setStyleSheet(
-            "margin: 0px;padding: 0px;height: " + str(self.TabBar_Size) + ";"
-        )
+        self.tabBar().setStyleSheet("margin: 0px;padding: 0px;height: " + str(self.TabBar_Size) + ";")
 
         # Correct colors when no stylesheet is selected for FreeCAD.
         self.quickAccessToolBar().setStyleSheet("")
         if Parameters_Ribbon.BUTTON_BACKGROUND_ENABLED is True:
-            FreeCAD_preferences = App.ParamGet(
-                "User parameter:BaseApp/Preferences/MainWindow"
-            )
+            FreeCAD_preferences = App.ParamGet("User parameter:BaseApp/Preferences/MainWindow")
             currentStyleSheet = FreeCAD_preferences.GetString("StyleSheet")
             if currentStyleSheet == "":
                 hexColor = StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
                 # Set the quickaccess toolbar background color
-                self.quickAccessToolBar().setStyleSheet(
-                    "background-color: " + hexColor + ";"
-                )
+                self.quickAccessToolBar().setStyleSheet("background-color: " + hexColor + ";")
 
         # Get the order of workbenches from Parameters
         WorkbenchOrderedList: list = Parameters_Ribbon.TAB_ORDER.split(",")
@@ -1095,10 +976,7 @@ class ModernMenu(RibbonBar):
         # There is an issue with the internal assembly wb showing the wrong panel
         # when assembly4 wb is installed and positioned for the internal assembly wb
         for i in range(len(WorkbenchOrderedList)):
-            if (
-                WorkbenchOrderedList[i] == "Assembly4Workbench"
-                or WorkbenchOrderedList[i] == "Assembly3Workbench"
-            ):
+            if WorkbenchOrderedList[i] == "Assembly4Workbench" or WorkbenchOrderedList[i] == "Assembly3Workbench":
                 try:
                     index_1 = WorkbenchOrderedList.index(WorkbenchOrderedList[i])
                     index_2 = WorkbenchOrderedList.index("AssemblyWorkbench")
@@ -1138,14 +1016,10 @@ class ModernMenu(RibbonBar):
                             icon: QIcon = self.ReturnWorkbenchIcon(workbenchName)
                             self.tabBar().setTabIcon(len(self.categories()) - 1, icon)
                         if Parameters_Ribbon.TABBAR_STYLE == 2:
-                            self.tabBar().setTabIcon(
-                                len(self.categories()) - 1, QIcon()
-                            )
+                            self.tabBar().setTabIcon(len(self.categories()) - 1, QIcon())
 
                         # Set the tab data
-                        self.tabBar().setTabData(
-                            len(self.categories()) - 1, workbenchName
-                        )
+                        self.tabBar().setTabData(len(self.categories()) - 1, workbenchName)
 
                         # Set the tooltip
                         MenuText = workbench.MenuText
@@ -1154,20 +1028,14 @@ class ModernMenu(RibbonBar):
                             ToolTipText.lower() != MenuText.lower() + " workbench"
                             and MenuText.lower() != ToolTipText.lower()
                         ):
-                            MenuText = (
-                                f"<b>{workbench.MenuText}</b><br>{workbench.ToolTip}"
-                            )
+                            MenuText = f"<b>{workbench.MenuText}</b><br>{workbench.ToolTip}"
                         else:
                             MenuText = f"<b>{MenuText}<b>"
 
-                        self.tabBar().setTabToolTip(
-                            len(self.categories()) - 1, MenuText
-                        )
+                        self.tabBar().setTabToolTip(len(self.categories()) - 1, MenuText)
 
         # Set the size of the collapseRibbonButton
-        self.collapseRibbonButton().setFixedSize(
-            self.RightToolBarButtonSize, self.RightToolBarButtonSize
-        )
+        self.collapseRibbonButton().setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
 
         # add the searchbar if available
         SearchBarWidth = self.AddSearchBar()
@@ -1185,18 +1053,10 @@ class ModernMenu(RibbonBar):
         if self.OverlayMenu is not None:
             OverlayMenu = QToolButton()
             OverlayMenu.setIcon(QIcon(os.path.join(pathIcons, "Draft_Layer.svg")))
-            OverlayMenu.setToolTip(
-                translate("FreeCAD Ribbon", "Overlay functions") + "..."
-            )
+            OverlayMenu.setToolTip(translate("FreeCAD Ribbon", "Overlay functions") + "...")
             OverlayMenu.setMenu(self.OverlayMenu)
-            OverlayMenu.setFixedSize(
-                self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
-            )
-            OverlayMenu.setStyleSheet(
-                StyleMapping_Ribbon.ReturnStyleSheet(
-                    control="toolbutton", padding_right="12px"
-                )
-            )
+            OverlayMenu.setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
+            OverlayMenu.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px"))
             OverlayMenu.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
             Font = OverlayMenu.font()
             Font.setPixelSize(Parameters_Ribbon.FONTSIZE_MENUS)
@@ -1240,51 +1100,36 @@ class ModernMenu(RibbonBar):
                     Button.triggered.connect(SaveAndRestore.SaveAndRestore.LoadDialog)
                     break
         except Exception:
+            pass
         # add the ribbon settings menu
         SettingsMenu.addAction(self.RibbonMenu.menuAction())
         SettingsMenu.setIcon(Gui.getIcon("Std_DlgParameter.svg"))
         SettingsMenu.setToolTip(translate("FreeCAD Ribbon", "Preferences") + "...")
-        SettingsMenu.setFixedSize(
-            self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
-        )
-        SettingsMenu.setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet(
-                control="toolbutton", padding_right="12px"
-            )
-        )
+        SettingsMenu.setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
+        SettingsMenu.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px"))
         SettingsMenu.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         # add the settingsmenu to the right toolbar
         self.rightToolBar().addWidget(SettingsMenu)
 
         # Set the helpbutton
         self.helpRibbonButton().setEnabled(True)
-        self.helpRibbonButton().setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
-        )
+        self.helpRibbonButton().setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self.helpRibbonButton().setToolTip(translate("FreeCAD Ribbon", "Help") + "...")
         # Get the default help action from FreeCAD
         helpMenu = mw.findChildren(QMenu, "&Help")[0]
         helpAction = helpMenu.actions()[0]
         self.helpRibbonButton().setIcon(helpAction.icon())
         self.helpRibbonButton().setMenu(self.HelpMenu)
-        self.helpRibbonButton().setFixedSize(
-            self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize
-        )
+        self.helpRibbonButton().setFixedSize(self.RightToolBarButtonSize + 12, self.RightToolBarButtonSize)
         self.helpRibbonButton().setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet(
-                control="toolbutton", padding_right="12px"
-            )
+            StyleMapping_Ribbon.ReturnStyleSheet(control="toolbutton", padding_right="12px")
         )
-        self.helpRibbonButton().setPopupMode(
-            QToolButton.ToolButtonPopupMode.InstantPopup
-        )
+        self.helpRibbonButton().setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
 
         # Add a button the enable or disable AutoHide
         pinButton = QToolButton()
         pinButton.setCheckable(True)
-        pinButton.setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
-        )
+        pinButton.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         pinButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
         # Set the correct icon
         if Parameters_Ribbon.AUTOHIDE_RIBBON is True:
@@ -1302,14 +1147,10 @@ class ModernMenu(RibbonBar):
             pinButton.setChecked(False)
         if Parameters_Ribbon.AUTOHIDE_RIBBON is False:
             pinButton.setChecked(True)
-        pinButton.setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px")
-        )
+        pinButton.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton", "2px"))
         ShortcutKey = "Alt+T"
         try:
-            CustomShortCuts = App.ParamGet(
-                "User parameter:BaseApp/Preferences/Shortcut"
-            )
+            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
             if "Ribbon_Pin" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Pin")
             if ShortcutKey != "" and ShortcutKey is not None:
@@ -1317,16 +1158,13 @@ class ModernMenu(RibbonBar):
         except Exception:
             pass
         # Set the tooltip
-        ToolTip = translate(
-            "FreeCAD Ribbon", "Click to toggle the autohide function on or off"
-        )
+        ToolTip = translate("FreeCAD Ribbon", "Click to toggle the autohide function on or off")
         if ShortcutKey != "none":
             ToolTip = ToolTip + f"<br></br><i>{ShortcutKey}</i>"
         pinButton.setToolTip(
             translate(
                 "FreeCAD Ribbon",
-                "Click to toggle the autohide function on or off"
-                + f"<br></br><i>{ShortcutKey}</i>",
+                "Click to toggle the autohide function on or off" + f"<br></br><i>{ShortcutKey}</i>",
             )
         )
 
@@ -1360,13 +1198,9 @@ class ModernMenu(RibbonBar):
                     padding_right="3px",
                 )
             )
-            MinimzeButton.setIcon(
-                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[3]
-            )
+            MinimzeButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[3])
             MinimzeButton.clicked.connect(self.MinimizeFreeCAD)
-            MinimzeButton.setFixedSize(
-                self.RightToolBarButtonSize, self.RightToolBarButtonSize
-            )
+            MinimzeButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
             self.rightToolBar().addWidget(MinimzeButton)
             # Restore button
             RestoreButton = QToolButton()
@@ -1381,13 +1215,9 @@ class ModernMenu(RibbonBar):
                     padding_right="3px",
                 )
             )
-            RestoreButton.setIcon(
-                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2]
-            )
+            RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2])
             RestoreButton.clicked.connect(self.RestoreFreeCAD)
-            RestoreButton.setFixedSize(
-                self.RightToolBarButtonSize, self.RightToolBarButtonSize
-            )
+            RestoreButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
             self.rightToolBar().addWidget(RestoreButton)
             # Close button
             CloseButton = QToolButton()
@@ -1402,29 +1232,19 @@ class ModernMenu(RibbonBar):
                     HoverColor="#e62424",
                 )
             )
-            CloseButton.setIcon(
-                StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[0]
-            )
+            CloseButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[0])
             CloseButton.clicked.connect(self.CloseFreeCAD)
-            CloseButton.setFixedSize(
-                self.RightToolBarButtonSize, self.RightToolBarButtonSize
-            )
+            CloseButton.setFixedSize(self.RightToolBarButtonSize, self.RightToolBarButtonSize)
             self.rightToolBar().addWidget(CloseButton)
 
         # Set the width of the right toolbar
-        RightToolbarWidth = (
-            SearchBarWidth
-            + 3 * (self.RightToolBarButtonSize + 16)
-            + self.RightToolBarButtonSize
-        )
+        RightToolbarWidth = SearchBarWidth + 3 * (self.RightToolBarButtonSize + 16) + self.RightToolBarButtonSize
         if Parameters_Ribbon.USE_FC_OVERLAY is True:
             RightToolbarWidth = SearchBarWidth + 2 * (self.RightToolBarButtonSize + 16)
         self.rightToolBar().setMinimumWidth(RightToolbarWidth)
         self.setRightToolBarHeight(self.RibbonMinimalHeight)
         # Set the size policy
-        self.rightToolBar().setSizePolicy(
-            QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding
-        )
+        self.rightToolBar().setSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding)
         self.rightToolBar().setSizeIncrement(1, 1)
         # Set the objectName for the right toolbar. needed for excluding from hiding.
         self.rightToolBar().setObjectName("rightToolBar")
@@ -1442,17 +1262,11 @@ class ModernMenu(RibbonBar):
 
                 sea = SearchBoxLight.SearchBoxLight(
                     getItemGroups=lambda: __import__("GetItemGroups").getItemGroups(),
-                    getToolTip=lambda groupId, setParent: __import__(
-                        "GetItemGroups"
-                    ).getToolTip(groupId, setParent),
-                    getItemDelegate=lambda: __import__(
-                        "IndentedItemDelegate"
-                    ).IndentedItemDelegate(),
+                    getToolTip=lambda groupId, setParent: __import__("GetItemGroups").getToolTip(groupId, setParent),
+                    getItemDelegate=lambda: __import__("IndentedItemDelegate").IndentedItemDelegate(),
                 )
                 sea.resultSelected.connect(
-                    lambda index, groupId: __import__("GetItemGroups").onResultSelected(
-                        index, groupId
-                    )
+                    lambda index, groupId: __import__("GetItemGroups").onResultSelected(index, groupId)
                 )
                 sea.setFixedSize(width, self.RightToolBarButtonSize)
                 BeforeAction = self.rightToolBar().actions()[1]
@@ -1470,18 +1284,13 @@ class ModernMenu(RibbonBar):
         MenuBar = mw.menuBar()
 
         # Set a stylesheet specific for the menubar. Otherwise the fontsize of the menus will not be applied
-        StyleSheet_MenuBar = (
-            "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
-        )
+        StyleSheet_MenuBar = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
         MenuBar.setStyleSheet(StyleSheet_MenuBar)
         # # Add the actions of the menubar to the application menu
         for child in MenuBar.actions():
             if child.objectName() != "&Help" and child.objectName != "AccessoriesMenu":
                 ApplictionMenu.addAction(child)
-            if (
-                child.objectName == "AccessoriesMenu"
-                and self.AccessoriesMenu is not None
-            ):
+            if child.objectName == "AccessoriesMenu" and self.AccessoriesMenu is not None:
                 ApplictionMenu.addMenu(self.AccessoriesMenu)
 
         # if you on macOS, add the ribbon menus to the menubar
@@ -1510,9 +1319,7 @@ class ModernMenu(RibbonBar):
             color = StyleMapping_Ribbon.ReturnStyleItem("DevelopColor")
             Label = QLabel()
             Label.setText("Development version")
-            Label.setStyleSheet(
-                f"color: {color};border: 1px solid {color};border-radius: 2px;"
-            )
+            Label.setStyleSheet(f"color: {color};border: 1px solid {color};border-radius: 2px;")
             ApplictionMenu.addWidget(Label)
         # if there is an update, add a button that opens the addon manager
         if self.UpdateVersion != "" and self.DeveloperVersion == "":
@@ -1551,17 +1358,12 @@ class ModernMenu(RibbonBar):
                 self.AccessoriesMenu.addActions(subMenus)
 
         # Create the overlay menu when the native overlay function is not used
-        if (
-            Parameters_Ribbon.USE_FC_OVERLAY is False
-            and Parameters_Ribbon.USE_OVERLAY is True
-        ):
+        if Parameters_Ribbon.USE_FC_OVERLAY is False and Parameters_Ribbon.USE_OVERLAY is True:
             OverlayMenu = QMenu(translate("FreeCAD Ribbon", "Overlay") + "...", self)
             OverlayMenu.setToolTipsVisible(True)
 
             # Toggle overlay for all -----------------------------------------------------
-            OverlayButton_All = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle overlay for all")
-            )
+            OverlayButton_All = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle overlay for all"))
             OverlayButton_All.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1572,9 +1374,7 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "F4"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayAll" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayAll")
             except Exception as e:
@@ -1584,9 +1384,7 @@ class ModernMenu(RibbonBar):
             OverlayButton_All.setShortcut(ShortcutKey)
 
             # Toggle transparancy for all -----------------------------------------------------
-            TransparancyButton_All = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle transparancy")
-            )
+            TransparancyButton_All = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle transparancy"))
             TransparancyButton_All.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1597,13 +1395,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Shift+F4"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayTransparentAll" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString(
-                        "Std_DockOverlayTransparentAll"
-                    )
+                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayTransparentAll")
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1612,9 +1406,7 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle overlay for active panel-----------------------------------------------------
-            OverlayButton_Active = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle overlay")
-            )
+            OverlayButton_Active = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle overlay"))
             OverlayButton_Active.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1625,9 +1417,7 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "F3"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayToggle" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggle")
             except Exception as e:
@@ -1637,9 +1427,7 @@ class ModernMenu(RibbonBar):
             OverlayButton_Active.setShortcut(ShortcutKey)
 
             # Toggle transparancy for active panel-----------------------------------------------------
-            TransparancyButton = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle transparant mode")
-            )
+            TransparancyButton = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle transparant mode"))
             TransparancyButton.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1650,13 +1438,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Shift+F3"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayToggleTransparent" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString(
-                        "Std_DockOverlayToggleTransparent"
-                    )
+                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleTransparent")
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1665,25 +1449,15 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle mouse bypass-----------------------------------------------------
-            ToggleMouseByPass = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Bypass mouse events")
-            )
-            ToggleMouseByPass.setToolTip(
-                translate(
-                    "FreeCAD Ribbon", "Bypass mouse events in docked overlay windows"
-                )
-            )
+            ToggleMouseByPass = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Bypass mouse events"))
+            ToggleMouseByPass.setToolTip(translate("FreeCAD Ribbon", "Bypass mouse events in docked overlay windows"))
             ToggleMouseByPass.triggered.connect(self.ToggleMouseByPass)
             # Get the shortcut from the original command
             ShortcutKey = "T,T"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayMouseTransparent" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString(
-                        "Std_DockOverlayMouseTransparent"
-                    )
+                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayMouseTransparent")
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1692,9 +1466,7 @@ class ModernMenu(RibbonBar):
 
             OverlayMenu.addSeparator()
             # Toggle overlay for left panels-----------------------------------------------------
-            OverlayButton_Left = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle left")
-            )
+            OverlayButton_Left = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle left"))
             OverlayButton_Left.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1705,9 +1477,7 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+left"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayToggleLeft" in CustomShortCuts.GetStrings():
                     ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleLeft")
             except Exception as e:
@@ -1716,9 +1486,7 @@ class ModernMenu(RibbonBar):
                 ShortcutKey = "Ctrl+left"
             OverlayButton_Left.setShortcut(ShortcutKey)
             # Toggle overlay for right panels-----------------------------------------------------
-            OverlayButton_Right = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle right")
-            )
+            OverlayButton_Right = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle right"))
             OverlayButton_Right.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1729,22 +1497,16 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+right"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayToggleRight" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString(
-                        "Std_DockOverlayToggleRight"
-                    )
+                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleRight")
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
                 ShortcutKey = "Ctrl+right"
             OverlayButton_Right.setShortcut(ShortcutKey)
             # Toggle overlay for Bottom panels-----------------------------------------------------
-            OverlayButton_Bottom = OverlayMenu.addAction(
-                translate("FreeCAD Ribbon", "Toggle bottom")
-            )
+            OverlayButton_Bottom = OverlayMenu.addAction(translate("FreeCAD Ribbon", "Toggle bottom"))
             OverlayButton_Bottom.setToolTip(
                 translate(
                     "FreeCAD Ribbon",
@@ -1755,13 +1517,9 @@ class ModernMenu(RibbonBar):
             # Get the shortcut from the original command
             ShortcutKey = "Ctrl+down"
             try:
-                CustomShortCuts = App.ParamGet(
-                    "User parameter:BaseApp/Preferences/Shortcut"
-                )
+                CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
                 if "Std_DockOverlayToggleBottom" in CustomShortCuts.GetStrings():
-                    ShortcutKey = CustomShortCuts.GetString(
-                        "Std_DockOverlayToggleBottom"
-                    )
+                    ShortcutKey = CustomShortCuts.GetString("Std_DockOverlayToggleBottom")
             except Exception as e:
                 if Parameters_Ribbon.DEBUG_MODE is True:
                     print(e.with_traceback())
@@ -1772,23 +1530,15 @@ class ModernMenu(RibbonBar):
             self.OverlayMenu = OverlayMenu
 
         # Create a ribbon menu
-        RibbonMenu = QMenu(
-            translate("FreeCAD Ribbon", "Ribbon UI preferences") + " ...", self
-        )
+        RibbonMenu = QMenu(translate("FreeCAD Ribbon", "Ribbon UI preferences") + " ...", self)
         RibbonMenu.setToolTipsVisible(True)
         # Add the ribbon design button
-        DesignButton = RibbonMenu.addAction(
-            translate("FreeCAD Ribbon", "Ribbon layout")
-        )
-        DesignButton.setToolTip(
-            translate("FreeCAD Ribbon", "Design the ribbon to your preference")
-        )
+        DesignButton = RibbonMenu.addAction(translate("FreeCAD Ribbon", "Ribbon layout"))
+        DesignButton.setToolTip(translate("FreeCAD Ribbon", "Design the ribbon to your preference"))
         DesignButton.triggered.connect(self.loadDesignMenu)
         ShortcutKey = "Alt+L"
         try:
-            CustomShortCuts = App.ParamGet(
-                "User parameter:BaseApp/Preferences/Shortcut"
-            )
+            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
             if "Ribbon_Layout" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Layout")
         except Exception:
@@ -1797,19 +1547,13 @@ class ModernMenu(RibbonBar):
             DesignButton.setShortcut(ShortcutKey)
             self.LayoutMenuShortCut = ShortcutKey
         # Add the preference button
-        PreferenceButton = RibbonMenu.addAction(
-            translate("FreeCAD Ribbon", "Preferences")
-        )
-        PreferenceButton.setToolTip(
-            translate("FreeCAD Ribbon", "Set preferences for the Ribbon UI")
-        )
+        PreferenceButton = RibbonMenu.addAction(translate("FreeCAD Ribbon", "Preferences"))
+        PreferenceButton.setToolTip(translate("FreeCAD Ribbon", "Set preferences for the Ribbon UI"))
         PreferenceButton.setMenuRole(QAction.MenuRole.NoRole)
         PreferenceButton.triggered.connect(self.loadSettingsMenu)
         ShortcutKey = "Alt+P"
         try:
-            CustomShortCuts = App.ParamGet(
-                "User parameter:BaseApp/Preferences/Shortcut"
-            )
+            CustomShortCuts = App.ParamGet("User parameter:BaseApp/Preferences/Shortcut")
             if "Ribbon_Preferences" in CustomShortCuts.GetStrings():
                 ShortcutKey = CustomShortCuts.GetString("Ribbon_Preferences")
         except Exception:
@@ -1821,12 +1565,8 @@ class ModernMenu(RibbonBar):
         if os.path.exists(ScriptDir) is True:
             ListScripts = os.listdir(ScriptDir)
             if len(ListScripts) > 0:
-                ScriptButtonMenu = RibbonMenu.addMenu(
-                    translate("FreeCAD Ribbon", "Scripts")
-                )
-                ScriptButtonMenu.setToolTip(
-                    translate("FreeCAD Ribbon", "Scripts to help setup the ribbon.")
-                )
+                ScriptButtonMenu = RibbonMenu.addMenu(translate("FreeCAD Ribbon", "Scripts"))
+                ScriptButtonMenu.setToolTip(translate("FreeCAD Ribbon", "Scripts to help setup the ribbon."))
                 for i in range(len(ListScripts)):
                     ScriptButtonMenu.addAction(
                         ListScripts[i],
@@ -1858,11 +1598,7 @@ class ModernMenu(RibbonBar):
 
         # Add the ribbon helpbutton under the FreeCAD
         RibbonHelpButton = QAction(translate("FreeCAD Ribbon", "Ribbon UI help"))
-        RibbonHelpButton.setToolTip(
-            translate(
-                "FreeCAD Ribbon", "Open the help page for the Ribbon UI in your browser"
-            )
-        )
+        RibbonHelpButton.setToolTip(translate("FreeCAD Ribbon", "Open the help page for the Ribbon UI in your browser"))
         RibbonHelpButton.setIcon(HelpIcon)
         RibbonHelpButton.triggered.connect(self.on_RibbonHelpButton_clicked)
         HelpMenu.insertAction(actions[1], RibbonHelpButton)
@@ -1885,15 +1621,11 @@ class ModernMenu(RibbonBar):
         PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
         version = StandardFunctions.ReturnXML_Value(PackageXML, "version")
         # Create the ribbon about button
-        AboutButton_Ribbon = AboutMenu.addAction(
-            translate("FreeCAD Ribbon", "About Ribbon UI ") + version
-        )
+        AboutButton_Ribbon = AboutMenu.addAction(translate("FreeCAD Ribbon", "About Ribbon UI ") + version)
         AboutButton_Ribbon.setIcon(AboutIcon)
         AboutButton_Ribbon.triggered.connect(self.on_AboutButton_clicked)
         # Create the what's new button
-        WhatsNewButton_Ribbon = AboutMenu.addAction(
-            translate("FreeCAD Ribbon", "What's new?")
-        )
+        WhatsNewButton_Ribbon = AboutMenu.addAction(translate("FreeCAD Ribbon", "What's new?"))
         WhatsNewButton_Ribbon.triggered.connect(self.on_WhatsNewButton_clicked)
         # add the aboutmenu to the help menu
         HelpMenu.addMenu(AboutMenu)
@@ -1940,9 +1672,7 @@ class ModernMenu(RibbonBar):
             Parameters_Ribbon.Settings.SetBoolSetting("AutoHideRibbon", True)
             Parameters_Ribbon.AUTOHIDE_RIBBON = True
 
-            pinButton: QToolButton = self.rightToolBar().findChildren(
-                QToolButton, "Pin Ribbon"
-            )[0]
+            pinButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "Pin Ribbon")[0]
             pinButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed"))
 
             # Make sure that the ribbon remains visible
@@ -1954,9 +1684,7 @@ class ModernMenu(RibbonBar):
             Parameters_Ribbon.Settings.SetBoolSetting("AutoHideRibbon", False)
             Parameters_Ribbon.AUTOHIDE_RIBBON = False
 
-            pinButton: QToolButton = self.rightToolBar().findChildren(
-                QToolButton, "Pin Ribbon"
-            )[0]
+            pinButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "Pin Ribbon")[0]
             pinButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_open"))
 
             # Make sure that the ribbon remains visible
@@ -2001,9 +1729,7 @@ class ModernMenu(RibbonBar):
         # Set the text color depending in tabstyle
         if Parameters_Ribbon.TABBAR_STYLE != 1:
             self.tabBar().setStyleSheet(
-                "QTabBar::tab {color: "
-                + StyleMapping_Ribbon.ReturnStyleItem("FontColor")
-                + ";}"
+                "QTabBar::tab {color: " + StyleMapping_Ribbon.ReturnStyleItem("FontColor") + ";}"
             )
         if Parameters_Ribbon.TABBAR_STYLE == 1:
             self.tabBar().setStyleSheet(
@@ -2084,20 +1810,16 @@ class ModernMenu(RibbonBar):
         # Get the custom panels and add them to the list of toolbars
         try:
             if workbenchName in self.ribbonStructure["customToolbars"]:
-                for CustomPanel in self.ribbonStructure["customToolbars"][
-                    workbenchName
-                ]:
+                for CustomPanel in self.ribbonStructure["customToolbars"][workbenchName]:
                     ListToolbars.append(CustomPanel)
 
                     # remove the original toolbars from the list
-                    Commands = self.ribbonStructure["customToolbars"][workbenchName][
-                        CustomPanel
-                    ]["commands"]
+                    Commands = self.ribbonStructure["customToolbars"][workbenchName][CustomPanel]["commands"]
                     for Command in Commands:
                         try:
-                            OriginalToolbar = self.ribbonStructure["customToolbars"][
-                                workbenchName
-                            ][CustomPanel]["commands"][Command]
+                            OriginalToolbar = self.ribbonStructure["customToolbars"][workbenchName][CustomPanel][
+                                "commands"
+                            ][Command]
                             ListToolbars.remove(OriginalToolbar)
                         except Exception:
                             continue
@@ -2117,9 +1839,7 @@ class ModernMenu(RibbonBar):
 
         try:
             # Get the order of toolbars
-            ToolbarOrder: list = self.ribbonStructure["workbenches"][workbenchName][
-                "toolbars"
-            ]["order"]
+            ToolbarOrder: list = self.ribbonStructure["workbenches"][workbenchName]["toolbars"]["order"]
 
             # Sort the list of toolbars according the toolbar order
             def SortToolbars(toolbar):
@@ -2183,51 +1903,30 @@ class ModernMenu(RibbonBar):
 
             # add separators to the command list.
             if workbenchName in self.ribbonStructure["workbenches"]:
-                if (
-                    toolbar != ""
-                    and toolbar
-                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
-                ):
-                    if (
-                        "order"
-                        in self.ribbonStructure["workbenches"][workbenchName][
-                            "toolbars"
-                        ][toolbar]
-                    ):
+                if toolbar != "" and toolbar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]:
+                    if "order" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]:
                         for j in range(
-                            len(
-                                self.ribbonStructure["workbenches"][workbenchName][
-                                    "toolbars"
-                                ][toolbar]["order"]
-                            )
+                            len(self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"])
                         ):
                             if (
                                 "separator"
-                                in self.ribbonStructure["workbenches"][workbenchName][
-                                    "toolbars"
-                                ][toolbar]["order"][j].lower()
+                                in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"][
+                                    j
+                                ].lower()
                             ):
                                 separator = QToolButton()
                                 separator.setText(
-                                    self.ribbonStructure["workbenches"][workbenchName][
-                                        "toolbars"
-                                    ][toolbar]["order"][j]
+                                    self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"][j]
                                 )
                                 allButtons.insert(j, separator)
 
             if workbenchName in self.ribbonStructure["workbenches"]:
                 # order buttons like defined in ribbonStructure
                 if (
-                    toolbar
-                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
-                    and "order"
-                    in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][
-                        toolbar
-                    ]
+                    toolbar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]
+                    and "order" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]
                 ):
-                    OrderList: list = self.ribbonStructure["workbenches"][
-                        workbenchName
-                    ]["toolbars"][toolbar]["order"]
+                    OrderList: list = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["order"]
 
                     # XXX check that positionsList consists of strings only
                     def sortButtons(button: QToolButton):
@@ -2236,9 +1935,7 @@ class ModernMenu(RibbonBar):
                         # Get the menu text
                         if len(button.actions()) > 0:
                             action = button.actions()[0]
-                            Text = StandardFunctions.CommandInfoCorrections(
-                                action.data()
-                            )["menuText"]
+                            Text = StandardFunctions.CommandInfoCorrections(action.data())["menuText"]
 
                         if Text == "":
                             return -1
@@ -2258,8 +1955,12 @@ class ModernMenu(RibbonBar):
                 []
             )  # if buttons are used in multiple workbenches, they can show up double. (Sketcher_NewSketch)
             # for button in allButtons:
-            NoSmallButtons_spacer = 0  # needed to count the number of small buttons in a column. (bug fix with adding separators)
-            NoMediumButtons_spacer = 0  # needed to count the number of medium buttons in a column. (bug fix with adding separators)
+            NoSmallButtons_spacer = (
+                0  # needed to count the number of small buttons in a column. (bug fix with adding separators)
+            )
+            NoMediumButtons_spacer = (
+                0  # needed to count the number of medium buttons in a column. (bug fix with adding separators)
+            )
 
             # Define number of rows used per button size
             LargeButtonRows = 3
@@ -2282,9 +1983,9 @@ class ModernMenu(RibbonBar):
                 buttonSize = "small"
                 try:
                     action = button.defaultAction()
-                    buttonSize = self.ribbonStructure["workbenches"][workbenchName][
-                        "toolbars"
-                    ][toolbar]["commands"][action.data()]["size"]
+                    buttonSize = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar]["commands"][
+                        action.data()
+                    ]["size"]
                     if buttonSize == "small":
                         NoSmallButtons_spacer += 1
                     if buttonSize == "medium":
@@ -2375,28 +2076,22 @@ class ModernMenu(RibbonBar):
                             try:
                                 # If the text is not from a hardcoded dropdown:
                                 if len(action.data().split(", ")) <= 1:
-                                    text = StandardFunctions.CommandInfoCorrections(
-                                        action.data()
-                                    )["ActionText"]
+                                    text = StandardFunctions.CommandInfoCorrections(action.data())["ActionText"]
                             except Exception:
                                 pass
 
                             # try to get alternative text from ribbonStructure
                             try:
-                                textJSON = self.ribbonStructure["workbenches"][
-                                    workbenchName
-                                ]["toolbars"][toolbar]["commands"][action.data()][
-                                    "text"
-                                ]
+                                textJSON = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                    "commands"
+                                ][action.data()]["text"]
 
                                 # There is a bug in freecad with the comp-sketch menu hase the wrong text
                                 if (
                                     action.data() == "PartDesign_CompSketches"
-                                    and self.ribbonStructure["workbenches"][
-                                        workbenchName
-                                    ]["toolbars"][toolbar]["commands"][action.data()][
-                                        "text"
-                                    ]
+                                    and self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                        "commands"
+                                    ][action.data()]["text"]
                                     == "Create datum"
                                 ):
                                     textJSON = "Create sketch"
@@ -2407,19 +2102,13 @@ class ModernMenu(RibbonBar):
                                     # if it is a normal command:
                                     if len(action.data().split(", ")) <= 1:
                                         Command = Gui.Command.get(CommandName)
-                                        MenuName = CommandInfoCorrections(CommandName)[
-                                            "menuText"
-                                        ].replace("&", "")
+                                        MenuName = CommandInfoCorrections(CommandName)["menuText"].replace("&", "")
                                         if CommandName == action.data():
                                             if (
                                                 MenuName
-                                                != self.ribbonStructure["workbenches"][
-                                                    workbenchName
-                                                ]["toolbars"][toolbar]["commands"][
-                                                    action.data()
-                                                ][
-                                                    "text"
-                                                ]
+                                                != self.ribbonStructure["workbenches"][workbenchName]["toolbars"][
+                                                    toolbar
+                                                ]["commands"][action.data()]["text"]
                                                 and MenuName != ""
                                                 and textJSON != ""
                                             ):
@@ -2429,13 +2118,9 @@ class ModernMenu(RibbonBar):
                                         MenuName = action.text()
                                         if (
                                             MenuName
-                                            != self.ribbonStructure["workbenches"][
-                                                workbenchName
-                                            ]["toolbars"][toolbar]["commands"][
-                                                action.data()
-                                            ][
-                                                "text"
-                                            ]
+                                            != self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                                "commands"
+                                            ][action.data()]["text"]
                                             and MenuName != ""
                                             and textJSON != ""
                                         ):
@@ -2460,9 +2145,9 @@ class ModernMenu(RibbonBar):
                                 CommandName = button.text()
 
                             try:
-                                pixmap = self.ribbonStructure["workbenches"][
-                                    workbenchName
-                                ]["toolbars"][toolbar]["commands"][CommandName]["icon"]
+                                pixmap = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                    "commands"
+                                ][CommandName]["icon"]
                             except Exception:
                                 pass
                             actionIcon = self.ReturnCommandIcon(action.data(), pixmap)
@@ -2471,24 +2156,18 @@ class ModernMenu(RibbonBar):
 
                             # try to get alternative icon from ribbonStructure
                             try:
-                                icon_Json = self.ribbonStructure["workbenches"][
-                                    workbenchName
-                                ]["toolbars"][toolbar]["commands"][CommandName]["icon"]
+                                icon_Json = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                    "commands"
+                                ][CommandName]["icon"]
                                 if icon_Json != "":
                                     action.setIcon(Gui.getIcon(icon_Json))
                             except KeyError:
                                 pass
 
                             # If the icon is still none, try to retrieve it from the data file
-                            if action.icon() is None or (
-                                action.icon() is not None and action.icon().isNull()
-                            ):
-                                StandardFunctions.Print(
-                                    f"An icon retrieved from data file for '{CommandName}'"
-                                )
-                                DataFile = os.path.join(
-                                    os.path.dirname(__file__), "RibbonDataFile.dat"
-                                )
+                            if action.icon() is None or (action.icon() is not None and action.icon().isNull()):
+                                StandardFunctions.Print(f"An icon retrieved from data file for '{CommandName}'")
+                                DataFile = os.path.join(os.path.dirname(__file__), "RibbonDataFile.dat")
 
                                 if os.path.exists(DataFile) is True:
                                     Data = {}
@@ -2502,11 +2181,7 @@ class ModernMenu(RibbonBar):
                                             # This works only for FreeCAD Commands
                                             CommandName_Icon = action.data()
                                             if CommandName_Icon == IconItem[0]:
-                                                Icon: QIcon = (
-                                                    Serialize_Ribbon.deserializeIcon(
-                                                        IconItem[1]
-                                                    )
-                                                )
+                                                Icon: QIcon = Serialize_Ribbon.deserializeIcon(IconItem[1])
                                                 action.setIcon(Icon)
                                     except Exception as e:
                                         if Parameters_Ribbon.DEBUG_MODE is True:
@@ -2518,9 +2193,9 @@ class ModernMenu(RibbonBar):
 
                             # get button size from ribbonStructure
                             try:
-                                buttonSize = self.ribbonStructure["workbenches"][
-                                    workbenchName
-                                ]["toolbars"][toolbar]["commands"][CommandName]["size"]
+                                buttonSize = self.ribbonStructure["workbenches"][workbenchName]["toolbars"][toolbar][
+                                    "commands"
+                                ][CommandName]["size"]
                                 if buttonSize == "":
                                     buttonSize = "small"
                             except KeyError:
@@ -2537,10 +2212,7 @@ class ModernMenu(RibbonBar):
                             action.setText(action.text().replace("&", ""))
                             if buttonSize == "small":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_SMALL
-                                if (
-                                    IconOnly is True
-                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
-                                ):
+                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2579,10 +2251,7 @@ class ModernMenu(RibbonBar):
 
                             elif buttonSize == "medium":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_MEDIUM
-                                if (
-                                    IconOnly is True
-                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
-                                ):
+                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2619,10 +2288,7 @@ class ModernMenu(RibbonBar):
                                 )  # Set fixedheight to false. This is set in the custom widgets
                             elif buttonSize == "large":
                                 showText = Parameters_Ribbon.SHOW_ICON_TEXT_LARGE
-                                if (
-                                    IconOnly is True
-                                    or Parameters_Ribbon.USE_FC_OVERLAY is True
-                                ):
+                                if IconOnly is True or Parameters_Ribbon.USE_FC_OVERLAY is True:
                                     showText = False
 
                                 # Create a custom toolbutton
@@ -2660,23 +2326,17 @@ class ModernMenu(RibbonBar):
                             else:
                                 if Parameters_Ribbon.DEBUG_MODE is True:
                                     if buttonSize != "none":
-                                        print(
-                                            f"{action.text()} is ignored. Its size was: {buttonSize}"
-                                        )
+                                        print(f"{action.text()} is ignored. Its size was: {buttonSize}")
                                 pass
 
                             if btn.menu() is not None:
-                                btn.popupMode(
-                                    QToolButton.ToolButtonPopupMode.MenuButtonPopup
-                                )
+                                btn.popupMode(QToolButton.ToolButtonPopupMode.MenuButtonPopup)
 
                             # Set the background always to background color.
                             # Styling is managed in the custom button class
                             StyleSheet_Addition_Button = (
                                 "QToolButton, QToolButton:hover {background-color: "
-                                + StyleMapping_Ribbon.ReturnStyleItem(
-                                    "Background_Color"
-                                )
+                                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color")
                                 + ";border: none"
                                 + ";}"
                             )
@@ -2691,10 +2351,7 @@ class ModernMenu(RibbonBar):
                             continue
 
             # Change the name of the view panels to "View"
-            if (
-                panel.title() in "Views - Ribbon_newPanel"
-                or panel.title() in "Individual views"
-            ):
+            if panel.title() in "Views - Ribbon_newPanel" or panel.title() in "Individual views":
                 panel.setTitle(" Views ")
             else:
                 # Remove possible workbench names from the titles
@@ -2734,9 +2391,7 @@ class ModernMenu(RibbonBar):
             actionList = []
             for i in range(len(ButtonList)):
                 button = ButtonList[i]
-                StyleSheet_Menu = (
-                    "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
-                )
+                StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
                 button.setStyleSheet(StyleSheet_Menu)
                 if len(button.actions()) == 1:
                     actionList.append(button.actions()[0])
@@ -2744,20 +2399,14 @@ class ModernMenu(RibbonBar):
                     actionList.append(button.actions())
             OptionButton = panel.panelOptionButton()
             if len(actionList) > 0:
-                Menu = CustomControls.CustomOptionMenu(
-                    OptionButton.menu(), actionList, self
-                )
+                Menu = CustomControls.CustomOptionMenu(OptionButton.menu(), actionList, self)
                 OptionButton.setMenu(Menu)
-                StyleSheet_Menu = (
-                    "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
-                )
+                StyleSheet_Menu = "* {font-size: " + str(Parameters_Ribbon.FONTSIZE_MENUS) + "px;}"
                 Menu.setStyleSheet(StyleSheet_Menu)
                 # Set the behavior of the option button
                 OptionButton.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
                 # Remove the image to avoid double arrows
-                OptionButton.setStyleSheet(
-                    "RibbonPanelOptionButton::menu-indicator {image: none;}"
-                )
+                OptionButton.setStyleSheet("RibbonPanelOptionButton::menu-indicator {image: none;}")
                 Menu = OptionButton.menu()
 
                 # Set the icon
@@ -2766,9 +2415,7 @@ class ModernMenu(RibbonBar):
                     OptionButton.setIcon(OptionButton_Icon)
                 else:
                     OptionButton.setArrowType(Qt.ArrowType.DownArrow)
-                    OptionButton.setToolButtonStyle(
-                        Qt.ToolButtonStyle.ToolButtonTextBesideIcon
-                    )
+                    OptionButton.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
                     OptionButton.setText("more...")
             if len(actionList) == 0:
                 panel.panelOptionButton().hide()
@@ -2777,21 +2424,13 @@ class ModernMenu(RibbonBar):
 
         # Set the previous/next buttons
         category = self.currentCategory()
-        ScrollLeftButton_Category: RibbonCategoryLayoutButton = category.findChildren(
-            RibbonCategoryLayoutButton
-        )[0]
-        ScrollRightButton_Category: RibbonCategoryLayoutButton = category.findChildren(
-            RibbonCategoryLayoutButton
-        )[1]
+        ScrollLeftButton_Category: RibbonCategoryLayoutButton = category.findChildren(RibbonCategoryLayoutButton)[0]
+        ScrollRightButton_Category: RibbonCategoryLayoutButton = category.findChildren(RibbonCategoryLayoutButton)[1]
         ScrollLeftButton_Category.setMinimumWidth(self.iconSize * 0.5)
         ScrollRightButton_Category.setMinimumWidth(self.iconSize * 0.5)
         # get the icons
-        ScrollLeftButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem(
-            "ScrollLeftButton_Category"
-        )
-        ScrollRightButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem(
-            "ScrollRightButton_Category"
-        )
+        ScrollLeftButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category")
+        ScrollRightButton_Category_Icon = StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category")
         # Set the icons
         if ScrollLeftButton_Category_Icon is not None:
             ScrollLeftButton_Category.setIcon(ScrollLeftButton_Category_Icon)
@@ -2805,37 +2444,23 @@ class ModernMenu(RibbonBar):
         ScrollLeftButton_Category.setFixedHeight(Parameters_Ribbon.ICON_SIZE_SMALL * 3)
         ScrollRightButton_Category.setFixedHeight(Parameters_Ribbon.ICON_SIZE_SMALL * 3)
         # Set the stylesheet
-        ScrollLeftButton_Category.setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton")
-        )
-        ScrollRightButton_Category.setStyleSheet(
-            StyleMapping_Ribbon.ReturnStyleSheet("toolbutton")
-        )
+        ScrollLeftButton_Category.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton"))
+        ScrollRightButton_Category.setStyleSheet(StyleMapping_Ribbon.ReturnStyleSheet("toolbutton"))
         # Connect the custom click event
-        ScrollLeftButton_Category.mousePressEvent = (
-            lambda clickLeft: self.on_ScrollButton_Category_clicked(
-                clickLeft, ScrollLeftButton_Category
-            )
+        ScrollLeftButton_Category.mousePressEvent = lambda clickLeft: self.on_ScrollButton_Category_clicked(
+            clickLeft, ScrollLeftButton_Category
         )
-        ScrollRightButton_Category.mousePressEvent = (
-            lambda clickRight: self.on_ScrollButton_Category_clicked(
-                clickRight, ScrollRightButton_Category
-            )
+        ScrollRightButton_Category.mousePressEvent = lambda clickRight: self.on_ScrollButton_Category_clicked(
+            clickRight, ScrollRightButton_Category
         )
 
         # Set the maximum height to a high value to prevent from the ribbon to be clipped off
-        self.currentCategory().setMinimumHeight(
-            self.RibbonHeight - self.RibbonMinimalHeight - 3
-        )
-        self.currentCategory().setMaximumHeight(
-            self.RibbonHeight - self.RibbonMinimalHeight - 3
-        )
+        self.currentCategory().setMinimumHeight(self.RibbonHeight - self.RibbonMinimalHeight - 3)
+        self.currentCategory().setMaximumHeight(self.RibbonHeight - self.RibbonMinimalHeight - 3)
         self.setRibbonHeight(self.RibbonHeight)
         return
 
-    def on_ScrollButton_Category_clicked(
-        self, event, ScrollButton: RibbonCategoryLayoutButton
-    ):
+    def on_ScrollButton_Category_clicked(self, event, ScrollButton: RibbonCategoryLayoutButton):
         for i in range(Parameters_Ribbon.RIBBON_CLICKSPEED):
             ScrollButton.click()
         return
@@ -2856,10 +2481,7 @@ class ModernMenu(RibbonBar):
             parentWidget = toolbar.parentWidget()
             toolbar.setHidden(True)
             # hide toolbars that are not in the statusBar and show toolbars that are in the statusbar.
-            if (
-                parentWidget.objectName() == "statusBar"
-                or parentWidget.objectName() == "StatusBarArea"
-            ):
+            if parentWidget.objectName() == "statusBar" or parentWidget.objectName() == "StatusBarArea":
                 toolbar.setEnabled(True)
                 toolbar.setVisible(True)
             # # # Show specific toolbars and go to the next
@@ -2883,11 +2505,7 @@ class ModernMenu(RibbonBar):
         return
 
     def FoldRibbon(self, Ignore=False):
-        if (
-            Parameters_Ribbon.AUTOHIDE_RIBBON is True
-            and self.isLoaded is True
-            and Ignore is False
-        ):
+        if Parameters_Ribbon.AUTOHIDE_RIBBON is True and self.isLoaded is True and Ignore is False:
             if len(mw.findChildren(QDockWidget, "Ribbon")) > 0:
                 TB: QDockWidget = mw.findChildren(QDockWidget, "Ribbon")[0]
                 TB.setMinimumHeight(self.RibbonMinimalHeight)
@@ -2907,10 +2525,7 @@ class ModernMenu(RibbonBar):
 
                     for Group in CustomToolbars:
                         Parameter = App.ParamGet(
-                            "User parameter:BaseApp/Workbench/"
-                            + WorkBenchName
-                            + "/Toolbar/"
-                            + Group
+                            "User parameter:BaseApp/Workbench/" + WorkBenchName + "/Toolbar/" + Group
                         )
                         Name = Parameter.GetString("Name")
                         Toolbars.append([Name, WorkBenchName])
@@ -2919,14 +2534,10 @@ class ModernMenu(RibbonBar):
 
     def List_ReturnCustomToolbars_Global(self):
         Toolbars = []
-        CustomToolbars: list = App.ParamGet(
-            "User parameter:BaseApp/Workbench/Global/Toolbar"
-        ).GetGroups()
+        CustomToolbars: list = App.ParamGet("User parameter:BaseApp/Workbench/Global/Toolbar").GetGroups()
 
         for Group in CustomToolbars:
-            Parameter = App.ParamGet(
-                "User parameter:BaseApp/Workbench/Global/Toolbar/" + Group
-            )
+            Parameter = App.ParamGet("User parameter:BaseApp/Workbench/Global/Toolbar/" + Group)
             Name = Parameter.GetString("Name")
             Toolbars.append([Name, "Global"])
 
@@ -2937,9 +2548,7 @@ class ModernMenu(RibbonBar):
 
         try:
             # Get the commands from the custom panel
-            Commands = self.ribbonStructure["customToolbars"][WorkBenchName][
-                CustomToolbar
-            ]["commands"]
+            Commands = self.ribbonStructure["customToolbars"][WorkBenchName][CustomToolbar]["commands"]
 
             # Get the command and its original toolbar
             for key, value in list(Commands.items()):
@@ -2948,9 +2557,7 @@ class ModernMenu(RibbonBar):
                     # Get the english menutext
                     MenuName = CommandInfoCorrections(CommandName)["menuText"]
                     # Get the translated menutext
-                    MenuNameTtranslated = CommandInfoCorrections(CommandName)[
-                        "ActionText"
-                    ]
+                    MenuNameTtranslated = CommandInfoCorrections(CommandName)["ActionText"]
 
                     if MenuName == key:
                         try:
@@ -2965,16 +2572,11 @@ class ModernMenu(RibbonBar):
                                     if Toolbutton.text() == Child.text():
                                         IsInList = True
 
-                                if (
-                                    Child.text() == MenuNameTtranslated
-                                    and IsInList is False
-                                ):
+                                if Child.text() == MenuNameTtranslated and IsInList is False:
                                     ButtonList.append(Child)
                         except Exception as e:
                             if Parameters_Ribbon.DEBUG_MODE is True:
-                                StandardFunctions.Print(
-                                    f"{e.with_traceback(e.__traceback__)}, 3", "Warning"
-                                )
+                                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}, 3", "Warning")
                             continue
         except Exception:
             pass
@@ -2988,9 +2590,7 @@ class ModernMenu(RibbonBar):
             if WorkBenchName in self.ribbonStructure["newPanels"]:
                 if NewPanel in self.ribbonStructure["newPanels"][WorkBenchName]:
                     # Get the commands from the custom panel
-                    Commands = self.ribbonStructure["newPanels"][WorkBenchName][
-                        NewPanel
-                    ]
+                    Commands = self.ribbonStructure["newPanels"][WorkBenchName][NewPanel]
 
                     # Get the command and its original toolbar
                     for CommandItem in Commands:
@@ -3009,9 +2609,7 @@ class ModernMenu(RibbonBar):
                                     CommandActionList = Command.getAction()
                                 if Command is None:
                                     if Parameters_Ribbon.DEBUG_MODE is True:
-                                        StandardFunctions.Print(
-                                            f"{CommandName} was None", "Warning"
-                                        )
+                                        StandardFunctions.Print(f"{CommandName} was None", "Warning")
                             # If the commandname can be splitted, it is a FreeCAD dropdown
                             if len(CommandName.split(", ")) > 1:
                                 CommandActionList = self.LoadDropDownAction(CommandName)
@@ -3022,14 +2620,10 @@ class ModernMenu(RibbonBar):
                                 # if there is only one action, add it directly
                                 if len(CommandActionList) == 1:
                                     NewToolbutton.addAction(CommandActionList[0])
-                                    NewToolbutton.setDefaultAction(
-                                        NewToolbutton.actions()[0]
-                                    )
+                                    NewToolbutton.setDefaultAction(NewToolbutton.actions()[0])
                                     # If the commandname is from a FreeCAD dropdown, set the commandname as text
                                     if len(CommandName.split(", ")) > 1:
-                                        NewToolbutton.setText(
-                                            NewToolbutton.actions()[0].text()
-                                        )
+                                        NewToolbutton.setText(NewToolbutton.actions()[0].text())
                                 # if there are more actions, create a menu
                                 elif len(CommandActionList) > 1:
                                     menu = QMenu()
@@ -3047,9 +2641,7 @@ class ModernMenu(RibbonBar):
                                 # Set the text for the toolbutton
                                 if len(CommandName.split(", ")) <= 1:
                                     NewToolbutton.setText(
-                                        CommandInfoCorrections(CommandName)[
-                                            "menuText"
-                                        ].replace("&", "")
+                                        CommandInfoCorrections(CommandName)["menuText"].replace("&", "")
                                     )
                                 # # If the commandname is from a FreeCAD dropdown, set the commandname as text
                                 # if len(CommandName.split(", ")) > 1:
@@ -3066,9 +2658,7 @@ class ModernMenu(RibbonBar):
                                 # if there is only one action, add it directly
                                 if len(CommandActionList) == 1:
                                     NewToolbutton.addAction(CommandActionList[0])
-                                    NewToolbutton.setDefaultAction(
-                                        NewToolbutton.actions()[0]
-                                    )
+                                    NewToolbutton.setDefaultAction(NewToolbutton.actions()[0])
                                 # if there are more actions, create a menu
                                 if len(CommandActionList) > 1:
                                     menu = QMenu()
@@ -3091,9 +2681,7 @@ class ModernMenu(RibbonBar):
 
         except Exception as e:
             if Parameters_Ribbon.DEBUG_MODE is True:
-                StandardFunctions.Print(
-                    f"{e.with_traceback(e.__traceback__)}, 4", "Warning"
-                )
+                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}, 4", "Warning")
             pass
         return ButtonList
 
@@ -3134,14 +2722,12 @@ class ModernMenu(RibbonBar):
         # Check whichs is has the most height: 3 small buttons, 2 medium buttons or 1 large button
         # and set the height accordingly
         if (
-            Parameters_Ribbon.ICON_SIZE_SMALL * 3
-            >= Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
+            Parameters_Ribbon.ICON_SIZE_SMALL * 3 >= Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
             and Parameters_Ribbon.ICON_SIZE_SMALL * 3 >= LargeButtonHeight
         ):
             ribbonHeight = ribbonHeight + Parameters_Ribbon.ICON_SIZE_SMALL * 3 + 6
         elif (
-            Parameters_Ribbon.ICON_SIZE_MEDIUM * 2
-            >= Parameters_Ribbon.ICON_SIZE_SMALL * 3
+            Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 >= Parameters_Ribbon.ICON_SIZE_SMALL * 3
             and Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 >= LargeButtonHeight
         ):
             ribbonHeight = ribbonHeight + Parameters_Ribbon.ICON_SIZE_MEDIUM * 2 + 4
@@ -3254,18 +2840,10 @@ class ModernMenu(RibbonBar):
             Enable = False
 
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
-        )
-        OverlayParam_Right = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
-        )
-        OverlayParam_Top = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayTop"
-        )
-        OverlayParam_Bottom = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
-        )
+        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
+        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
+        OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
+        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
 
         # If overlay is enabled, go here
         PanelsLeft = []
@@ -3348,16 +2926,10 @@ class ModernMenu(RibbonBar):
         OverlayParam_Right = None
         OverlayParam_Bottom = None
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
-        )
-        OverlayParam_Right = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
-        )
+        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
+        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
-        )
+        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
 
         # Ge the focused dockwidget
         FocusWidget = mw.focusWidget().parent().objectName()
@@ -3403,32 +2975,22 @@ class ModernMenu(RibbonBar):
             RightPanels = OverlayParam_Right.GetString("Widgets")
             if FocusWidget in RightPanels:
                 RightPanels = OverlayParam_Left.GetString("Widgets")
-                RightPanels = RightPanels.replace(f"{FocusWidget}", "").replace(
-                    ",,", ","
-                )
+                RightPanels = RightPanels.replace(f"{FocusWidget}", "").replace(",,", ",")
                 OverlayParam_Right.SetString("Widgets", f"{RightPanels}")
                 return
             BottomPanels = OverlayParam_Bottom.GetString("Widgets")
             if FocusWidget in BottomPanels:
                 BottomPanels = OverlayParam_Bottom.GetString("Widgets")
-                BottomPanels = BottomPanels.replace(f"{FocusWidget}", "").replace(
-                    ",,", ","
-                )
+                BottomPanels = BottomPanels.replace(f"{FocusWidget}", "").replace(",,", ",")
                 OverlayParam_Bottom.SetString("Widgets", f"{BottomPanels}")
                 return
         return
 
     def CustomTransparancy(self):
-        OverlayParam_Left = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
-        )
-        OverlayParam_Right = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
-        )
+        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
+        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
-        )
+        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
 
         Enable = None
         if OverlayParam_Left.GetBool("Transparent") is False:
@@ -3450,16 +3012,10 @@ class ModernMenu(RibbonBar):
         OverlayParam_Right = None
         OverlayParam_Bottom = None
         # Get the different overlay areas
-        OverlayParam_Left = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
-        )
-        OverlayParam_Right = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayRight"
-        )
+        OverlayParam_Left = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft")
+        OverlayParam_Right = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayRight")
         # OverlayParam_Top = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayTop")
-        OverlayParam_Bottom = App.ParamGet(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom"
-        )
+        OverlayParam_Bottom = App.ParamGet("User parameter:BaseApp/MainWindow/DockWindows/OverlayBottom")
 
         # Ge the focused dockwidget
         FocusWidget = mw.focusWidget().parent().objectName()
@@ -3485,21 +3041,15 @@ class ModernMenu(RibbonBar):
         if position == "":
             LeftPanels = OverlayParam_Left.GetString("Widgets")
             if FocusWidget in LeftPanels:
-                OverlayParam_Left.SetBool(
-                    "Transparent", not OverlayParam_Left.GetBool("Transparent")
-                )
+                OverlayParam_Left.SetBool("Transparent", not OverlayParam_Left.GetBool("Transparent"))
                 return
             RightPanels = OverlayParam_Right.GetString("Widgets")
             if FocusWidget in RightPanels:
-                OverlayParam_Right.SetBool(
-                    "Transparent", not OverlayParam_Right.GetBool("Transparent")
-                )
+                OverlayParam_Right.SetBool("Transparent", not OverlayParam_Right.GetBool("Transparent"))
                 return
             BottomPanels = OverlayParam_Bottom.GetString("Widgets")
             if FocusWidget in BottomPanels:
-                OverlayParam_Bottom.SetBool(
-                    "Transparent", not OverlayParam_Bottom.GetBool("Transparent")
-                )
+                OverlayParam_Bottom.SetBool("Transparent", not OverlayParam_Bottom.GetBool("Transparent"))
                 return
         return
 
@@ -3507,9 +3057,7 @@ class ModernMenu(RibbonBar):
         actionList = []
 
         try:
-            for DropDownCommand, Commands in self.ribbonStructure[
-                "dropdownButtons"
-            ].items():
+            for DropDownCommand, Commands in self.ribbonStructure["dropdownButtons"].items():
                 if CommandName == DropDownCommand:
                     for CommandItem in Commands:
                         Command = Gui.Command.get(CommandItem[0])
@@ -3520,9 +3068,7 @@ class ModernMenu(RibbonBar):
             return actionList
         except Exception as e:
             if Parameters_Ribbon.DEBUG_MODE is True:
-                StandardFunctions.Print(
-                    f"{e.with_traceback(e.__traceback__)}", "Warning"
-                )
+                StandardFunctions.Print(f"{e.with_traceback(e.__traceback__)}", "Warning")
             return
 
     def CloseFreeCAD(self):
@@ -3538,9 +3084,7 @@ class ModernMenu(RibbonBar):
         # if self.isLoaded:
         StatusBarState = mw.findChild(QStatusBar, "statusBar").isVisible()
         # Get the style and restore button
-        RestoreButton: QToolButton = self.rightToolBar().findChildren(
-            QToolButton, "RestoreButton"
-        )[0]
+        RestoreButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
         # If the mainwindow is maximized, set the mainwindow to normal, set a size and icon
         if mw.isMaximized() is True:
             try:
@@ -3628,27 +3172,18 @@ class ModernMenu(RibbonBar):
 
     def CheckLanguage(self):
         FreeCAD_preferences = App.ParamGet("User parameter:BaseApp/Preferences/General")
-        if self.ribbonStructure["language"] != FreeCAD_preferences.GetString(
-            "Language"
-        ):
+        if self.ribbonStructure["language"] != FreeCAD_preferences.GetString("Language"):
             if "workbenches" in self.ribbonStructure:
                 for workbenchName in self.ribbonStructure["workbenches"]:
                     if "toolbars" in self.ribbonStructure["workbenches"][workbenchName]:
-                        for ToolBar in self.ribbonStructure["workbenches"][
-                            workbenchName
-                        ]["toolbars"]:
-                            if (
-                                "commands"
-                                in self.ribbonStructure["workbenches"][workbenchName][
-                                    "toolbars"
-                                ][ToolBar]
-                            ):
-                                for Command in self.ribbonStructure["workbenches"][
-                                    workbenchName
-                                ]["toolbars"][ToolBar]["commands"]:
-                                    self.ribbonStructure["workbenches"][workbenchName][
-                                        "toolbars"
-                                    ][ToolBar]["commands"][Command]["text"] = ""
+                        for ToolBar in self.ribbonStructure["workbenches"][workbenchName]["toolbars"]:
+                            if "commands" in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar]:
+                                for Command in self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar][
+                                    "commands"
+                                ]:
+                                    self.ribbonStructure["workbenches"][workbenchName]["toolbars"][ToolBar]["commands"][
+                                        Command
+                                    ]["text"] = ""
 
             print("Ribbon UI: Custom text are reset because the language was changed")
         return
@@ -3666,36 +3201,27 @@ class EventInspector(QObject):
             mw.showMaximal()
             Style = mw.style()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
-            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(
-                QToolButton, "RestoreButton"
-            )[0]
+            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
             try:
-                RestoreButton.setIcon(
-                    Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton)
-                )
+                RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton))
             except Exception:
                 pass
             return QObject.eventFilter(self, obj, event)
         # This is a workaround for windows
         # If the window stat changes and the titlebar is hidden, catch the event
         if (
-            event.type() == QEvent.Type.WindowStateChange
-            or event.type() == QEvent.Type.DragMove
+            event.type() == QEvent.Type.WindowStateChange or event.type() == QEvent.Type.DragMove
         ) and Parameters_Ribbon.HIDE_TITLEBAR_FC is True:
             # Get the main window, its style, the ribbon and the restore button
             mw = Gui.getMainWindow()
             Style = mw.style()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
-            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(
-                QToolButton, "RestoreButton"
-            )[0]
+            RestoreButton: QToolButton = RibbonBar.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
             # If the mainwindow is maximized, set the window state to maximize and set the correct icon
             if mw.isMaximized():
                 try:
                     # RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarNormalButton))
-                    RestoreButton.setIcon(
-                        StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2]
-                    )
+                    RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2])
                 except Exception:
                     pass
                 return QObject.eventFilter(self, obj, event)
@@ -3703,18 +3229,13 @@ class EventInspector(QObject):
             if mw.isMaximized() is False:
                 try:
                     # RestoreButton.setIcon(Style.standardIcon(QStyle.StandardPixmap.SP_TitleBarMaxButton))
-                    RestoreButton.setIcon(
-                        StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1]
-                    )
+                    RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1])
                 except Exception:
                     pass
                 return QObject.eventFilter(self, obj, event)
         # If the event is a modfied event, update the title
         # This is done when switching from one part to another
-        if (
-            event.type() == QEvent.Type.ModifiedChange
-            and Parameters_Ribbon.TOOLBAR_POSITION == 0
-        ):
+        if event.type() == QEvent.Type.ModifiedChange and Parameters_Ribbon.TOOLBAR_POSITION == 0:
             # Get the mainwindow, the ribbon and the title
             mw = Gui.getMainWindow()
             RibbonBar = mw.findChild(ModernMenu, "Ribbon")
@@ -3722,9 +3243,7 @@ class EventInspector(QObject):
             # If there is an active document, continue here
             if App.ActiveDocument is not None:
                 # Define the standard title as a prefix
-                Prefix = (
-                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
-                )
+                Prefix = f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
                 # if the title is not equal to the prefix with the active document label,
                 # Get the text from the active tab from the viewport and combine it with the prefix
                 # Set it as the new title
@@ -3735,9 +3254,7 @@ class EventInspector(QObject):
                     RibbonBar.setTitle(Prefix + " - " + CurrentText)
             # If there is no active document, set just the standard title
             if App.ActiveDocument is None:
-                RibbonBar.setTitle(
-                    f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}"
-                )
+                RibbonBar.setTitle(f"FreeCAD {App.Version()[0]}.{App.Version()[1]}.{App.Version()[2]}")
             return QObject.eventFilter(self, obj, event)
         return False
 

--- a/FCBinding.py
+++ b/FCBinding.py
@@ -1220,6 +1220,26 @@ class ModernMenu(RibbonBar):
             if action.objectName() == "Std_DlgCustomize":
                 CustomizeButton_FreeCAD = action
                 SettingsMenu.addAction(CustomizeButton_FreeCAD)
+        # Add a save and restore button
+        try:
+            path = os.path.dirname(__file__)
+            # Get the folder with add-ons
+            for i in range(2):
+                # Starting point
+                path = os.path.dirname(path)
+
+            # Go through the sub-folders
+            for root, dirs, files in os.walk(path):
+                if "SaveAndRestore" in root:
+                    SaveAndRestore = os.path.join(path, "SaveAndRestore", "SaveAndRestore.py")
+                    import SaveAndRestore
+
+                    # Add a button for the Save and Restore dialog
+                    Button = SettingsMenu.addAction(translate("FreeCAD SaveAndRestore", "Save and restore..."))
+                    Button.setToolTip(translate("FreeCAD SaveAndRestore", "Save and restore FreeCAD's setting files"))
+                    Button.triggered.connect(SaveAndRestore.SaveAndRestore.LoadDialog)
+                    break
+        except Exception:
         # add the ribbon settings menu
         SettingsMenu.addAction(self.RibbonMenu.menuAction())
         SettingsMenu.setIcon(Gui.getIcon("Std_DlgParameter.svg"))

--- a/FCBinding.py
+++ b/FCBinding.py
@@ -699,6 +699,21 @@ class ModernMenu(RibbonBar):
                 self.RibbonOffset = 46 + self.QuickAccessButtonSize
                 self._titleWidget._tabBarLayout.setRowMinimumHeight(0, self.QuickAccessButtonSize)
 
+        # Get the main window, its style, the ribbon and the restore button
+        RestoreButton: QToolButton = self.rightToolBar().findChildren(QToolButton, "RestoreButton")[0]
+        # If the mainwindow is maximized, set the window state to maximize and set the correct icon
+        if mw.isMaximized():
+            try:
+                RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[2])
+            except Exception:
+                pass
+        # If the mainwindow is not maximized, set the window state to no state and set the correct icon
+        if mw.isMaximized() is False:
+            try:
+                RestoreButton.setIcon(StyleMapping_Ribbon.ReturnStyleItem("TitleBarButtons")[1])
+            except Exception:
+                pass
+
         # Install an event filter to catch events from the main window and act on it.
         mw.installEventFilter(EventInspector(mw))
 

--- a/LoadSettings_Ribbon.py
+++ b/LoadSettings_Ribbon.py
@@ -185,7 +185,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
 
         # Get the address of the repository address
         PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
-        self.ReproAdress = StandardFunctions.ReturnXML_Value(PackageXML, "url", "type", "repository")
+        self.ReproAdress = StandardFunctions.ReturnXML_Value(
+            PackageXML, "url", "type", "repository"
+        )
 
         # Set the size of the window to the previous state
         #

--- a/LoadSettings_Ribbon.py
+++ b/LoadSettings_Ribbon.py
@@ -184,10 +184,14 @@ class LoadDialog(Settings_ui.Ui_Settings):
         # Set the size of the window to the previous state
         #
         # Get the previous values
-        LayoutDialog_Height = Parameters_Ribbon.Settings.GetIntSetting("SettingsDialog_Height")
+        LayoutDialog_Height = Parameters_Ribbon.Settings.GetIntSetting(
+            "SettingsDialog_Height"
+        )
         if LayoutDialog_Height == 0 or LayoutDialog_Height is None:
             LayoutDialog_Height = 730
-        LayoutDialog_Width = Parameters_Ribbon.Settings.GetIntSetting("SettingsDialog_Width")
+        LayoutDialog_Width = Parameters_Ribbon.Settings.GetIntSetting(
+            "SettingsDialog_Width"
+        )
         if LayoutDialog_Width == 0 or LayoutDialog_Height is None:
             LayoutDialog_Width = 800
         # set a fixed size to force the form in to shape
@@ -198,7 +202,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.setMinimumSize(600, 600)
         self.form.setMaximumSize(120000, 120000)
         # change the sizepolicy to preferred, to allow stretching
-        self.form.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+        self.form.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred
+        )
 
         # Disable and hide the controls for the old application button
         self.form.label_5.setDisabled(True)
@@ -240,7 +246,10 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.label_4.setText(Parameters_Ribbon.BACKUP_LOCATION)
         self.form.TabbarStyle.setCurrentIndex(Parameters_Ribbon.TABBAR_STYLE)
         self.form.ToolbarPositions.setCurrentIndex(Parameters_Ribbon.TOOLBAR_POSITION)
-        if Parameters_Ribbon.HIDE_TITLEBAR_FC is True or Parameters_Ribbon.HIDE_TITLEBAR_FC is None:
+        if (
+            Parameters_Ribbon.HIDE_TITLEBAR_FC is True
+            or Parameters_Ribbon.HIDE_TITLEBAR_FC is None
+        ):
             self.form.HideTitleBarFC.setCheckState(Qt.CheckState.Checked)
         else:
             self.form.HideTitleBarFC.setCheckState(Qt.CheckState.Unchecked)
@@ -250,7 +259,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.IconSize_Large.setValue(Parameters_Ribbon.ICON_SIZE_LARGE)
         self.form.IconSize_ApplicationButton.setValue(Parameters_Ribbon.APP_ICON_SIZE)
         self.form.IconSize_QuickAccessButton.setValue(Parameters_Ribbon.QUICK_ICON_SIZE)
-        self.form.IconSize_rightToolbarButton.setValue(Parameters_Ribbon.RIGHT_ICON_SIZE)
+        self.form.IconSize_rightToolbarButton.setValue(
+            Parameters_Ribbon.RIGHT_ICON_SIZE
+        )
         self.form.TabbarHeight.setValue(Parameters_Ribbon.TABBAR_SIZE)
 
         self.form.TextSize_Menus.setValue(Parameters_Ribbon.FONTSIZE_MENUS)
@@ -335,7 +346,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         else:
             self.form.CustomIcons.setCheckState(Qt.CheckState.Unchecked)
 
-        self.form.Tab_Scroll_Left.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab", True))
+        self.form.Tab_Scroll_Left.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab", True)
+        )
         self.form.Tab_Scroll_Left.setIconSize(
             QSize(
                 self.form.Tab_Scroll_Left.width() - 6,
@@ -343,7 +356,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Tab_Scroll_Right.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab", True))
+        self.form.Tab_Scroll_Right.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab", True)
+        )
         self.form.Tab_Scroll_Right.setIconSize(
             QSize(
                 self.form.Tab_Scroll_Right.width() - 6,
@@ -351,7 +366,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Ribbon_Scroll_Left.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category", True))
+        self.form.Ribbon_Scroll_Left.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category", True)
+        )
         self.form.Ribbon_Scroll_Left.setIconSize(
             QSize(
                 self.form.Ribbon_Scroll_Left.width() - 6,
@@ -359,7 +376,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Ribbon_Scroll_Right.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category", True))
+        self.form.Ribbon_Scroll_Right.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category", True)
+        )
         self.form.Ribbon_Scroll_Right.setIconSize(
             QSize(
                 self.form.Ribbon_Scroll_Right.width() - 6,
@@ -367,12 +386,18 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.MoreCommands.setIcon(StyleMapping_Ribbon.ReturnStyleItem("OptionButton", True))
+        self.form.MoreCommands.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("OptionButton", True)
+        )
         self.form.MoreCommands.setIconSize(
-            QSize(self.form.MoreCommands.width() - 6, self.form.MoreCommands.height() - 6)
+            QSize(
+                self.form.MoreCommands.width() - 6, self.form.MoreCommands.height() - 6
+            )
         )
 
-        self.form.pinButton_open.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_open", True))
+        self.form.pinButton_open.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("PinButton_open", True)
+        )
         self.form.pinButton_open.setIconSize(
             QSize(
                 self.form.pinButton_open.width() - 6,
@@ -380,7 +405,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.pinButton_closed.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed", True))
+        self.form.pinButton_closed.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed", True)
+        )
         self.form.pinButton_closed.setIconSize(
             QSize(
                 self.form.pinButton_closed.width() - 6,
@@ -398,9 +425,13 @@ class LoadDialog(Settings_ui.Ui_Settings):
         else:
             self.form.BorderTransparant.setCheckState(Qt.CheckState.Unchecked)
 
-        self.form.Color_Borders.setProperty("color", QColor(Parameters_Ribbon.COLOR_BORDERS))
+        self.form.Color_Borders.setProperty(
+            "color", QColor(Parameters_Ribbon.COLOR_BORDERS)
+        )
         # self.form.Color_Background.setProperty("color", QColor(Parameters_Ribbon.COLOR_BACKGROUND))
-        self.form.Color_Background_Hover.setProperty("color", QColor(Parameters_Ribbon.COLOR_BACKGROUND_HOVER))
+        self.form.Color_Background_Hover.setProperty(
+            "color", QColor(Parameters_Ribbon.COLOR_BACKGROUND_HOVER)
+        )
         self.form.Color_Background_App.setProperty(
             "color", QColor(Parameters_Ribbon.COLOR_APPLICATION_BUTTON_BACKGROUND)
         )
@@ -412,7 +443,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
 
         if helpIcon is not None:
             self.form.HelpButton.setIcon(helpIcon)
-        self.form.HelpButton.setMinimumHeight(self.form.GenerateJsonExit.minimumHeight())
+        self.form.HelpButton.setMinimumHeight(
+            self.form.GenerateJsonExit.minimumHeight()
+        )
 
         # region - connect controls with functions----------------------------------------------------
         #
@@ -420,16 +453,28 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.EnableBackup.clicked.connect(self.on_EnableBackup_clicked)
         self.form.BackUpLocation.clicked.connect(self.on_BackUpLocation_clicked)
         # Connect the tabbar style
-        self.form.TabbarStyle.currentIndexChanged.connect(self.on_TabbarStyle_currentIndexChanged)
-        self.form.ToolbarPositions.currentIndexChanged.connect(self.on_ToolbarPositions_currentIndexChanged)
+        self.form.TabbarStyle.currentIndexChanged.connect(
+            self.on_TabbarStyle_currentIndexChanged
+        )
+        self.form.ToolbarPositions.currentIndexChanged.connect(
+            self.on_ToolbarPositions_currentIndexChanged
+        )
         self.form.HideTitleBarFC.clicked.connect(self.on_HideTitleBarFC_clicked)
         # Connect icon sizes
         self.form.IconSize_Small.textChanged.connect(self.on_IconSize_Small_TextChanged)
-        self.form.IconSize_Medium.textChanged.connect(self.on_IconSize_Medium_TextChanged)
+        self.form.IconSize_Medium.textChanged.connect(
+            self.on_IconSize_Medium_TextChanged
+        )
         self.form.IconSize_Large.textChanged.connect(self.on_IconSize_Large_TextChanged)
-        self.form.IconSize_ApplicationButton.textChanged.connect(self.on_IconSize_ApplicationButton_TextChanged)
-        self.form.IconSize_QuickAccessButton.textChanged.connect(self.on_IconSize_QuickAccessButton_TextChanged)
-        self.form.IconSize_rightToolbarButton.textChanged.connect(self.on_IconSize_rightToolbarButton_TextChanged)
+        self.form.IconSize_ApplicationButton.textChanged.connect(
+            self.on_IconSize_ApplicationButton_TextChanged
+        )
+        self.form.IconSize_QuickAccessButton.textChanged.connect(
+            self.on_IconSize_QuickAccessButton_TextChanged
+        )
+        self.form.IconSize_rightToolbarButton.textChanged.connect(
+            self.on_IconSize_rightToolbarButton_TextChanged
+        )
         self.form.TabbarHeight.textChanged.connect(self.on_TabbarHeight_TextChanged)
         # Connect stylesheet
         self.form.StyleSheetLocation.clicked.connect(self.on_StyleSheetLocation_clicked)
@@ -441,9 +486,13 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.EnableWrap_Large.clicked.connect(self.on_EnableWrap_Large_clicked)
         # Connect text sizes
         self.form.TextSize_Menus.textChanged.connect(self.on_TextSize_Menus_TextChanged)
-        self.form.TextSize_Buttons.textChanged.connect(self.on_TextSize_Buttons_TextChanged)
+        self.form.TextSize_Buttons.textChanged.connect(
+            self.on_TextSize_Buttons_TextChanged
+        )
         self.form.TextSize_Tabs.textChanged.connect(self.on_TextSize_Tabs_TextChanged)
-        self.form.TextSize_Panels.textChanged.connect(self.on_TextSize_Panels_TextChanged)
+        self.form.TextSize_Panels.textChanged.connect(
+            self.on_TextSize_Panels_TextChanged
+        )
 
         # Connect column width
         self.form.MaxPanelColumn.textChanged.connect(self.on_MaxPanelColumn_TextChanged)
@@ -466,7 +515,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         def GenerateJsonExit():
             self.on_Close_clicked(self)
 
-        self.form.GenerateJsonExit.connect(self.form.GenerateJsonExit, SIGNAL("clicked()"), GenerateJsonExit)
+        self.form.GenerateJsonExit.connect(
+            self.form.GenerateJsonExit, SIGNAL("clicked()"), GenerateJsonExit
+        )
 
         # Connect the reset button
         def Reset():
@@ -476,19 +527,31 @@ class LoadDialog(Settings_ui.Ui_Settings):
 
         # Connect the behavior settings
         self.form.EnableEnterEvent.clicked.connect(self.on_EnableEnterEvent_clicked)
-        self.form.ScrollSpeed_TabBar.valueChanged.connect(self.on_ScrollSpeed_TabBar_valueCHanged)
-        self.form.ScrollSpeed_Ribbon.valueChanged.connect(self.on_ScrollSpeed_Ribbon_valueCHanged)
-        self.form.ScrollClicks_TabBar.textChanged.connect(self.on_ScrollClicks_TabBar_valueCHanged)
-        self.form.ScrollClicks_Ribbon.textChanged.connect(self.on_ScrollClicks_Ribbon_valueCHanged)
+        self.form.ScrollSpeed_TabBar.valueChanged.connect(
+            self.on_ScrollSpeed_TabBar_valueCHanged
+        )
+        self.form.ScrollSpeed_Ribbon.valueChanged.connect(
+            self.on_ScrollSpeed_Ribbon_valueCHanged
+        )
+        self.form.ScrollClicks_TabBar.textChanged.connect(
+            self.on_ScrollClicks_TabBar_valueCHanged
+        )
+        self.form.ScrollClicks_Ribbon.textChanged.connect(
+            self.on_ScrollClicks_Ribbon_valueCHanged
+        )
 
         # Connect the preferred panel settings
-        self.form.PreferedViewPanel.currentIndexChanged.connect(self.on_PreferedViewPanel_currentIndexChanged)
+        self.form.PreferedViewPanel.currentIndexChanged.connect(
+            self.on_PreferedViewPanel_currentIndexChanged
+        )
         # Connect the EnableTools checkbox:
         self.form.EnableToolsPanel.clicked.connect(self.on_EnableToolsPanel_clicked)
         # Connect the overlay setting:
         self.form.EnableOverlay.clicked.connect(self.on_OverlayEnabled_clicked)
         self.form.FCOverlayEnabled.clicked.connect(self.on_FCOverlayEnabled_clicked)
-        self.form.UseButtonBackGround.clicked.connect(self.on_UseButtonBackGround_clicked)
+        self.form.UseButtonBackGround.clicked.connect(
+            self.on_UseButtonBackGround_clicked
+        )
 
         # endregion
 
@@ -499,49 +562,67 @@ class LoadDialog(Settings_ui.Ui_Settings):
         def TabScrollLeft():
             self.on_Tab_Scroll_Left_clicked()
 
-        self.form.Tab_Scroll_Left.connect(self.form.Tab_Scroll_Left, SIGNAL("clicked()"), TabScrollLeft)
+        self.form.Tab_Scroll_Left.connect(
+            self.form.Tab_Scroll_Left, SIGNAL("clicked()"), TabScrollLeft
+        )
 
         #
         def TabScrollRight():
             self.on_Tab_Scroll_Right_clicked()
 
-        self.form.Tab_Scroll_Right.connect(self.form.Tab_Scroll_Right, SIGNAL("clicked()"), TabScrollRight)
+        self.form.Tab_Scroll_Right.connect(
+            self.form.Tab_Scroll_Right, SIGNAL("clicked()"), TabScrollRight
+        )
 
         #
         def CategoryScrollLeft():
             self.on_Ribbon_Scroll_Left_clicked()
 
-        self.form.Ribbon_Scroll_Left.connect(self.form.Ribbon_Scroll_Left, SIGNAL("clicked()"), CategoryScrollLeft)
+        self.form.Ribbon_Scroll_Left.connect(
+            self.form.Ribbon_Scroll_Left, SIGNAL("clicked()"), CategoryScrollLeft
+        )
 
         #
         def CategoryScrollRight():
             self.on_Ribbon_Scroll_Right_clicked()
 
-        self.form.Ribbon_Scroll_Right.connect(self.form.Ribbon_Scroll_Right, SIGNAL("clicked()"), CategoryScrollRight)
+        self.form.Ribbon_Scroll_Right.connect(
+            self.form.Ribbon_Scroll_Right, SIGNAL("clicked()"), CategoryScrollRight
+        )
 
         #
         def MoreCommands():
             self.on_MoreCommands_clicked()
 
-        self.form.MoreCommands.connect(self.form.MoreCommands, SIGNAL("clicked()"), MoreCommands)
+        self.form.MoreCommands.connect(
+            self.form.MoreCommands, SIGNAL("clicked()"), MoreCommands
+        )
 
         #
         def PinButtonOpen():
             self.on_pinButton_open_clicked()
 
-        self.form.pinButton_open.connect(self.form.pinButton_open, SIGNAL("clicked()"), PinButtonOpen)
+        self.form.pinButton_open.connect(
+            self.form.pinButton_open, SIGNAL("clicked()"), PinButtonOpen
+        )
 
         #
         def PinButtonClosed():
             self.on_pinButton_closed_clicked()
 
-        self.form.pinButton_closed.connect(self.form.pinButton_closed, SIGNAL("clicked()"), PinButtonClosed)
+        self.form.pinButton_closed.connect(
+            self.form.pinButton_closed, SIGNAL("clicked()"), PinButtonClosed
+        )
         self.form.CustomColors.clicked.connect(self.on_CustomColors_clicked)
         self.form.BorderTransparant.clicked.connect(self.on_BorderTransparant_clicked)
         self.form.Color_Borders.clicked.connect(self.on_Color_Borders_clicked)
         # self.form.Color_Background.clicked.connect(self.on_Color_Background_clicked)
-        self.form.Color_Background_Hover.clicked.connect(self.on_Color_Background_Hover_clicked)
-        self.form.Color_Background_App.clicked.connect(self.on_Color_Background_App_clicked)
+        self.form.Color_Background_Hover.clicked.connect(
+            self.on_Color_Background_Hover_clicked
+        )
+        self.form.Color_Background_App.clicked.connect(
+            self.on_Color_Background_App_clicked
+        )
         # endregion
 
         # Set the first tab active
@@ -564,7 +645,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
 
     def on_BackUpLocation_clicked(self):
         BackupFolder = ""
-        BackupFolder = StandardFunctions.GetFolder(parent=self.form, DefaultPath=Parameters_Ribbon.BACKUP_LOCATION)
+        BackupFolder = StandardFunctions.GetFolder(
+            parent=self.form, DefaultPath=Parameters_Ribbon.BACKUP_LOCATION
+        )
         if BackupFolder != "":
             self.pathBackup = BackupFolder
             self.form.label_4.setText(BackupFolder)
@@ -578,7 +661,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         return
 
     def on_ToolbarPositions_currentIndexChanged(self):
-        self.ValuesToUpdate["Toolbar_Position"] = self.form.ToolbarPositions.currentIndex()
+        self.ValuesToUpdate["Toolbar_Position"] = (
+            self.form.ToolbarPositions.currentIndex()
+        )
         self.settingChanged = True
         return
 
@@ -605,17 +690,23 @@ class LoadDialog(Settings_ui.Ui_Settings):
         return
 
     def on_IconSize_ApplicationButton_TextChanged(self):
-        self.ValuesToUpdate["ApplicationButtonSize"] = int(self.form.IconSize_ApplicationButton.text())
+        self.ValuesToUpdate["ApplicationButtonSize"] = int(
+            self.form.IconSize_ApplicationButton.text()
+        )
         self.settingChanged = True
         return
 
     def on_IconSize_QuickAccessButton_TextChanged(self):
-        self.ValuesToUpdate["QuickAccessButtonSize"] = int(self.form.IconSize_QuickAccessButton.text())
+        self.ValuesToUpdate["QuickAccessButtonSize"] = int(
+            self.form.IconSize_QuickAccessButton.text()
+        )
         self.settingChanged = True
         return
 
     def on_IconSize_rightToolbarButton_TextChanged(self):
-        self.ValuesToUpdate["RightToolbarButtonSize"] = int(self.form.IconSize_rightToolbarButton.text())
+        self.ValuesToUpdate["RightToolbarButtonSize"] = int(
+            self.form.IconSize_rightToolbarButton.text()
+        )
         self.settingChanged = True
         return
 
@@ -734,7 +825,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.settingChanged = True
 
     def on_PreferedViewPanel_currentIndexChanged(self):
-        self.ValuesToUpdate["Preferred_view"] = self.form.PreferedViewPanel.currentIndex()
+        self.ValuesToUpdate["Preferred_view"] = (
+            self.form.PreferedViewPanel.currentIndex()
+        )
         self.settingChanged = True
         return
 
@@ -863,7 +956,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         )
         # if File is not nothing, set the icon in settings and on the button
         if File is not None and File != "" and os.path.isfile(File):
-            Parameters_Ribbon.Settings.SetStringSetting("ScrollLeftButton_Category", File)
+            Parameters_Ribbon.Settings.SetStringSetting(
+                "ScrollLeftButton_Category", File
+            )
             self.form.Ribbon_Scroll_Left.setIcon(QIcon(QPixmap(File)))
             self.form.Ribbon_Scroll_Left.setIconSize(
                 QSize(
@@ -888,7 +983,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         )
         # if File is not nothing, set the icon in settings and on the button
         if File is not None and File != "" and os.path.isfile(File):
-            Parameters_Ribbon.Settings.SetStringSetting("ScrollRightButton_Category", File)
+            Parameters_Ribbon.Settings.SetStringSetting(
+                "ScrollRightButton_Category", File
+            )
             self.form.Ribbon_Scroll_Right.setIcon(QIcon(QPixmap(File)))
             self.form.Ribbon_Scroll_Right.setIconSize(
                 QSize(
@@ -983,7 +1080,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         return
 
     def on_Color_Borders_clicked(self):
-        Color = QColor(self.form.Color_Borders.property("color")).toTuple()  # RGBA tupple
+        Color = QColor(
+            self.form.Color_Borders.property("color")
+        ).toTuple()  # RGBA tupple
         HexColor = StandardFunctions.ColorConvertor(Color, Color[3] / 255, True, False)
         self.ValuesToUpdate["Color_Borders"] = HexColor
         self.settingChanged = True
@@ -997,14 +1096,18 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.settingChanged = True
 
     def on_Color_Background_Hover_clicked(self):
-        Color = QColor(self.form.Color_Background_Hover.property("color")).toTuple()  # RGBA tupple
+        Color = QColor(
+            self.form.Color_Background_Hover.property("color")
+        ).toTuple()  # RGBA tupple
         HexColor = StandardFunctions.ColorConvertor(Color, Color[3] / 255, True, False)
         self.ValuesToUpdate["Color_Background_Hover"] = HexColor
         self.settingChanged = True
         return
 
     def on_Color_Background_App_clicked(self):
-        Color = QColor(self.form.Color_Background_App.property("color")).toTuple()  # RGBA tupple
+        Color = QColor(
+            self.form.Color_Background_App.property("color")
+        ).toTuple()  # RGBA tupple
         HexColor = StandardFunctions.ColorConvertor(Color, Color[3] / 255, True, False)
         self.ValuesToUpdate["Color_Background_App"] = HexColor
         self.settingChanged = True
@@ -1015,68 +1118,144 @@ class LoadDialog(Settings_ui.Ui_Settings):
     @staticmethod
     def on_Cancel_clicked(self):
         # Save backup settings
-        Parameters_Ribbon.Settings.SetBoolSetting("BackupEnabled", self.OriginalValues["BackupEnabled"])
-        Parameters_Ribbon.Settings.SetStringSetting("BackupFolder", self.OriginalValues["BackupFolder"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "BackupEnabled", self.OriginalValues["BackupEnabled"]
+        )
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "BackupFolder", self.OriginalValues["BackupFolder"]
+        )
         # Save tabBar style
-        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Style", self.OriginalValues["TabBar_Style"])
-        Parameters_Ribbon.Settings.SetIntSetting("Toolbar_Position", self.OriginalValues["Toolbar_Position"])
-        Parameters_Ribbon.Settings.SetBoolSetting("Hide_Titlebar_FC", self.OriginalValues["Hide_Titlebar_FC"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "TabBar_Style", self.OriginalValues["TabBar_Style"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "Toolbar_Position", self.OriginalValues["Toolbar_Position"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "Hide_Titlebar_FC", self.OriginalValues["Hide_Titlebar_FC"]
+        )
         # Save icon sizes
-        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Small", int(self.OriginalValues["IconSize_Small"]))
-        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Medium", int(self.OriginalValues["IconSize_Medium"]))
-        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Large", int(self.OriginalValues["IconSize_Large"]))
-        Parameters_Ribbon.Settings.SetStringSetting("Stylesheet", self.OriginalValues["Stylesheet"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "IconSize_Small", int(self.OriginalValues["IconSize_Small"])
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "IconSize_Medium", int(self.OriginalValues["IconSize_Medium"])
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "IconSize_Large", int(self.OriginalValues["IconSize_Large"])
+        )
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "Stylesheet", self.OriginalValues["Stylesheet"]
+        )
         Parameters_Ribbon.Settings.SetIntSetting(
             "ApplicationButtonSize", int(self.OriginalValues["ApplicationButtonSize"])
         )
         Parameters_Ribbon.Settings.SetIntSetting(
             "QuickAccessButtonSize", int(self.OriginalValues["QuickAccessButtonSize"])
         )
-        Parameters_Ribbon.Settings.SetIntSetting("TabBarSize", int(self.OriginalValues["TabBarSize"]))
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "TabBarSize", int(self.OriginalValues["TabBarSize"])
+        )
         Parameters_Ribbon.Settings.SetIntSetting(
             "RightToolbarButtonSize", int(self.OriginalValues["RightToolbarButtonSize"])
         )
         # Save text settings
-        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Small", self.OriginalValues["ShowIconText_Small"])
-        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Medium", self.OriginalValues["ShowIconText_Medium"])
-        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Large", self.OriginalValues["ShowIconText_Large"])
-        Parameters_Ribbon.Settings.SetBoolSetting("WrapText_Medium", self.OriginalValues["WrapText_Medium"])
-        Parameters_Ribbon.Settings.SetBoolSetting("WrapText_Large", self.OriginalValues["WrapText_Large"])
-        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Menus", self.OriginalValues["FontSize_Menus"])
-        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Buttons", self.OriginalValues["FontSize_Buttons"])
-        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Tabs", self.OriginalValues["FontSize_Tabs"])
-        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Panels", self.OriginalValues["FontSize_Panels"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "ShowIconText_Small", self.OriginalValues["ShowIconText_Small"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "ShowIconText_Medium", self.OriginalValues["ShowIconText_Medium"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "ShowIconText_Large", self.OriginalValues["ShowIconText_Large"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "WrapText_Medium", self.OriginalValues["WrapText_Medium"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "WrapText_Large", self.OriginalValues["WrapText_Large"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "FontSize_Menus", self.OriginalValues["FontSize_Menus"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "FontSize_Buttons", self.OriginalValues["FontSize_Buttons"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "FontSize_Tabs", self.OriginalValues["FontSize_Tabs"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "FontSize_Panels", self.OriginalValues["FontSize_Panels"]
+        )
         # Save No of columns
-        Parameters_Ribbon.Settings.SetIntSetting("MaxColumnsPerPanel", int(self.OriginalValues["MaxColumnsPerPanel"]))
-        Parameters_Ribbon.Settings.SetBoolSetting("DebugMode", self.OriginalValues["DebugMode"])
-        Parameters_Ribbon.Settings.SetBoolSetting("ShowOnHover", self.OriginalValues["ShowOnHover"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "MaxColumnsPerPanel", int(self.OriginalValues["MaxColumnsPerPanel"])
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "DebugMode", self.OriginalValues["DebugMode"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "ShowOnHover", self.OriginalValues["ShowOnHover"]
+        )
         # Save behavior settings
-        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Scroll", self.OriginalValues["TabBar_Scroll"])
-        Parameters_Ribbon.Settings.SetIntSetting("Ribbon_Scroll", self.OriginalValues["Ribbon_Scroll"])
-        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Click", self.OriginalValues["TabBar_Click"])
-        Parameters_Ribbon.Settings.SetIntSetting("Ribbon_Click", self.OriginalValues["Ribbon_Click"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "TabBar_Scroll", self.OriginalValues["TabBar_Scroll"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "Ribbon_Scroll", self.OriginalValues["Ribbon_Scroll"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "TabBar_Click", self.OriginalValues["TabBar_Click"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "Ribbon_Click", self.OriginalValues["Ribbon_Click"]
+        )
         # Save the preferred toolbars
-        Parameters_Ribbon.Settings.SetIntSetting("Preferred_view", self.OriginalValues["Preferred_view"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "Preferred_view", self.OriginalValues["Preferred_view"]
+        )
         # Set the use of the tools panel
-        Parameters_Ribbon.Settings.SetBoolSetting("UseToolsPanel", self.OriginalValues["UseToolsPanel"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "UseToolsPanel", self.OriginalValues["UseToolsPanel"]
+        )
         # Set the use of FreeCAD's overlay function
-        Parameters_Ribbon.Settings.SetBoolSetting("UseOverlay", self.OriginalValues["UseOverlay"])
-        Parameters_Ribbon.Settings.SetBoolSetting("UseFCOverlay", self.OriginalValues["UseFCOverlay"])
-        Parameters_Ribbon.Settings.SetBoolSetting("UseButtonBackGround", self.OriginalValues["UseButtonBackGround"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "UseOverlay", self.OriginalValues["UseOverlay"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "UseFCOverlay", self.OriginalValues["UseFCOverlay"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "UseButtonBackGround", self.OriginalValues["UseButtonBackGround"]
+        )
         # Set the use of custom icons
-        Parameters_Ribbon.Settings.SetBoolSetting("CustomIcons", self.OriginalValues["CustomIcons"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "CustomIcons", self.OriginalValues["CustomIcons"]
+        )
         # Set the use of custom colors
-        Parameters_Ribbon.Settings.SetBoolSetting("CustomColors", self.OriginalValues["CustomColors"])
-        Parameters_Ribbon.Settings.SetBoolSetting("BorderTransparant", self.OriginalValues["BorderTransparant"])
-        Parameters_Ribbon.Settings.SetStringSetting("Color_Borders", self.OriginalValues["Color_Borders"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "CustomColors", self.OriginalValues["CustomColors"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "BorderTransparant", self.OriginalValues["BorderTransparant"]
+        )
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "Color_Borders", self.OriginalValues["Color_Borders"]
+        )
         Parameters_Ribbon.Settings.SetStringSetting(
             "Color_Background_Hover", self.OriginalValues["Color_Background_Hover"]
         )
-        Parameters_Ribbon.Settings.SetStringSetting("Color_Background_App", self.OriginalValues["Color_Background_App"])
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "Color_Background_App", self.OriginalValues["Color_Background_App"]
+        )
 
         # Set the size of the window to the previous state
-        Parameters_Ribbon.Settings.SetIntSetting("SettingsDialog_Height", self.form.height())
-        Parameters_Ribbon.Settings.SetIntSetting("SettingsDialog_Width", self.form.width())
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "SettingsDialog_Height", self.form.height()
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "SettingsDialog_Width", self.form.width()
+        )
 
         # Close the form
         self.form.close()
@@ -1085,70 +1264,148 @@ class LoadDialog(Settings_ui.Ui_Settings):
     @staticmethod
     def on_Close_clicked(self):
         # Save backup settings
-        Parameters_Ribbon.Settings.SetBoolSetting("BackupEnabled", self.ValuesToUpdate["BackupEnabled"])
-        Parameters_Ribbon.Settings.SetStringSetting("BackupFolder", self.ValuesToUpdate["BackupFolder"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "BackupEnabled", self.ValuesToUpdate["BackupEnabled"]
+        )
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "BackupFolder", self.ValuesToUpdate["BackupFolder"]
+        )
         # Save tabBar style
-        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Style", self.ValuesToUpdate["TabBar_Style"])
-        Parameters_Ribbon.Settings.SetIntSetting("Toolbar_Position", self.ValuesToUpdate["Toolbar_Position"])
-        Parameters_Ribbon.Settings.SetBoolSetting("Hide_Titlebar_FC", self.ValuesToUpdate["Hide_Titlebar_FC"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "TabBar_Style", self.ValuesToUpdate["TabBar_Style"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "Toolbar_Position", self.ValuesToUpdate["Toolbar_Position"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "Hide_Titlebar_FC", self.ValuesToUpdate["Hide_Titlebar_FC"]
+        )
         # Save icon sizes
-        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Small", int(self.ValuesToUpdate["IconSize_Small"]))
-        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Medium", int(self.ValuesToUpdate["IconSize_Medium"]))
-        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Large", int(self.ValuesToUpdate["IconSize_Large"]))
-        Parameters_Ribbon.Settings.SetStringSetting("Stylesheet", self.ValuesToUpdate["Stylesheet"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "IconSize_Small", int(self.ValuesToUpdate["IconSize_Small"])
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "IconSize_Medium", int(self.ValuesToUpdate["IconSize_Medium"])
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "IconSize_Large", int(self.ValuesToUpdate["IconSize_Large"])
+        )
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "Stylesheet", self.ValuesToUpdate["Stylesheet"]
+        )
         Parameters_Ribbon.Settings.SetIntSetting(
             "ApplicationButtonSize", int(self.ValuesToUpdate["ApplicationButtonSize"])
         )
         Parameters_Ribbon.Settings.SetIntSetting(
             "QuickAccessButtonSize", int(self.ValuesToUpdate["QuickAccessButtonSize"])
         )
-        Parameters_Ribbon.Settings.SetIntSetting("TabBarSize", int(self.ValuesToUpdate["TabBarSize"]))
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "TabBarSize", int(self.ValuesToUpdate["TabBarSize"])
+        )
         Parameters_Ribbon.Settings.SetIntSetting(
             "RightToolbarButtonSize", int(self.ValuesToUpdate["RightToolbarButtonSize"])
         )
         # Save text settings
-        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Small", self.ValuesToUpdate["ShowIconText_Small"])
-        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Medium", self.ValuesToUpdate["ShowIconText_Medium"])
-        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Large", self.ValuesToUpdate["ShowIconText_Large"])
-        Parameters_Ribbon.Settings.SetBoolSetting("WrapText_Medium", self.ValuesToUpdate["WrapText_Medium"])
-        Parameters_Ribbon.Settings.SetBoolSetting("WrapText_Large", self.ValuesToUpdate["WrapText_Large"])
-        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Menus", self.ValuesToUpdate["FontSize_Menus"])
-        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Buttons", self.ValuesToUpdate["FontSize_Buttons"])
-        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Tabs", self.ValuesToUpdate["FontSize_Tabs"])
-        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Panels", self.ValuesToUpdate["FontSize_Panels"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "ShowIconText_Small", self.ValuesToUpdate["ShowIconText_Small"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "ShowIconText_Medium", self.ValuesToUpdate["ShowIconText_Medium"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "ShowIconText_Large", self.ValuesToUpdate["ShowIconText_Large"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "WrapText_Medium", self.ValuesToUpdate["WrapText_Medium"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "WrapText_Large", self.ValuesToUpdate["WrapText_Large"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "FontSize_Menus", self.ValuesToUpdate["FontSize_Menus"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "FontSize_Buttons", self.ValuesToUpdate["FontSize_Buttons"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "FontSize_Tabs", self.ValuesToUpdate["FontSize_Tabs"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "FontSize_Panels", self.ValuesToUpdate["FontSize_Panels"]
+        )
         # Save No of columns
-        Parameters_Ribbon.Settings.SetIntSetting("MaxColumnsPerPanel", int(self.ValuesToUpdate["MaxColumnsPerPanel"]))
-        Parameters_Ribbon.Settings.SetBoolSetting("DebugMode", self.ValuesToUpdate["DebugMode"])
-        Parameters_Ribbon.Settings.SetBoolSetting("ShowOnHover", self.ValuesToUpdate["ShowOnHover"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "MaxColumnsPerPanel", int(self.ValuesToUpdate["MaxColumnsPerPanel"])
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "DebugMode", self.ValuesToUpdate["DebugMode"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "ShowOnHover", self.ValuesToUpdate["ShowOnHover"]
+        )
         # Save behavior settings
-        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Scroll", self.ValuesToUpdate["TabBar_Scroll"])
-        Parameters_Ribbon.Settings.SetIntSetting("Ribbon_Scroll", self.ValuesToUpdate["Ribbon_Scroll"])
-        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Click", self.ValuesToUpdate["TabBar_Click"])
-        Parameters_Ribbon.Settings.SetIntSetting("Ribbon_Click", self.ValuesToUpdate["Ribbon_Click"])
-        Parameters_Ribbon.Settings.SetStringSetting("Shortcut_Application", self.ValuesToUpdate["Shortcut_Application"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "TabBar_Scroll", self.ValuesToUpdate["TabBar_Scroll"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "Ribbon_Scroll", self.ValuesToUpdate["Ribbon_Scroll"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "TabBar_Click", self.ValuesToUpdate["TabBar_Click"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "Ribbon_Click", self.ValuesToUpdate["Ribbon_Click"]
+        )
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "Shortcut_Application", self.ValuesToUpdate["Shortcut_Application"]
+        )
         # Save the preferred toolbars
-        Parameters_Ribbon.Settings.SetIntSetting("Preferred_view", self.ValuesToUpdate["Preferred_view"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "Preferred_view", self.ValuesToUpdate["Preferred_view"]
+        )
         # Set the use of the tools panel
-        Parameters_Ribbon.Settings.SetBoolSetting("UseToolsPanel", self.ValuesToUpdate["UseToolsPanel"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "UseToolsPanel", self.ValuesToUpdate["UseToolsPanel"]
+        )
         # Set the use of FreeCAD's overlay function
-        Parameters_Ribbon.Settings.SetBoolSetting("UseOverlay", self.ValuesToUpdate["UseOverlay"])
-        Parameters_Ribbon.Settings.SetBoolSetting("UseFCOverlay", self.ValuesToUpdate["UseFCOverlay"])
-        Parameters_Ribbon.Settings.SetBoolSetting("UseButtonBackGround", self.ValuesToUpdate["UseButtonBackGround"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "UseOverlay", self.ValuesToUpdate["UseOverlay"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "UseFCOverlay", self.ValuesToUpdate["UseFCOverlay"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "UseButtonBackGround", self.ValuesToUpdate["UseButtonBackGround"]
+        )
         # Set the use of custom icons
-        Parameters_Ribbon.Settings.SetBoolSetting("CustomIcons", self.ValuesToUpdate["CustomIcons"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "CustomIcons", self.ValuesToUpdate["CustomIcons"]
+        )
         # Set the use of custom colors
-        Parameters_Ribbon.Settings.SetBoolSetting("CustomColors", self.ValuesToUpdate["CustomColors"])
-        Parameters_Ribbon.Settings.SetBoolSetting("BorderTransparant", self.ValuesToUpdate["BorderTransparant"])
-        Parameters_Ribbon.Settings.SetStringSetting("Color_Borders", self.ValuesToUpdate["Color_Borders"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "CustomColors", self.ValuesToUpdate["CustomColors"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "BorderTransparant", self.ValuesToUpdate["BorderTransparant"]
+        )
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "Color_Borders", self.ValuesToUpdate["Color_Borders"]
+        )
         # Parameters_Ribbon.Settings.SetStringSetting("Color_Background", self.ValuesToUpdate["Color_Background"])
         Parameters_Ribbon.Settings.SetStringSetting(
             "Color_Background_Hover", self.ValuesToUpdate["Color_Background_Hover"]
         )
-        Parameters_Ribbon.Settings.SetStringSetting("Color_Background_App", self.ValuesToUpdate["Color_Background_App"])
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "Color_Background_App", self.ValuesToUpdate["Color_Background_App"]
+        )
 
         # Set the size of the window to the previous state
-        Parameters_Ribbon.Settings.SetIntSetting("SettingsDialog_Height", self.form.height())
-        Parameters_Ribbon.Settings.SetIntSetting("SettingsDialog_Width", self.form.width())
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "SettingsDialog_Height", self.form.height()
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "SettingsDialog_Width", self.form.width()
+        )
 
         # Close the form
         self.form.close()
@@ -1185,9 +1442,15 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.IconSize_Small.setValue(DefaultSettings["IconSize_Small"])
         self.form.IconSize_Medium.setValue(DefaultSettings["IconSize_Medium"])
         self.form.IconSize_Large.setValue(DefaultSettings["IconSize_Large"])
-        self.form.IconSize_ApplicationButton.setValue(DefaultSettings["ApplicationButtonSize"])
-        self.form.IconSize_QuickAccessButton.setValue(DefaultSettings["QuickAccessButtonSize"])
-        self.form.IconSize_rightToolbarButton.setValue(DefaultSettings["RightToolbarButtonSize"])
+        self.form.IconSize_ApplicationButton.setValue(
+            DefaultSettings["ApplicationButtonSize"]
+        )
+        self.form.IconSize_QuickAccessButton.setValue(
+            DefaultSettings["QuickAccessButtonSize"]
+        )
+        self.form.IconSize_rightToolbarButton.setValue(
+            DefaultSettings["RightToolbarButtonSize"]
+        )
         self.form.TabbarHeight.setValue(DefaultSettings["TabBarSize"])
         self.form.label_7.setText(DefaultSettings["Stylesheet"])
         if DefaultSettings["ShowIconText_Small"] is True:
@@ -1248,7 +1511,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         # Set the color and icon buttons
         self.form.CustomIcons.setCheckState(Qt.CheckState.Unchecked)
 
-        self.form.Tab_Scroll_Left.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab", False))
+        self.form.Tab_Scroll_Left.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab", False)
+        )
         self.form.Tab_Scroll_Left.setIconSize(
             QSize(
                 self.form.Tab_Scroll_Left.width() - 6,
@@ -1256,7 +1521,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Tab_Scroll_Right.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab", False))
+        self.form.Tab_Scroll_Right.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab", False)
+        )
         self.form.Tab_Scroll_Right.setIconSize(
             QSize(
                 self.form.Tab_Scroll_Right.width() - 6,
@@ -1264,7 +1531,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Ribbon_Scroll_Left.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category", False))
+        self.form.Ribbon_Scroll_Left.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category", False)
+        )
         self.form.Ribbon_Scroll_Left.setIconSize(
             QSize(
                 self.form.Ribbon_Scroll_Left.width() - 6,
@@ -1272,7 +1541,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Ribbon_Scroll_Right.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category", False))
+        self.form.Ribbon_Scroll_Right.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category", False)
+        )
         self.form.Ribbon_Scroll_Right.setIconSize(
             QSize(
                 self.form.Ribbon_Scroll_Right.width() - 6,
@@ -1280,12 +1551,18 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.MoreCommands.setIcon(StyleMapping_Ribbon.ReturnStyleItem("OptionButton", False))
+        self.form.MoreCommands.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("OptionButton", False)
+        )
         self.form.MoreCommands.setIconSize(
-            QSize(self.form.MoreCommands.width() - 6, self.form.MoreCommands.height() - 6)
+            QSize(
+                self.form.MoreCommands.width() - 6, self.form.MoreCommands.height() - 6
+            )
         )
 
-        self.form.pinButton_open.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_open", False))
+        self.form.pinButton_open.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("PinButton_open", False)
+        )
         self.form.pinButton_open.setIconSize(
             QSize(
                 self.form.pinButton_open.width() - 6,
@@ -1293,7 +1570,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.pinButton_closed.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed", False))
+        self.form.pinButton_closed.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed", False)
+        )
         self.form.pinButton_closed.setIconSize(
             QSize(
                 self.form.pinButton_closed.width() - 6,
@@ -1301,7 +1580,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Color_Borders.setProperty("color", QColor(StyleMapping_Ribbon.ReturnStyleItem("Color_Borders")))
+        self.form.Color_Borders.setProperty(
+            "color", QColor(StyleMapping_Ribbon.ReturnStyleItem("Color_Borders"))
+        )
         # self.form.Color_Background.setProperty("color", QColor(StyleMapping.ReturnStyleItem("Color_Background")))
         self.form.Color_Background_Hover.setProperty(
             "color",

--- a/LoadSettings_Ribbon.py
+++ b/LoadSettings_Ribbon.py
@@ -37,6 +37,7 @@ from PySide.QtWidgets import (
     QLineEdit,
     QWidget,
     QGroupBox,
+    QMenu,
 )
 from PySide.QtGui import QIcon, QPixmap, QColor
 
@@ -45,6 +46,7 @@ import StyleMapping_Ribbon
 import Standard_Functions_RIbbon as StandardFunctions
 import Parameters_Ribbon
 from Parameters_Ribbon import DefaultSettings
+import webbrowser
 
 # Get the resources
 pathIcons = Parameters_Ribbon.ICON_LOCATION
@@ -182,14 +184,10 @@ class LoadDialog(Settings_ui.Ui_Settings):
         # Set the size of the window to the previous state
         #
         # Get the previous values
-        LayoutDialog_Height = Parameters_Ribbon.Settings.GetIntSetting(
-            "SettingsDialog_Height"
-        )
+        LayoutDialog_Height = Parameters_Ribbon.Settings.GetIntSetting("SettingsDialog_Height")
         if LayoutDialog_Height == 0 or LayoutDialog_Height is None:
             LayoutDialog_Height = 730
-        LayoutDialog_Width = Parameters_Ribbon.Settings.GetIntSetting(
-            "SettingsDialog_Width"
-        )
+        LayoutDialog_Width = Parameters_Ribbon.Settings.GetIntSetting("SettingsDialog_Width")
         if LayoutDialog_Width == 0 or LayoutDialog_Height is None:
             LayoutDialog_Width = 800
         # set a fixed size to force the form in to shape
@@ -200,9 +198,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.setMinimumSize(600, 600)
         self.form.setMaximumSize(120000, 120000)
         # change the sizepolicy to preferred, to allow stretching
-        self.form.setSizePolicy(
-            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred
-        )
+        self.form.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
 
         # Disable and hide the controls for the old application button
         self.form.label_5.setDisabled(True)
@@ -244,10 +240,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.label_4.setText(Parameters_Ribbon.BACKUP_LOCATION)
         self.form.TabbarStyle.setCurrentIndex(Parameters_Ribbon.TABBAR_STYLE)
         self.form.ToolbarPositions.setCurrentIndex(Parameters_Ribbon.TOOLBAR_POSITION)
-        if (
-            Parameters_Ribbon.HIDE_TITLEBAR_FC is True
-            or Parameters_Ribbon.HIDE_TITLEBAR_FC is None
-        ):
+        if Parameters_Ribbon.HIDE_TITLEBAR_FC is True or Parameters_Ribbon.HIDE_TITLEBAR_FC is None:
             self.form.HideTitleBarFC.setCheckState(Qt.CheckState.Checked)
         else:
             self.form.HideTitleBarFC.setCheckState(Qt.CheckState.Unchecked)
@@ -257,9 +250,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.IconSize_Large.setValue(Parameters_Ribbon.ICON_SIZE_LARGE)
         self.form.IconSize_ApplicationButton.setValue(Parameters_Ribbon.APP_ICON_SIZE)
         self.form.IconSize_QuickAccessButton.setValue(Parameters_Ribbon.QUICK_ICON_SIZE)
-        self.form.IconSize_rightToolbarButton.setValue(
-            Parameters_Ribbon.RIGHT_ICON_SIZE
-        )
+        self.form.IconSize_rightToolbarButton.setValue(Parameters_Ribbon.RIGHT_ICON_SIZE)
         self.form.TabbarHeight.setValue(Parameters_Ribbon.TABBAR_SIZE)
 
         self.form.TextSize_Menus.setValue(Parameters_Ribbon.FONTSIZE_MENUS)
@@ -344,9 +335,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         else:
             self.form.CustomIcons.setCheckState(Qt.CheckState.Unchecked)
 
-        self.form.Tab_Scroll_Left.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab", True)
-        )
+        self.form.Tab_Scroll_Left.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab", True))
         self.form.Tab_Scroll_Left.setIconSize(
             QSize(
                 self.form.Tab_Scroll_Left.width() - 6,
@@ -354,9 +343,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Tab_Scroll_Right.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab", True)
-        )
+        self.form.Tab_Scroll_Right.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab", True))
         self.form.Tab_Scroll_Right.setIconSize(
             QSize(
                 self.form.Tab_Scroll_Right.width() - 6,
@@ -364,9 +351,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Ribbon_Scroll_Left.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category", True)
-        )
+        self.form.Ribbon_Scroll_Left.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category", True))
         self.form.Ribbon_Scroll_Left.setIconSize(
             QSize(
                 self.form.Ribbon_Scroll_Left.width() - 6,
@@ -374,9 +359,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Ribbon_Scroll_Right.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category", True)
-        )
+        self.form.Ribbon_Scroll_Right.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category", True))
         self.form.Ribbon_Scroll_Right.setIconSize(
             QSize(
                 self.form.Ribbon_Scroll_Right.width() - 6,
@@ -384,18 +367,12 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.MoreCommands.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("OptionButton", True)
-        )
+        self.form.MoreCommands.setIcon(StyleMapping_Ribbon.ReturnStyleItem("OptionButton", True))
         self.form.MoreCommands.setIconSize(
-            QSize(
-                self.form.MoreCommands.width() - 6, self.form.MoreCommands.height() - 6
-            )
+            QSize(self.form.MoreCommands.width() - 6, self.form.MoreCommands.height() - 6)
         )
 
-        self.form.pinButton_open.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("PinButton_open", True)
-        )
+        self.form.pinButton_open.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_open", True))
         self.form.pinButton_open.setIconSize(
             QSize(
                 self.form.pinButton_open.width() - 6,
@@ -403,9 +380,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.pinButton_closed.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed", True)
-        )
+        self.form.pinButton_closed.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed", True))
         self.form.pinButton_closed.setIconSize(
             QSize(
                 self.form.pinButton_closed.width() - 6,
@@ -423,16 +398,21 @@ class LoadDialog(Settings_ui.Ui_Settings):
         else:
             self.form.BorderTransparant.setCheckState(Qt.CheckState.Unchecked)
 
-        self.form.Color_Borders.setProperty(
-            "color", QColor(Parameters_Ribbon.COLOR_BORDERS)
-        )
+        self.form.Color_Borders.setProperty("color", QColor(Parameters_Ribbon.COLOR_BORDERS))
         # self.form.Color_Background.setProperty("color", QColor(Parameters_Ribbon.COLOR_BACKGROUND))
-        self.form.Color_Background_Hover.setProperty(
-            "color", QColor(Parameters_Ribbon.COLOR_BACKGROUND_HOVER)
-        )
+        self.form.Color_Background_Hover.setProperty("color", QColor(Parameters_Ribbon.COLOR_BACKGROUND_HOVER))
         self.form.Color_Background_App.setProperty(
             "color", QColor(Parameters_Ribbon.COLOR_APPLICATION_BUTTON_BACKGROUND)
         )
+
+        # Get the icon from the FreeCAD help
+        helpMenu = mw.findChildren(QMenu, "&Help")[0]
+        helpAction = helpMenu.actions()[0]
+        helpIcon = helpAction.icon()
+
+        if helpIcon is not None:
+            self.form.HelpButton.setIcon(helpIcon)
+        self.form.HelpButton.setMinimumHeight(self.form.Close.minimumHeight())
 
         # region - connect controls with functions----------------------------------------------------
         #
@@ -440,28 +420,16 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.EnableBackup.clicked.connect(self.on_EnableBackup_clicked)
         self.form.BackUpLocation.clicked.connect(self.on_BackUpLocation_clicked)
         # Connect the tabbar style
-        self.form.TabbarStyle.currentIndexChanged.connect(
-            self.on_TabbarStyle_currentIndexChanged
-        )
-        self.form.ToolbarPositions.currentIndexChanged.connect(
-            self.on_ToolbarPositions_currentIndexChanged
-        )
+        self.form.TabbarStyle.currentIndexChanged.connect(self.on_TabbarStyle_currentIndexChanged)
+        self.form.ToolbarPositions.currentIndexChanged.connect(self.on_ToolbarPositions_currentIndexChanged)
         self.form.HideTitleBarFC.clicked.connect(self.on_HideTitleBarFC_clicked)
         # Connect icon sizes
         self.form.IconSize_Small.textChanged.connect(self.on_IconSize_Small_TextChanged)
-        self.form.IconSize_Medium.textChanged.connect(
-            self.on_IconSize_Medium_TextChanged
-        )
+        self.form.IconSize_Medium.textChanged.connect(self.on_IconSize_Medium_TextChanged)
         self.form.IconSize_Large.textChanged.connect(self.on_IconSize_Large_TextChanged)
-        self.form.IconSize_ApplicationButton.textChanged.connect(
-            self.on_IconSize_ApplicationButton_TextChanged
-        )
-        self.form.IconSize_QuickAccessButton.textChanged.connect(
-            self.on_IconSize_QuickAccessButton_TextChanged
-        )
-        self.form.IconSize_rightToolbarButton.textChanged.connect(
-            self.on_IconSize_rightToolbarButton_TextChanged
-        )
+        self.form.IconSize_ApplicationButton.textChanged.connect(self.on_IconSize_ApplicationButton_TextChanged)
+        self.form.IconSize_QuickAccessButton.textChanged.connect(self.on_IconSize_QuickAccessButton_TextChanged)
+        self.form.IconSize_rightToolbarButton.textChanged.connect(self.on_IconSize_rightToolbarButton_TextChanged)
         self.form.TabbarHeight.textChanged.connect(self.on_TabbarHeight_TextChanged)
         # Connect stylesheet
         self.form.StyleSheetLocation.clicked.connect(self.on_StyleSheetLocation_clicked)
@@ -473,13 +441,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.EnableWrap_Large.clicked.connect(self.on_EnableWrap_Large_clicked)
         # Connect text sizes
         self.form.TextSize_Menus.textChanged.connect(self.on_TextSize_Menus_TextChanged)
-        self.form.TextSize_Buttons.textChanged.connect(
-            self.on_TextSize_Buttons_TextChanged
-        )
+        self.form.TextSize_Buttons.textChanged.connect(self.on_TextSize_Buttons_TextChanged)
         self.form.TextSize_Tabs.textChanged.connect(self.on_TextSize_Tabs_TextChanged)
-        self.form.TextSize_Panels.textChanged.connect(
-            self.on_TextSize_Panels_TextChanged
-        )
+        self.form.TextSize_Panels.textChanged.connect(self.on_TextSize_Panels_TextChanged)
 
         # Connect column width
         self.form.MaxPanelColumn.textChanged.connect(self.on_MaxPanelColumn_TextChanged)
@@ -492,13 +456,17 @@ class LoadDialog(Settings_ui.Ui_Settings):
 
         self.form.Cancel.connect(self.form.Cancel, SIGNAL("clicked()"), Cancel)
 
+        # Connect the help buttons
+        def Help():
+            self.on_Helpbutton_clicked(self)
+
+        self.form.HelpButton.connect(self.form.HelpButton, SIGNAL("clicked()"), Help)
+
         # Connect the button GenerateJsonExit with the function on_GenerateJsonExit_clicked
         def GenerateJsonExit():
             self.on_Close_clicked(self)
 
-        self.form.GenerateJsonExit.connect(
-            self.form.GenerateJsonExit, SIGNAL("clicked()"), GenerateJsonExit
-        )
+        self.form.GenerateJsonExit.connect(self.form.GenerateJsonExit, SIGNAL("clicked()"), GenerateJsonExit)
 
         # Connect the reset button
         def Reset():
@@ -508,102 +476,73 @@ class LoadDialog(Settings_ui.Ui_Settings):
 
         # Connect the behavior settings
         self.form.EnableEnterEvent.clicked.connect(self.on_EnableEnterEvent_clicked)
-        self.form.ScrollSpeed_TabBar.valueChanged.connect(
-            self.on_ScrollSpeed_TabBar_valueCHanged
-        )
-        self.form.ScrollSpeed_Ribbon.valueChanged.connect(
-            self.on_ScrollSpeed_Ribbon_valueCHanged
-        )
-        self.form.ScrollClicks_TabBar.textChanged.connect(
-            self.on_ScrollClicks_TabBar_valueCHanged
-        )
-        self.form.ScrollClicks_Ribbon.textChanged.connect(
-            self.on_ScrollClicks_Ribbon_valueCHanged
-        )
+        self.form.ScrollSpeed_TabBar.valueChanged.connect(self.on_ScrollSpeed_TabBar_valueCHanged)
+        self.form.ScrollSpeed_Ribbon.valueChanged.connect(self.on_ScrollSpeed_Ribbon_valueCHanged)
+        self.form.ScrollClicks_TabBar.textChanged.connect(self.on_ScrollClicks_TabBar_valueCHanged)
+        self.form.ScrollClicks_Ribbon.textChanged.connect(self.on_ScrollClicks_Ribbon_valueCHanged)
 
         # Connect the preferred panel settings
-        self.form.PreferedViewPanel.currentIndexChanged.connect(
-            self.on_PreferedViewPanel_currentIndexChanged
-        )
+        self.form.PreferedViewPanel.currentIndexChanged.connect(self.on_PreferedViewPanel_currentIndexChanged)
         # Connect the EnableTools checkbox:
         self.form.EnableToolsPanel.clicked.connect(self.on_EnableToolsPanel_clicked)
         # Connect the overlay setting:
         self.form.EnableOverlay.clicked.connect(self.on_OverlayEnabled_clicked)
         self.form.FCOverlayEnabled.clicked.connect(self.on_FCOverlayEnabled_clicked)
-        self.form.UseButtonBackGround.clicked.connect(
-            self.on_UseButtonBackGround_clicked
-        )
+        self.form.UseButtonBackGround.clicked.connect(self.on_UseButtonBackGround_clicked)
 
         # endregion
 
-        # Connect the controls for custom icons and colors
+        # region - Connect the controls for custom icons and colors
         self.form.CustomIcons.clicked.connect(self.on_CustomIcons_clicked)
 
         #
         def TabScrollLeft():
             self.on_Tab_Scroll_Left_clicked()
 
-        self.form.Tab_Scroll_Left.connect(
-            self.form.Tab_Scroll_Left, SIGNAL("clicked()"), TabScrollLeft
-        )
+        self.form.Tab_Scroll_Left.connect(self.form.Tab_Scroll_Left, SIGNAL("clicked()"), TabScrollLeft)
 
         #
         def TabScrollRight():
             self.on_Tab_Scroll_Right_clicked()
 
-        self.form.Tab_Scroll_Right.connect(
-            self.form.Tab_Scroll_Right, SIGNAL("clicked()"), TabScrollRight
-        )
+        self.form.Tab_Scroll_Right.connect(self.form.Tab_Scroll_Right, SIGNAL("clicked()"), TabScrollRight)
 
         #
         def CategoryScrollLeft():
             self.on_Ribbon_Scroll_Left_clicked()
 
-        self.form.Ribbon_Scroll_Left.connect(
-            self.form.Ribbon_Scroll_Left, SIGNAL("clicked()"), CategoryScrollLeft
-        )
+        self.form.Ribbon_Scroll_Left.connect(self.form.Ribbon_Scroll_Left, SIGNAL("clicked()"), CategoryScrollLeft)
 
         #
         def CategoryScrollRight():
             self.on_Ribbon_Scroll_Right_clicked()
 
-        self.form.Ribbon_Scroll_Right.connect(
-            self.form.Ribbon_Scroll_Right, SIGNAL("clicked()"), CategoryScrollRight
-        )
+        self.form.Ribbon_Scroll_Right.connect(self.form.Ribbon_Scroll_Right, SIGNAL("clicked()"), CategoryScrollRight)
 
         #
         def MoreCommands():
             self.on_MoreCommands_clicked()
 
-        self.form.MoreCommands.connect(
-            self.form.MoreCommands, SIGNAL("clicked()"), MoreCommands
-        )
+        self.form.MoreCommands.connect(self.form.MoreCommands, SIGNAL("clicked()"), MoreCommands)
 
         #
         def PinButtonOpen():
             self.on_pinButton_open_clicked()
 
-        self.form.pinButton_open.connect(
-            self.form.pinButton_open, SIGNAL("clicked()"), PinButtonOpen
-        )
+        self.form.pinButton_open.connect(self.form.pinButton_open, SIGNAL("clicked()"), PinButtonOpen)
 
         #
         def PinButtonClosed():
             self.on_pinButton_closed_clicked()
 
-        self.form.pinButton_closed.connect(
-            self.form.pinButton_closed, SIGNAL("clicked()"), PinButtonClosed
-        )
+        self.form.pinButton_closed.connect(self.form.pinButton_closed, SIGNAL("clicked()"), PinButtonClosed)
         self.form.CustomColors.clicked.connect(self.on_CustomColors_clicked)
         self.form.BorderTransparant.clicked.connect(self.on_BorderTransparant_clicked)
         self.form.Color_Borders.clicked.connect(self.on_Color_Borders_clicked)
         # self.form.Color_Background.clicked.connect(self.on_Color_Background_clicked)
-        self.form.Color_Background_Hover.clicked.connect(
-            self.on_Color_Background_Hover_clicked
-        )
-        self.form.Color_Background_App.clicked.connect(
-            self.on_Color_Background_App_clicked
-        )
+        self.form.Color_Background_Hover.clicked.connect(self.on_Color_Background_Hover_clicked)
+        self.form.Color_Background_App.clicked.connect(self.on_Color_Background_App_clicked)
+        # endregion
 
         # Set the first tab active
         self.form.tabWidget.setCurrentIndex(0)
@@ -625,9 +564,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
 
     def on_BackUpLocation_clicked(self):
         BackupFolder = ""
-        BackupFolder = StandardFunctions.GetFolder(
-            parent=self.form, DefaultPath=Parameters_Ribbon.BACKUP_LOCATION
-        )
+        BackupFolder = StandardFunctions.GetFolder(parent=self.form, DefaultPath=Parameters_Ribbon.BACKUP_LOCATION)
         if BackupFolder != "":
             self.pathBackup = BackupFolder
             self.form.label_4.setText(BackupFolder)
@@ -641,9 +578,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         return
 
     def on_ToolbarPositions_currentIndexChanged(self):
-        self.ValuesToUpdate["Toolbar_Position"] = (
-            self.form.ToolbarPositions.currentIndex()
-        )
+        self.ValuesToUpdate["Toolbar_Position"] = self.form.ToolbarPositions.currentIndex()
         self.settingChanged = True
         return
 
@@ -670,23 +605,17 @@ class LoadDialog(Settings_ui.Ui_Settings):
         return
 
     def on_IconSize_ApplicationButton_TextChanged(self):
-        self.ValuesToUpdate["ApplicationButtonSize"] = int(
-            self.form.IconSize_ApplicationButton.text()
-        )
+        self.ValuesToUpdate["ApplicationButtonSize"] = int(self.form.IconSize_ApplicationButton.text())
         self.settingChanged = True
         return
 
     def on_IconSize_QuickAccessButton_TextChanged(self):
-        self.ValuesToUpdate["QuickAccessButtonSize"] = int(
-            self.form.IconSize_QuickAccessButton.text()
-        )
+        self.ValuesToUpdate["QuickAccessButtonSize"] = int(self.form.IconSize_QuickAccessButton.text())
         self.settingChanged = True
         return
 
     def on_IconSize_rightToolbarButton_TextChanged(self):
-        self.ValuesToUpdate["RightToolbarButtonSize"] = int(
-            self.form.IconSize_rightToolbarButton.text()
-        )
+        self.ValuesToUpdate["RightToolbarButtonSize"] = int(self.form.IconSize_rightToolbarButton.text())
         self.settingChanged = True
         return
 
@@ -805,9 +734,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.settingChanged = True
 
     def on_PreferedViewPanel_currentIndexChanged(self):
-        self.ValuesToUpdate["Preferred_view"] = (
-            self.form.PreferedViewPanel.currentIndex()
-        )
+        self.ValuesToUpdate["Preferred_view"] = self.form.PreferedViewPanel.currentIndex()
         self.settingChanged = True
         return
 
@@ -936,9 +863,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         )
         # if File is not nothing, set the icon in settings and on the button
         if File is not None and File != "" and os.path.isfile(File):
-            Parameters_Ribbon.Settings.SetStringSetting(
-                "ScrollLeftButton_Category", File
-            )
+            Parameters_Ribbon.Settings.SetStringSetting("ScrollLeftButton_Category", File)
             self.form.Ribbon_Scroll_Left.setIcon(QIcon(QPixmap(File)))
             self.form.Ribbon_Scroll_Left.setIconSize(
                 QSize(
@@ -963,9 +888,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         )
         # if File is not nothing, set the icon in settings and on the button
         if File is not None and File != "" and os.path.isfile(File):
-            Parameters_Ribbon.Settings.SetStringSetting(
-                "ScrollRightButton_Category", File
-            )
+            Parameters_Ribbon.Settings.SetStringSetting("ScrollRightButton_Category", File)
             self.form.Ribbon_Scroll_Right.setIcon(QIcon(QPixmap(File)))
             self.form.Ribbon_Scroll_Right.setIconSize(
                 QSize(
@@ -1060,9 +983,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         return
 
     def on_Color_Borders_clicked(self):
-        Color = QColor(
-            self.form.Color_Borders.property("color")
-        ).toTuple()  # RGBA tupple
+        Color = QColor(self.form.Color_Borders.property("color")).toTuple()  # RGBA tupple
         HexColor = StandardFunctions.ColorConvertor(Color, Color[3] / 255, True, False)
         self.ValuesToUpdate["Color_Borders"] = HexColor
         self.settingChanged = True
@@ -1076,18 +997,14 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.settingChanged = True
 
     def on_Color_Background_Hover_clicked(self):
-        Color = QColor(
-            self.form.Color_Background_Hover.property("color")
-        ).toTuple()  # RGBA tupple
+        Color = QColor(self.form.Color_Background_Hover.property("color")).toTuple()  # RGBA tupple
         HexColor = StandardFunctions.ColorConvertor(Color, Color[3] / 255, True, False)
         self.ValuesToUpdate["Color_Background_Hover"] = HexColor
         self.settingChanged = True
         return
 
     def on_Color_Background_App_clicked(self):
-        Color = QColor(
-            self.form.Color_Background_App.property("color")
-        ).toTuple()  # RGBA tupple
+        Color = QColor(self.form.Color_Background_App.property("color")).toTuple()  # RGBA tupple
         HexColor = StandardFunctions.ColorConvertor(Color, Color[3] / 255, True, False)
         self.ValuesToUpdate["Color_Background_App"] = HexColor
         self.settingChanged = True
@@ -1098,144 +1015,68 @@ class LoadDialog(Settings_ui.Ui_Settings):
     @staticmethod
     def on_Cancel_clicked(self):
         # Save backup settings
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "BackupEnabled", self.OriginalValues["BackupEnabled"]
-        )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "BackupFolder", self.OriginalValues["BackupFolder"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("BackupEnabled", self.OriginalValues["BackupEnabled"])
+        Parameters_Ribbon.Settings.SetStringSetting("BackupFolder", self.OriginalValues["BackupFolder"])
         # Save tabBar style
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "TabBar_Style", self.OriginalValues["TabBar_Style"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "Toolbar_Position", self.OriginalValues["Toolbar_Position"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "Hide_Titlebar_FC", self.OriginalValues["Hide_Titlebar_FC"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Style", self.OriginalValues["TabBar_Style"])
+        Parameters_Ribbon.Settings.SetIntSetting("Toolbar_Position", self.OriginalValues["Toolbar_Position"])
+        Parameters_Ribbon.Settings.SetBoolSetting("Hide_Titlebar_FC", self.OriginalValues["Hide_Titlebar_FC"])
         # Save icon sizes
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "IconSize_Small", int(self.OriginalValues["IconSize_Small"])
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "IconSize_Medium", int(self.OriginalValues["IconSize_Medium"])
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "IconSize_Large", int(self.OriginalValues["IconSize_Large"])
-        )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "Stylesheet", self.OriginalValues["Stylesheet"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Small", int(self.OriginalValues["IconSize_Small"]))
+        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Medium", int(self.OriginalValues["IconSize_Medium"]))
+        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Large", int(self.OriginalValues["IconSize_Large"]))
+        Parameters_Ribbon.Settings.SetStringSetting("Stylesheet", self.OriginalValues["Stylesheet"])
         Parameters_Ribbon.Settings.SetIntSetting(
             "ApplicationButtonSize", int(self.OriginalValues["ApplicationButtonSize"])
         )
         Parameters_Ribbon.Settings.SetIntSetting(
             "QuickAccessButtonSize", int(self.OriginalValues["QuickAccessButtonSize"])
         )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "TabBarSize", int(self.OriginalValues["TabBarSize"])
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("TabBarSize", int(self.OriginalValues["TabBarSize"]))
         Parameters_Ribbon.Settings.SetIntSetting(
             "RightToolbarButtonSize", int(self.OriginalValues["RightToolbarButtonSize"])
         )
         # Save text settings
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "ShowIconText_Small", self.OriginalValues["ShowIconText_Small"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "ShowIconText_Medium", self.OriginalValues["ShowIconText_Medium"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "ShowIconText_Large", self.OriginalValues["ShowIconText_Large"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "WrapText_Medium", self.OriginalValues["WrapText_Medium"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "WrapText_Large", self.OriginalValues["WrapText_Large"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "FontSize_Menus", self.OriginalValues["FontSize_Menus"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "FontSize_Buttons", self.OriginalValues["FontSize_Buttons"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "FontSize_Tabs", self.OriginalValues["FontSize_Tabs"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "FontSize_Panels", self.OriginalValues["FontSize_Panels"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Small", self.OriginalValues["ShowIconText_Small"])
+        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Medium", self.OriginalValues["ShowIconText_Medium"])
+        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Large", self.OriginalValues["ShowIconText_Large"])
+        Parameters_Ribbon.Settings.SetBoolSetting("WrapText_Medium", self.OriginalValues["WrapText_Medium"])
+        Parameters_Ribbon.Settings.SetBoolSetting("WrapText_Large", self.OriginalValues["WrapText_Large"])
+        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Menus", self.OriginalValues["FontSize_Menus"])
+        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Buttons", self.OriginalValues["FontSize_Buttons"])
+        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Tabs", self.OriginalValues["FontSize_Tabs"])
+        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Panels", self.OriginalValues["FontSize_Panels"])
         # Save No of columns
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "MaxColumnsPerPanel", int(self.OriginalValues["MaxColumnsPerPanel"])
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "DebugMode", self.OriginalValues["DebugMode"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "ShowOnHover", self.OriginalValues["ShowOnHover"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("MaxColumnsPerPanel", int(self.OriginalValues["MaxColumnsPerPanel"]))
+        Parameters_Ribbon.Settings.SetBoolSetting("DebugMode", self.OriginalValues["DebugMode"])
+        Parameters_Ribbon.Settings.SetBoolSetting("ShowOnHover", self.OriginalValues["ShowOnHover"])
         # Save behavior settings
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "TabBar_Scroll", self.OriginalValues["TabBar_Scroll"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "Ribbon_Scroll", self.OriginalValues["Ribbon_Scroll"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "TabBar_Click", self.OriginalValues["TabBar_Click"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "Ribbon_Click", self.OriginalValues["Ribbon_Click"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Scroll", self.OriginalValues["TabBar_Scroll"])
+        Parameters_Ribbon.Settings.SetIntSetting("Ribbon_Scroll", self.OriginalValues["Ribbon_Scroll"])
+        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Click", self.OriginalValues["TabBar_Click"])
+        Parameters_Ribbon.Settings.SetIntSetting("Ribbon_Click", self.OriginalValues["Ribbon_Click"])
         # Save the preferred toolbars
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "Preferred_view", self.OriginalValues["Preferred_view"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("Preferred_view", self.OriginalValues["Preferred_view"])
         # Set the use of the tools panel
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "UseToolsPanel", self.OriginalValues["UseToolsPanel"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("UseToolsPanel", self.OriginalValues["UseToolsPanel"])
         # Set the use of FreeCAD's overlay function
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "UseOverlay", self.OriginalValues["UseOverlay"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "UseFCOverlay", self.OriginalValues["UseFCOverlay"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "UseButtonBackGround", self.OriginalValues["UseButtonBackGround"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("UseOverlay", self.OriginalValues["UseOverlay"])
+        Parameters_Ribbon.Settings.SetBoolSetting("UseFCOverlay", self.OriginalValues["UseFCOverlay"])
+        Parameters_Ribbon.Settings.SetBoolSetting("UseButtonBackGround", self.OriginalValues["UseButtonBackGround"])
         # Set the use of custom icons
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "CustomIcons", self.OriginalValues["CustomIcons"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("CustomIcons", self.OriginalValues["CustomIcons"])
         # Set the use of custom colors
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "CustomColors", self.OriginalValues["CustomColors"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "BorderTransparant", self.OriginalValues["BorderTransparant"]
-        )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "Color_Borders", self.OriginalValues["Color_Borders"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("CustomColors", self.OriginalValues["CustomColors"])
+        Parameters_Ribbon.Settings.SetBoolSetting("BorderTransparant", self.OriginalValues["BorderTransparant"])
+        Parameters_Ribbon.Settings.SetStringSetting("Color_Borders", self.OriginalValues["Color_Borders"])
         Parameters_Ribbon.Settings.SetStringSetting(
             "Color_Background_Hover", self.OriginalValues["Color_Background_Hover"]
         )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "Color_Background_App", self.OriginalValues["Color_Background_App"]
-        )
+        Parameters_Ribbon.Settings.SetStringSetting("Color_Background_App", self.OriginalValues["Color_Background_App"])
 
         # Set the size of the window to the previous state
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "SettingsDialog_Height", self.form.height()
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "SettingsDialog_Width", self.form.width()
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("SettingsDialog_Height", self.form.height())
+        Parameters_Ribbon.Settings.SetIntSetting("SettingsDialog_Width", self.form.width())
 
         # Close the form
         self.form.close()
@@ -1244,148 +1085,70 @@ class LoadDialog(Settings_ui.Ui_Settings):
     @staticmethod
     def on_Close_clicked(self):
         # Save backup settings
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "BackupEnabled", self.ValuesToUpdate["BackupEnabled"]
-        )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "BackupFolder", self.ValuesToUpdate["BackupFolder"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("BackupEnabled", self.ValuesToUpdate["BackupEnabled"])
+        Parameters_Ribbon.Settings.SetStringSetting("BackupFolder", self.ValuesToUpdate["BackupFolder"])
         # Save tabBar style
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "TabBar_Style", self.ValuesToUpdate["TabBar_Style"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "Toolbar_Position", self.ValuesToUpdate["Toolbar_Position"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "Hide_Titlebar_FC", self.ValuesToUpdate["Hide_Titlebar_FC"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Style", self.ValuesToUpdate["TabBar_Style"])
+        Parameters_Ribbon.Settings.SetIntSetting("Toolbar_Position", self.ValuesToUpdate["Toolbar_Position"])
+        Parameters_Ribbon.Settings.SetBoolSetting("Hide_Titlebar_FC", self.ValuesToUpdate["Hide_Titlebar_FC"])
         # Save icon sizes
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "IconSize_Small", int(self.ValuesToUpdate["IconSize_Small"])
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "IconSize_Medium", int(self.ValuesToUpdate["IconSize_Medium"])
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "IconSize_Large", int(self.ValuesToUpdate["IconSize_Large"])
-        )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "Stylesheet", self.ValuesToUpdate["Stylesheet"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Small", int(self.ValuesToUpdate["IconSize_Small"]))
+        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Medium", int(self.ValuesToUpdate["IconSize_Medium"]))
+        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Large", int(self.ValuesToUpdate["IconSize_Large"]))
+        Parameters_Ribbon.Settings.SetStringSetting("Stylesheet", self.ValuesToUpdate["Stylesheet"])
         Parameters_Ribbon.Settings.SetIntSetting(
             "ApplicationButtonSize", int(self.ValuesToUpdate["ApplicationButtonSize"])
         )
         Parameters_Ribbon.Settings.SetIntSetting(
             "QuickAccessButtonSize", int(self.ValuesToUpdate["QuickAccessButtonSize"])
         )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "TabBarSize", int(self.ValuesToUpdate["TabBarSize"])
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("TabBarSize", int(self.ValuesToUpdate["TabBarSize"]))
         Parameters_Ribbon.Settings.SetIntSetting(
             "RightToolbarButtonSize", int(self.ValuesToUpdate["RightToolbarButtonSize"])
         )
         # Save text settings
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "ShowIconText_Small", self.ValuesToUpdate["ShowIconText_Small"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "ShowIconText_Medium", self.ValuesToUpdate["ShowIconText_Medium"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "ShowIconText_Large", self.ValuesToUpdate["ShowIconText_Large"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "WrapText_Medium", self.ValuesToUpdate["WrapText_Medium"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "WrapText_Large", self.ValuesToUpdate["WrapText_Large"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "FontSize_Menus", self.ValuesToUpdate["FontSize_Menus"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "FontSize_Buttons", self.ValuesToUpdate["FontSize_Buttons"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "FontSize_Tabs", self.ValuesToUpdate["FontSize_Tabs"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "FontSize_Panels", self.ValuesToUpdate["FontSize_Panels"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Small", self.ValuesToUpdate["ShowIconText_Small"])
+        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Medium", self.ValuesToUpdate["ShowIconText_Medium"])
+        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Large", self.ValuesToUpdate["ShowIconText_Large"])
+        Parameters_Ribbon.Settings.SetBoolSetting("WrapText_Medium", self.ValuesToUpdate["WrapText_Medium"])
+        Parameters_Ribbon.Settings.SetBoolSetting("WrapText_Large", self.ValuesToUpdate["WrapText_Large"])
+        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Menus", self.ValuesToUpdate["FontSize_Menus"])
+        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Buttons", self.ValuesToUpdate["FontSize_Buttons"])
+        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Tabs", self.ValuesToUpdate["FontSize_Tabs"])
+        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Panels", self.ValuesToUpdate["FontSize_Panels"])
         # Save No of columns
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "MaxColumnsPerPanel", int(self.ValuesToUpdate["MaxColumnsPerPanel"])
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "DebugMode", self.ValuesToUpdate["DebugMode"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "ShowOnHover", self.ValuesToUpdate["ShowOnHover"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("MaxColumnsPerPanel", int(self.ValuesToUpdate["MaxColumnsPerPanel"]))
+        Parameters_Ribbon.Settings.SetBoolSetting("DebugMode", self.ValuesToUpdate["DebugMode"])
+        Parameters_Ribbon.Settings.SetBoolSetting("ShowOnHover", self.ValuesToUpdate["ShowOnHover"])
         # Save behavior settings
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "TabBar_Scroll", self.ValuesToUpdate["TabBar_Scroll"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "Ribbon_Scroll", self.ValuesToUpdate["Ribbon_Scroll"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "TabBar_Click", self.ValuesToUpdate["TabBar_Click"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "Ribbon_Click", self.ValuesToUpdate["Ribbon_Click"]
-        )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "Shortcut_Application", self.ValuesToUpdate["Shortcut_Application"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Scroll", self.ValuesToUpdate["TabBar_Scroll"])
+        Parameters_Ribbon.Settings.SetIntSetting("Ribbon_Scroll", self.ValuesToUpdate["Ribbon_Scroll"])
+        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Click", self.ValuesToUpdate["TabBar_Click"])
+        Parameters_Ribbon.Settings.SetIntSetting("Ribbon_Click", self.ValuesToUpdate["Ribbon_Click"])
+        Parameters_Ribbon.Settings.SetStringSetting("Shortcut_Application", self.ValuesToUpdate["Shortcut_Application"])
         # Save the preferred toolbars
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "Preferred_view", self.ValuesToUpdate["Preferred_view"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("Preferred_view", self.ValuesToUpdate["Preferred_view"])
         # Set the use of the tools panel
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "UseToolsPanel", self.ValuesToUpdate["UseToolsPanel"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("UseToolsPanel", self.ValuesToUpdate["UseToolsPanel"])
         # Set the use of FreeCAD's overlay function
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "UseOverlay", self.ValuesToUpdate["UseOverlay"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "UseFCOverlay", self.ValuesToUpdate["UseFCOverlay"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "UseButtonBackGround", self.ValuesToUpdate["UseButtonBackGround"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("UseOverlay", self.ValuesToUpdate["UseOverlay"])
+        Parameters_Ribbon.Settings.SetBoolSetting("UseFCOverlay", self.ValuesToUpdate["UseFCOverlay"])
+        Parameters_Ribbon.Settings.SetBoolSetting("UseButtonBackGround", self.ValuesToUpdate["UseButtonBackGround"])
         # Set the use of custom icons
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "CustomIcons", self.ValuesToUpdate["CustomIcons"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("CustomIcons", self.ValuesToUpdate["CustomIcons"])
         # Set the use of custom colors
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "CustomColors", self.ValuesToUpdate["CustomColors"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "BorderTransparant", self.ValuesToUpdate["BorderTransparant"]
-        )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "Color_Borders", self.ValuesToUpdate["Color_Borders"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("CustomColors", self.ValuesToUpdate["CustomColors"])
+        Parameters_Ribbon.Settings.SetBoolSetting("BorderTransparant", self.ValuesToUpdate["BorderTransparant"])
+        Parameters_Ribbon.Settings.SetStringSetting("Color_Borders", self.ValuesToUpdate["Color_Borders"])
         # Parameters_Ribbon.Settings.SetStringSetting("Color_Background", self.ValuesToUpdate["Color_Background"])
         Parameters_Ribbon.Settings.SetStringSetting(
             "Color_Background_Hover", self.ValuesToUpdate["Color_Background_Hover"]
         )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "Color_Background_App", self.ValuesToUpdate["Color_Background_App"]
-        )
+        Parameters_Ribbon.Settings.SetStringSetting("Color_Background_App", self.ValuesToUpdate["Color_Background_App"])
 
         # Set the size of the window to the previous state
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "SettingsDialog_Height", self.form.height()
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "SettingsDialog_Width", self.form.width()
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("SettingsDialog_Height", self.form.height())
+        Parameters_Ribbon.Settings.SetIntSetting("SettingsDialog_Width", self.form.width())
 
         # Close the form
         self.form.close()
@@ -1396,6 +1159,16 @@ class LoadDialog(Settings_ui.Ui_Settings):
                 StandardFunctions.restart_freecad()
             if result == "no":
                 App.saveParameter()
+        return
+
+    @staticmethod
+    def on_Helpbutton_clicked(self):
+        if self.ReproAdress != "" or self.ReproAdress is not None:
+            if not self.ReproAdress.endswith("/"):
+                self.ReproAdress = self.ReproAdress + "/"
+
+            Adress = self.ReproAdress + "wiki"
+            webbrowser.open(Adress, new=2, autoraise=True)
         return
 
     @staticmethod
@@ -1412,15 +1185,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.IconSize_Small.setValue(DefaultSettings["IconSize_Small"])
         self.form.IconSize_Medium.setValue(DefaultSettings["IconSize_Medium"])
         self.form.IconSize_Large.setValue(DefaultSettings["IconSize_Large"])
-        self.form.IconSize_ApplicationButton.setValue(
-            DefaultSettings["ApplicationButtonSize"]
-        )
-        self.form.IconSize_QuickAccessButton.setValue(
-            DefaultSettings["QuickAccessButtonSize"]
-        )
-        self.form.IconSize_rightToolbarButton.setValue(
-            DefaultSettings["RightToolbarButtonSize"]
-        )
+        self.form.IconSize_ApplicationButton.setValue(DefaultSettings["ApplicationButtonSize"])
+        self.form.IconSize_QuickAccessButton.setValue(DefaultSettings["QuickAccessButtonSize"])
+        self.form.IconSize_rightToolbarButton.setValue(DefaultSettings["RightToolbarButtonSize"])
         self.form.TabbarHeight.setValue(DefaultSettings["TabBarSize"])
         self.form.label_7.setText(DefaultSettings["Stylesheet"])
         if DefaultSettings["ShowIconText_Small"] is True:
@@ -1481,9 +1248,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         # Set the color and icon buttons
         self.form.CustomIcons.setCheckState(Qt.CheckState.Unchecked)
 
-        self.form.Tab_Scroll_Left.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab", False)
-        )
+        self.form.Tab_Scroll_Left.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab", False))
         self.form.Tab_Scroll_Left.setIconSize(
             QSize(
                 self.form.Tab_Scroll_Left.width() - 6,
@@ -1491,9 +1256,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Tab_Scroll_Right.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab", False)
-        )
+        self.form.Tab_Scroll_Right.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab", False))
         self.form.Tab_Scroll_Right.setIconSize(
             QSize(
                 self.form.Tab_Scroll_Right.width() - 6,
@@ -1501,9 +1264,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Ribbon_Scroll_Left.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category", False)
-        )
+        self.form.Ribbon_Scroll_Left.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category", False))
         self.form.Ribbon_Scroll_Left.setIconSize(
             QSize(
                 self.form.Ribbon_Scroll_Left.width() - 6,
@@ -1511,9 +1272,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Ribbon_Scroll_Right.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category", False)
-        )
+        self.form.Ribbon_Scroll_Right.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category", False))
         self.form.Ribbon_Scroll_Right.setIconSize(
             QSize(
                 self.form.Ribbon_Scroll_Right.width() - 6,
@@ -1521,18 +1280,12 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.MoreCommands.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("OptionButton", False)
-        )
+        self.form.MoreCommands.setIcon(StyleMapping_Ribbon.ReturnStyleItem("OptionButton", False))
         self.form.MoreCommands.setIconSize(
-            QSize(
-                self.form.MoreCommands.width() - 6, self.form.MoreCommands.height() - 6
-            )
+            QSize(self.form.MoreCommands.width() - 6, self.form.MoreCommands.height() - 6)
         )
 
-        self.form.pinButton_open.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("PinButton_open", False)
-        )
+        self.form.pinButton_open.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_open", False))
         self.form.pinButton_open.setIconSize(
             QSize(
                 self.form.pinButton_open.width() - 6,
@@ -1540,9 +1293,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.pinButton_closed.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed", False)
-        )
+        self.form.pinButton_closed.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed", False))
         self.form.pinButton_closed.setIconSize(
             QSize(
                 self.form.pinButton_closed.width() - 6,
@@ -1550,9 +1301,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Color_Borders.setProperty(
-            "color", QColor(StyleMapping_Ribbon.ReturnStyleItem("Color_Borders"))
-        )
+        self.form.Color_Borders.setProperty("color", QColor(StyleMapping_Ribbon.ReturnStyleItem("Color_Borders")))
         # self.form.Color_Background.setProperty("color", QColor(StyleMapping.ReturnStyleItem("Color_Background")))
         self.form.Color_Background_Hover.setProperty(
             "color",

--- a/LoadSettings_Ribbon.py
+++ b/LoadSettings_Ribbon.py
@@ -160,6 +160,8 @@ class LoadDialog(Settings_ui.Ui_Settings):
 
     settingChanged = False
 
+    ReproAdress: str = ""
+
     def __init__(self):
         # Makes "self.on_CreateBOM_clicked" listen to the changed control values instead initial values
         super(LoadDialog, self).__init__()
@@ -180,6 +182,10 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.setPalette(palette)
         Style = mw.style()
         self.form.setStyle(Style)
+
+        # Get the address of the repository address
+        PackageXML = os.path.join(os.path.dirname(__file__), "package.xml")
+        self.ReproAdress = StandardFunctions.ReturnXML_Value(PackageXML, "url", "type", "repository")
 
         # Set the size of the window to the previous state
         #

--- a/LoadSettings_Ribbon.py
+++ b/LoadSettings_Ribbon.py
@@ -184,10 +184,14 @@ class LoadDialog(Settings_ui.Ui_Settings):
         # Set the size of the window to the previous state
         #
         # Get the previous values
-        LayoutDialog_Height = Parameters_Ribbon.Settings.GetIntSetting("SettingsDialog_Height")
+        LayoutDialog_Height = Parameters_Ribbon.Settings.GetIntSetting(
+            "SettingsDialog_Height"
+        )
         if LayoutDialog_Height == 0 or LayoutDialog_Height is None:
             LayoutDialog_Height = 730
-        LayoutDialog_Width = Parameters_Ribbon.Settings.GetIntSetting("SettingsDialog_Width")
+        LayoutDialog_Width = Parameters_Ribbon.Settings.GetIntSetting(
+            "SettingsDialog_Width"
+        )
         if LayoutDialog_Width == 0 or LayoutDialog_Height is None:
             LayoutDialog_Width = 800
         # set a fixed size to force the form in to shape
@@ -198,7 +202,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.setMinimumSize(600, 600)
         self.form.setMaximumSize(120000, 120000)
         # change the sizepolicy to preferred, to allow stretching
-        self.form.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+        self.form.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred
+        )
 
         # Disable and hide the controls for the old application button
         self.form.label_5.setDisabled(True)
@@ -240,7 +246,10 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.label_4.setText(Parameters_Ribbon.BACKUP_LOCATION)
         self.form.TabbarStyle.setCurrentIndex(Parameters_Ribbon.TABBAR_STYLE)
         self.form.ToolbarPositions.setCurrentIndex(Parameters_Ribbon.TOOLBAR_POSITION)
-        if Parameters_Ribbon.HIDE_TITLEBAR_FC is True or Parameters_Ribbon.HIDE_TITLEBAR_FC is None:
+        if (
+            Parameters_Ribbon.HIDE_TITLEBAR_FC is True
+            or Parameters_Ribbon.HIDE_TITLEBAR_FC is None
+        ):
             self.form.HideTitleBarFC.setCheckState(Qt.CheckState.Checked)
         else:
             self.form.HideTitleBarFC.setCheckState(Qt.CheckState.Unchecked)
@@ -250,7 +259,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.IconSize_Large.setValue(Parameters_Ribbon.ICON_SIZE_LARGE)
         self.form.IconSize_ApplicationButton.setValue(Parameters_Ribbon.APP_ICON_SIZE)
         self.form.IconSize_QuickAccessButton.setValue(Parameters_Ribbon.QUICK_ICON_SIZE)
-        self.form.IconSize_rightToolbarButton.setValue(Parameters_Ribbon.RIGHT_ICON_SIZE)
+        self.form.IconSize_rightToolbarButton.setValue(
+            Parameters_Ribbon.RIGHT_ICON_SIZE
+        )
         self.form.TabbarHeight.setValue(Parameters_Ribbon.TABBAR_SIZE)
 
         self.form.TextSize_Menus.setValue(Parameters_Ribbon.FONTSIZE_MENUS)
@@ -335,7 +346,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         else:
             self.form.CustomIcons.setCheckState(Qt.CheckState.Unchecked)
 
-        self.form.Tab_Scroll_Left.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab", True))
+        self.form.Tab_Scroll_Left.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab", True)
+        )
         self.form.Tab_Scroll_Left.setIconSize(
             QSize(
                 self.form.Tab_Scroll_Left.width() - 6,
@@ -343,7 +356,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Tab_Scroll_Right.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab", True))
+        self.form.Tab_Scroll_Right.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab", True)
+        )
         self.form.Tab_Scroll_Right.setIconSize(
             QSize(
                 self.form.Tab_Scroll_Right.width() - 6,
@@ -351,7 +366,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Ribbon_Scroll_Left.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category", True))
+        self.form.Ribbon_Scroll_Left.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category", True)
+        )
         self.form.Ribbon_Scroll_Left.setIconSize(
             QSize(
                 self.form.Ribbon_Scroll_Left.width() - 6,
@@ -359,7 +376,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Ribbon_Scroll_Right.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category", True))
+        self.form.Ribbon_Scroll_Right.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category", True)
+        )
         self.form.Ribbon_Scroll_Right.setIconSize(
             QSize(
                 self.form.Ribbon_Scroll_Right.width() - 6,
@@ -367,12 +386,18 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.MoreCommands.setIcon(StyleMapping_Ribbon.ReturnStyleItem("OptionButton", True))
+        self.form.MoreCommands.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("OptionButton", True)
+        )
         self.form.MoreCommands.setIconSize(
-            QSize(self.form.MoreCommands.width() - 6, self.form.MoreCommands.height() - 6)
+            QSize(
+                self.form.MoreCommands.width() - 6, self.form.MoreCommands.height() - 6
+            )
         )
 
-        self.form.pinButton_open.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_open", True))
+        self.form.pinButton_open.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("PinButton_open", True)
+        )
         self.form.pinButton_open.setIconSize(
             QSize(
                 self.form.pinButton_open.width() - 6,
@@ -380,7 +405,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.pinButton_closed.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed", True))
+        self.form.pinButton_closed.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed", True)
+        )
         self.form.pinButton_closed.setIconSize(
             QSize(
                 self.form.pinButton_closed.width() - 6,
@@ -398,9 +425,13 @@ class LoadDialog(Settings_ui.Ui_Settings):
         else:
             self.form.BorderTransparant.setCheckState(Qt.CheckState.Unchecked)
 
-        self.form.Color_Borders.setProperty("color", QColor(Parameters_Ribbon.COLOR_BORDERS))
+        self.form.Color_Borders.setProperty(
+            "color", QColor(Parameters_Ribbon.COLOR_BORDERS)
+        )
         # self.form.Color_Background.setProperty("color", QColor(Parameters_Ribbon.COLOR_BACKGROUND))
-        self.form.Color_Background_Hover.setProperty("color", QColor(Parameters_Ribbon.COLOR_BACKGROUND_HOVER))
+        self.form.Color_Background_Hover.setProperty(
+            "color", QColor(Parameters_Ribbon.COLOR_BACKGROUND_HOVER)
+        )
         self.form.Color_Background_App.setProperty(
             "color", QColor(Parameters_Ribbon.COLOR_APPLICATION_BUTTON_BACKGROUND)
         )
@@ -420,16 +451,28 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.EnableBackup.clicked.connect(self.on_EnableBackup_clicked)
         self.form.BackUpLocation.clicked.connect(self.on_BackUpLocation_clicked)
         # Connect the tabbar style
-        self.form.TabbarStyle.currentIndexChanged.connect(self.on_TabbarStyle_currentIndexChanged)
-        self.form.ToolbarPositions.currentIndexChanged.connect(self.on_ToolbarPositions_currentIndexChanged)
+        self.form.TabbarStyle.currentIndexChanged.connect(
+            self.on_TabbarStyle_currentIndexChanged
+        )
+        self.form.ToolbarPositions.currentIndexChanged.connect(
+            self.on_ToolbarPositions_currentIndexChanged
+        )
         self.form.HideTitleBarFC.clicked.connect(self.on_HideTitleBarFC_clicked)
         # Connect icon sizes
         self.form.IconSize_Small.textChanged.connect(self.on_IconSize_Small_TextChanged)
-        self.form.IconSize_Medium.textChanged.connect(self.on_IconSize_Medium_TextChanged)
+        self.form.IconSize_Medium.textChanged.connect(
+            self.on_IconSize_Medium_TextChanged
+        )
         self.form.IconSize_Large.textChanged.connect(self.on_IconSize_Large_TextChanged)
-        self.form.IconSize_ApplicationButton.textChanged.connect(self.on_IconSize_ApplicationButton_TextChanged)
-        self.form.IconSize_QuickAccessButton.textChanged.connect(self.on_IconSize_QuickAccessButton_TextChanged)
-        self.form.IconSize_rightToolbarButton.textChanged.connect(self.on_IconSize_rightToolbarButton_TextChanged)
+        self.form.IconSize_ApplicationButton.textChanged.connect(
+            self.on_IconSize_ApplicationButton_TextChanged
+        )
+        self.form.IconSize_QuickAccessButton.textChanged.connect(
+            self.on_IconSize_QuickAccessButton_TextChanged
+        )
+        self.form.IconSize_rightToolbarButton.textChanged.connect(
+            self.on_IconSize_rightToolbarButton_TextChanged
+        )
         self.form.TabbarHeight.textChanged.connect(self.on_TabbarHeight_TextChanged)
         # Connect stylesheet
         self.form.StyleSheetLocation.clicked.connect(self.on_StyleSheetLocation_clicked)
@@ -441,9 +484,13 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.EnableWrap_Large.clicked.connect(self.on_EnableWrap_Large_clicked)
         # Connect text sizes
         self.form.TextSize_Menus.textChanged.connect(self.on_TextSize_Menus_TextChanged)
-        self.form.TextSize_Buttons.textChanged.connect(self.on_TextSize_Buttons_TextChanged)
+        self.form.TextSize_Buttons.textChanged.connect(
+            self.on_TextSize_Buttons_TextChanged
+        )
         self.form.TextSize_Tabs.textChanged.connect(self.on_TextSize_Tabs_TextChanged)
-        self.form.TextSize_Panels.textChanged.connect(self.on_TextSize_Panels_TextChanged)
+        self.form.TextSize_Panels.textChanged.connect(
+            self.on_TextSize_Panels_TextChanged
+        )
 
         # Connect column width
         self.form.MaxPanelColumn.textChanged.connect(self.on_MaxPanelColumn_TextChanged)
@@ -466,7 +513,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         def GenerateJsonExit():
             self.on_Close_clicked(self)
 
-        self.form.GenerateJsonExit.connect(self.form.GenerateJsonExit, SIGNAL("clicked()"), GenerateJsonExit)
+        self.form.GenerateJsonExit.connect(
+            self.form.GenerateJsonExit, SIGNAL("clicked()"), GenerateJsonExit
+        )
 
         # Connect the reset button
         def Reset():
@@ -476,19 +525,31 @@ class LoadDialog(Settings_ui.Ui_Settings):
 
         # Connect the behavior settings
         self.form.EnableEnterEvent.clicked.connect(self.on_EnableEnterEvent_clicked)
-        self.form.ScrollSpeed_TabBar.valueChanged.connect(self.on_ScrollSpeed_TabBar_valueCHanged)
-        self.form.ScrollSpeed_Ribbon.valueChanged.connect(self.on_ScrollSpeed_Ribbon_valueCHanged)
-        self.form.ScrollClicks_TabBar.textChanged.connect(self.on_ScrollClicks_TabBar_valueCHanged)
-        self.form.ScrollClicks_Ribbon.textChanged.connect(self.on_ScrollClicks_Ribbon_valueCHanged)
+        self.form.ScrollSpeed_TabBar.valueChanged.connect(
+            self.on_ScrollSpeed_TabBar_valueCHanged
+        )
+        self.form.ScrollSpeed_Ribbon.valueChanged.connect(
+            self.on_ScrollSpeed_Ribbon_valueCHanged
+        )
+        self.form.ScrollClicks_TabBar.textChanged.connect(
+            self.on_ScrollClicks_TabBar_valueCHanged
+        )
+        self.form.ScrollClicks_Ribbon.textChanged.connect(
+            self.on_ScrollClicks_Ribbon_valueCHanged
+        )
 
         # Connect the preferred panel settings
-        self.form.PreferedViewPanel.currentIndexChanged.connect(self.on_PreferedViewPanel_currentIndexChanged)
+        self.form.PreferedViewPanel.currentIndexChanged.connect(
+            self.on_PreferedViewPanel_currentIndexChanged
+        )
         # Connect the EnableTools checkbox:
         self.form.EnableToolsPanel.clicked.connect(self.on_EnableToolsPanel_clicked)
         # Connect the overlay setting:
         self.form.EnableOverlay.clicked.connect(self.on_OverlayEnabled_clicked)
         self.form.FCOverlayEnabled.clicked.connect(self.on_FCOverlayEnabled_clicked)
-        self.form.UseButtonBackGround.clicked.connect(self.on_UseButtonBackGround_clicked)
+        self.form.UseButtonBackGround.clicked.connect(
+            self.on_UseButtonBackGround_clicked
+        )
 
         # endregion
 
@@ -499,49 +560,67 @@ class LoadDialog(Settings_ui.Ui_Settings):
         def TabScrollLeft():
             self.on_Tab_Scroll_Left_clicked()
 
-        self.form.Tab_Scroll_Left.connect(self.form.Tab_Scroll_Left, SIGNAL("clicked()"), TabScrollLeft)
+        self.form.Tab_Scroll_Left.connect(
+            self.form.Tab_Scroll_Left, SIGNAL("clicked()"), TabScrollLeft
+        )
 
         #
         def TabScrollRight():
             self.on_Tab_Scroll_Right_clicked()
 
-        self.form.Tab_Scroll_Right.connect(self.form.Tab_Scroll_Right, SIGNAL("clicked()"), TabScrollRight)
+        self.form.Tab_Scroll_Right.connect(
+            self.form.Tab_Scroll_Right, SIGNAL("clicked()"), TabScrollRight
+        )
 
         #
         def CategoryScrollLeft():
             self.on_Ribbon_Scroll_Left_clicked()
 
-        self.form.Ribbon_Scroll_Left.connect(self.form.Ribbon_Scroll_Left, SIGNAL("clicked()"), CategoryScrollLeft)
+        self.form.Ribbon_Scroll_Left.connect(
+            self.form.Ribbon_Scroll_Left, SIGNAL("clicked()"), CategoryScrollLeft
+        )
 
         #
         def CategoryScrollRight():
             self.on_Ribbon_Scroll_Right_clicked()
 
-        self.form.Ribbon_Scroll_Right.connect(self.form.Ribbon_Scroll_Right, SIGNAL("clicked()"), CategoryScrollRight)
+        self.form.Ribbon_Scroll_Right.connect(
+            self.form.Ribbon_Scroll_Right, SIGNAL("clicked()"), CategoryScrollRight
+        )
 
         #
         def MoreCommands():
             self.on_MoreCommands_clicked()
 
-        self.form.MoreCommands.connect(self.form.MoreCommands, SIGNAL("clicked()"), MoreCommands)
+        self.form.MoreCommands.connect(
+            self.form.MoreCommands, SIGNAL("clicked()"), MoreCommands
+        )
 
         #
         def PinButtonOpen():
             self.on_pinButton_open_clicked()
 
-        self.form.pinButton_open.connect(self.form.pinButton_open, SIGNAL("clicked()"), PinButtonOpen)
+        self.form.pinButton_open.connect(
+            self.form.pinButton_open, SIGNAL("clicked()"), PinButtonOpen
+        )
 
         #
         def PinButtonClosed():
             self.on_pinButton_closed_clicked()
 
-        self.form.pinButton_closed.connect(self.form.pinButton_closed, SIGNAL("clicked()"), PinButtonClosed)
+        self.form.pinButton_closed.connect(
+            self.form.pinButton_closed, SIGNAL("clicked()"), PinButtonClosed
+        )
         self.form.CustomColors.clicked.connect(self.on_CustomColors_clicked)
         self.form.BorderTransparant.clicked.connect(self.on_BorderTransparant_clicked)
         self.form.Color_Borders.clicked.connect(self.on_Color_Borders_clicked)
         # self.form.Color_Background.clicked.connect(self.on_Color_Background_clicked)
-        self.form.Color_Background_Hover.clicked.connect(self.on_Color_Background_Hover_clicked)
-        self.form.Color_Background_App.clicked.connect(self.on_Color_Background_App_clicked)
+        self.form.Color_Background_Hover.clicked.connect(
+            self.on_Color_Background_Hover_clicked
+        )
+        self.form.Color_Background_App.clicked.connect(
+            self.on_Color_Background_App_clicked
+        )
         # endregion
 
         # Set the first tab active
@@ -564,7 +643,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
 
     def on_BackUpLocation_clicked(self):
         BackupFolder = ""
-        BackupFolder = StandardFunctions.GetFolder(parent=self.form, DefaultPath=Parameters_Ribbon.BACKUP_LOCATION)
+        BackupFolder = StandardFunctions.GetFolder(
+            parent=self.form, DefaultPath=Parameters_Ribbon.BACKUP_LOCATION
+        )
         if BackupFolder != "":
             self.pathBackup = BackupFolder
             self.form.label_4.setText(BackupFolder)
@@ -578,7 +659,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         return
 
     def on_ToolbarPositions_currentIndexChanged(self):
-        self.ValuesToUpdate["Toolbar_Position"] = self.form.ToolbarPositions.currentIndex()
+        self.ValuesToUpdate["Toolbar_Position"] = (
+            self.form.ToolbarPositions.currentIndex()
+        )
         self.settingChanged = True
         return
 
@@ -605,17 +688,23 @@ class LoadDialog(Settings_ui.Ui_Settings):
         return
 
     def on_IconSize_ApplicationButton_TextChanged(self):
-        self.ValuesToUpdate["ApplicationButtonSize"] = int(self.form.IconSize_ApplicationButton.text())
+        self.ValuesToUpdate["ApplicationButtonSize"] = int(
+            self.form.IconSize_ApplicationButton.text()
+        )
         self.settingChanged = True
         return
 
     def on_IconSize_QuickAccessButton_TextChanged(self):
-        self.ValuesToUpdate["QuickAccessButtonSize"] = int(self.form.IconSize_QuickAccessButton.text())
+        self.ValuesToUpdate["QuickAccessButtonSize"] = int(
+            self.form.IconSize_QuickAccessButton.text()
+        )
         self.settingChanged = True
         return
 
     def on_IconSize_rightToolbarButton_TextChanged(self):
-        self.ValuesToUpdate["RightToolbarButtonSize"] = int(self.form.IconSize_rightToolbarButton.text())
+        self.ValuesToUpdate["RightToolbarButtonSize"] = int(
+            self.form.IconSize_rightToolbarButton.text()
+        )
         self.settingChanged = True
         return
 
@@ -734,7 +823,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.settingChanged = True
 
     def on_PreferedViewPanel_currentIndexChanged(self):
-        self.ValuesToUpdate["Preferred_view"] = self.form.PreferedViewPanel.currentIndex()
+        self.ValuesToUpdate["Preferred_view"] = (
+            self.form.PreferedViewPanel.currentIndex()
+        )
         self.settingChanged = True
         return
 
@@ -863,7 +954,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         )
         # if File is not nothing, set the icon in settings and on the button
         if File is not None and File != "" and os.path.isfile(File):
-            Parameters_Ribbon.Settings.SetStringSetting("ScrollLeftButton_Category", File)
+            Parameters_Ribbon.Settings.SetStringSetting(
+                "ScrollLeftButton_Category", File
+            )
             self.form.Ribbon_Scroll_Left.setIcon(QIcon(QPixmap(File)))
             self.form.Ribbon_Scroll_Left.setIconSize(
                 QSize(
@@ -888,7 +981,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         )
         # if File is not nothing, set the icon in settings and on the button
         if File is not None and File != "" and os.path.isfile(File):
-            Parameters_Ribbon.Settings.SetStringSetting("ScrollRightButton_Category", File)
+            Parameters_Ribbon.Settings.SetStringSetting(
+                "ScrollRightButton_Category", File
+            )
             self.form.Ribbon_Scroll_Right.setIcon(QIcon(QPixmap(File)))
             self.form.Ribbon_Scroll_Right.setIconSize(
                 QSize(
@@ -983,7 +1078,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         return
 
     def on_Color_Borders_clicked(self):
-        Color = QColor(self.form.Color_Borders.property("color")).toTuple()  # RGBA tupple
+        Color = QColor(
+            self.form.Color_Borders.property("color")
+        ).toTuple()  # RGBA tupple
         HexColor = StandardFunctions.ColorConvertor(Color, Color[3] / 255, True, False)
         self.ValuesToUpdate["Color_Borders"] = HexColor
         self.settingChanged = True
@@ -997,14 +1094,18 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.settingChanged = True
 
     def on_Color_Background_Hover_clicked(self):
-        Color = QColor(self.form.Color_Background_Hover.property("color")).toTuple()  # RGBA tupple
+        Color = QColor(
+            self.form.Color_Background_Hover.property("color")
+        ).toTuple()  # RGBA tupple
         HexColor = StandardFunctions.ColorConvertor(Color, Color[3] / 255, True, False)
         self.ValuesToUpdate["Color_Background_Hover"] = HexColor
         self.settingChanged = True
         return
 
     def on_Color_Background_App_clicked(self):
-        Color = QColor(self.form.Color_Background_App.property("color")).toTuple()  # RGBA tupple
+        Color = QColor(
+            self.form.Color_Background_App.property("color")
+        ).toTuple()  # RGBA tupple
         HexColor = StandardFunctions.ColorConvertor(Color, Color[3] / 255, True, False)
         self.ValuesToUpdate["Color_Background_App"] = HexColor
         self.settingChanged = True
@@ -1015,68 +1116,144 @@ class LoadDialog(Settings_ui.Ui_Settings):
     @staticmethod
     def on_Cancel_clicked(self):
         # Save backup settings
-        Parameters_Ribbon.Settings.SetBoolSetting("BackupEnabled", self.OriginalValues["BackupEnabled"])
-        Parameters_Ribbon.Settings.SetStringSetting("BackupFolder", self.OriginalValues["BackupFolder"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "BackupEnabled", self.OriginalValues["BackupEnabled"]
+        )
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "BackupFolder", self.OriginalValues["BackupFolder"]
+        )
         # Save tabBar style
-        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Style", self.OriginalValues["TabBar_Style"])
-        Parameters_Ribbon.Settings.SetIntSetting("Toolbar_Position", self.OriginalValues["Toolbar_Position"])
-        Parameters_Ribbon.Settings.SetBoolSetting("Hide_Titlebar_FC", self.OriginalValues["Hide_Titlebar_FC"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "TabBar_Style", self.OriginalValues["TabBar_Style"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "Toolbar_Position", self.OriginalValues["Toolbar_Position"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "Hide_Titlebar_FC", self.OriginalValues["Hide_Titlebar_FC"]
+        )
         # Save icon sizes
-        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Small", int(self.OriginalValues["IconSize_Small"]))
-        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Medium", int(self.OriginalValues["IconSize_Medium"]))
-        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Large", int(self.OriginalValues["IconSize_Large"]))
-        Parameters_Ribbon.Settings.SetStringSetting("Stylesheet", self.OriginalValues["Stylesheet"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "IconSize_Small", int(self.OriginalValues["IconSize_Small"])
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "IconSize_Medium", int(self.OriginalValues["IconSize_Medium"])
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "IconSize_Large", int(self.OriginalValues["IconSize_Large"])
+        )
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "Stylesheet", self.OriginalValues["Stylesheet"]
+        )
         Parameters_Ribbon.Settings.SetIntSetting(
             "ApplicationButtonSize", int(self.OriginalValues["ApplicationButtonSize"])
         )
         Parameters_Ribbon.Settings.SetIntSetting(
             "QuickAccessButtonSize", int(self.OriginalValues["QuickAccessButtonSize"])
         )
-        Parameters_Ribbon.Settings.SetIntSetting("TabBarSize", int(self.OriginalValues["TabBarSize"]))
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "TabBarSize", int(self.OriginalValues["TabBarSize"])
+        )
         Parameters_Ribbon.Settings.SetIntSetting(
             "RightToolbarButtonSize", int(self.OriginalValues["RightToolbarButtonSize"])
         )
         # Save text settings
-        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Small", self.OriginalValues["ShowIconText_Small"])
-        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Medium", self.OriginalValues["ShowIconText_Medium"])
-        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Large", self.OriginalValues["ShowIconText_Large"])
-        Parameters_Ribbon.Settings.SetBoolSetting("WrapText_Medium", self.OriginalValues["WrapText_Medium"])
-        Parameters_Ribbon.Settings.SetBoolSetting("WrapText_Large", self.OriginalValues["WrapText_Large"])
-        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Menus", self.OriginalValues["FontSize_Menus"])
-        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Buttons", self.OriginalValues["FontSize_Buttons"])
-        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Tabs", self.OriginalValues["FontSize_Tabs"])
-        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Panels", self.OriginalValues["FontSize_Panels"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "ShowIconText_Small", self.OriginalValues["ShowIconText_Small"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "ShowIconText_Medium", self.OriginalValues["ShowIconText_Medium"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "ShowIconText_Large", self.OriginalValues["ShowIconText_Large"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "WrapText_Medium", self.OriginalValues["WrapText_Medium"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "WrapText_Large", self.OriginalValues["WrapText_Large"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "FontSize_Menus", self.OriginalValues["FontSize_Menus"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "FontSize_Buttons", self.OriginalValues["FontSize_Buttons"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "FontSize_Tabs", self.OriginalValues["FontSize_Tabs"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "FontSize_Panels", self.OriginalValues["FontSize_Panels"]
+        )
         # Save No of columns
-        Parameters_Ribbon.Settings.SetIntSetting("MaxColumnsPerPanel", int(self.OriginalValues["MaxColumnsPerPanel"]))
-        Parameters_Ribbon.Settings.SetBoolSetting("DebugMode", self.OriginalValues["DebugMode"])
-        Parameters_Ribbon.Settings.SetBoolSetting("ShowOnHover", self.OriginalValues["ShowOnHover"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "MaxColumnsPerPanel", int(self.OriginalValues["MaxColumnsPerPanel"])
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "DebugMode", self.OriginalValues["DebugMode"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "ShowOnHover", self.OriginalValues["ShowOnHover"]
+        )
         # Save behavior settings
-        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Scroll", self.OriginalValues["TabBar_Scroll"])
-        Parameters_Ribbon.Settings.SetIntSetting("Ribbon_Scroll", self.OriginalValues["Ribbon_Scroll"])
-        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Click", self.OriginalValues["TabBar_Click"])
-        Parameters_Ribbon.Settings.SetIntSetting("Ribbon_Click", self.OriginalValues["Ribbon_Click"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "TabBar_Scroll", self.OriginalValues["TabBar_Scroll"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "Ribbon_Scroll", self.OriginalValues["Ribbon_Scroll"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "TabBar_Click", self.OriginalValues["TabBar_Click"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "Ribbon_Click", self.OriginalValues["Ribbon_Click"]
+        )
         # Save the preferred toolbars
-        Parameters_Ribbon.Settings.SetIntSetting("Preferred_view", self.OriginalValues["Preferred_view"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "Preferred_view", self.OriginalValues["Preferred_view"]
+        )
         # Set the use of the tools panel
-        Parameters_Ribbon.Settings.SetBoolSetting("UseToolsPanel", self.OriginalValues["UseToolsPanel"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "UseToolsPanel", self.OriginalValues["UseToolsPanel"]
+        )
         # Set the use of FreeCAD's overlay function
-        Parameters_Ribbon.Settings.SetBoolSetting("UseOverlay", self.OriginalValues["UseOverlay"])
-        Parameters_Ribbon.Settings.SetBoolSetting("UseFCOverlay", self.OriginalValues["UseFCOverlay"])
-        Parameters_Ribbon.Settings.SetBoolSetting("UseButtonBackGround", self.OriginalValues["UseButtonBackGround"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "UseOverlay", self.OriginalValues["UseOverlay"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "UseFCOverlay", self.OriginalValues["UseFCOverlay"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "UseButtonBackGround", self.OriginalValues["UseButtonBackGround"]
+        )
         # Set the use of custom icons
-        Parameters_Ribbon.Settings.SetBoolSetting("CustomIcons", self.OriginalValues["CustomIcons"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "CustomIcons", self.OriginalValues["CustomIcons"]
+        )
         # Set the use of custom colors
-        Parameters_Ribbon.Settings.SetBoolSetting("CustomColors", self.OriginalValues["CustomColors"])
-        Parameters_Ribbon.Settings.SetBoolSetting("BorderTransparant", self.OriginalValues["BorderTransparant"])
-        Parameters_Ribbon.Settings.SetStringSetting("Color_Borders", self.OriginalValues["Color_Borders"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "CustomColors", self.OriginalValues["CustomColors"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "BorderTransparant", self.OriginalValues["BorderTransparant"]
+        )
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "Color_Borders", self.OriginalValues["Color_Borders"]
+        )
         Parameters_Ribbon.Settings.SetStringSetting(
             "Color_Background_Hover", self.OriginalValues["Color_Background_Hover"]
         )
-        Parameters_Ribbon.Settings.SetStringSetting("Color_Background_App", self.OriginalValues["Color_Background_App"])
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "Color_Background_App", self.OriginalValues["Color_Background_App"]
+        )
 
         # Set the size of the window to the previous state
-        Parameters_Ribbon.Settings.SetIntSetting("SettingsDialog_Height", self.form.height())
-        Parameters_Ribbon.Settings.SetIntSetting("SettingsDialog_Width", self.form.width())
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "SettingsDialog_Height", self.form.height()
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "SettingsDialog_Width", self.form.width()
+        )
 
         # Close the form
         self.form.close()
@@ -1085,70 +1262,148 @@ class LoadDialog(Settings_ui.Ui_Settings):
     @staticmethod
     def on_Close_clicked(self):
         # Save backup settings
-        Parameters_Ribbon.Settings.SetBoolSetting("BackupEnabled", self.ValuesToUpdate["BackupEnabled"])
-        Parameters_Ribbon.Settings.SetStringSetting("BackupFolder", self.ValuesToUpdate["BackupFolder"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "BackupEnabled", self.ValuesToUpdate["BackupEnabled"]
+        )
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "BackupFolder", self.ValuesToUpdate["BackupFolder"]
+        )
         # Save tabBar style
-        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Style", self.ValuesToUpdate["TabBar_Style"])
-        Parameters_Ribbon.Settings.SetIntSetting("Toolbar_Position", self.ValuesToUpdate["Toolbar_Position"])
-        Parameters_Ribbon.Settings.SetBoolSetting("Hide_Titlebar_FC", self.ValuesToUpdate["Hide_Titlebar_FC"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "TabBar_Style", self.ValuesToUpdate["TabBar_Style"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "Toolbar_Position", self.ValuesToUpdate["Toolbar_Position"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "Hide_Titlebar_FC", self.ValuesToUpdate["Hide_Titlebar_FC"]
+        )
         # Save icon sizes
-        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Small", int(self.ValuesToUpdate["IconSize_Small"]))
-        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Medium", int(self.ValuesToUpdate["IconSize_Medium"]))
-        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Large", int(self.ValuesToUpdate["IconSize_Large"]))
-        Parameters_Ribbon.Settings.SetStringSetting("Stylesheet", self.ValuesToUpdate["Stylesheet"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "IconSize_Small", int(self.ValuesToUpdate["IconSize_Small"])
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "IconSize_Medium", int(self.ValuesToUpdate["IconSize_Medium"])
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "IconSize_Large", int(self.ValuesToUpdate["IconSize_Large"])
+        )
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "Stylesheet", self.ValuesToUpdate["Stylesheet"]
+        )
         Parameters_Ribbon.Settings.SetIntSetting(
             "ApplicationButtonSize", int(self.ValuesToUpdate["ApplicationButtonSize"])
         )
         Parameters_Ribbon.Settings.SetIntSetting(
             "QuickAccessButtonSize", int(self.ValuesToUpdate["QuickAccessButtonSize"])
         )
-        Parameters_Ribbon.Settings.SetIntSetting("TabBarSize", int(self.ValuesToUpdate["TabBarSize"]))
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "TabBarSize", int(self.ValuesToUpdate["TabBarSize"])
+        )
         Parameters_Ribbon.Settings.SetIntSetting(
             "RightToolbarButtonSize", int(self.ValuesToUpdate["RightToolbarButtonSize"])
         )
         # Save text settings
-        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Small", self.ValuesToUpdate["ShowIconText_Small"])
-        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Medium", self.ValuesToUpdate["ShowIconText_Medium"])
-        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Large", self.ValuesToUpdate["ShowIconText_Large"])
-        Parameters_Ribbon.Settings.SetBoolSetting("WrapText_Medium", self.ValuesToUpdate["WrapText_Medium"])
-        Parameters_Ribbon.Settings.SetBoolSetting("WrapText_Large", self.ValuesToUpdate["WrapText_Large"])
-        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Menus", self.ValuesToUpdate["FontSize_Menus"])
-        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Buttons", self.ValuesToUpdate["FontSize_Buttons"])
-        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Tabs", self.ValuesToUpdate["FontSize_Tabs"])
-        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Panels", self.ValuesToUpdate["FontSize_Panels"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "ShowIconText_Small", self.ValuesToUpdate["ShowIconText_Small"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "ShowIconText_Medium", self.ValuesToUpdate["ShowIconText_Medium"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "ShowIconText_Large", self.ValuesToUpdate["ShowIconText_Large"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "WrapText_Medium", self.ValuesToUpdate["WrapText_Medium"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "WrapText_Large", self.ValuesToUpdate["WrapText_Large"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "FontSize_Menus", self.ValuesToUpdate["FontSize_Menus"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "FontSize_Buttons", self.ValuesToUpdate["FontSize_Buttons"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "FontSize_Tabs", self.ValuesToUpdate["FontSize_Tabs"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "FontSize_Panels", self.ValuesToUpdate["FontSize_Panels"]
+        )
         # Save No of columns
-        Parameters_Ribbon.Settings.SetIntSetting("MaxColumnsPerPanel", int(self.ValuesToUpdate["MaxColumnsPerPanel"]))
-        Parameters_Ribbon.Settings.SetBoolSetting("DebugMode", self.ValuesToUpdate["DebugMode"])
-        Parameters_Ribbon.Settings.SetBoolSetting("ShowOnHover", self.ValuesToUpdate["ShowOnHover"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "MaxColumnsPerPanel", int(self.ValuesToUpdate["MaxColumnsPerPanel"])
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "DebugMode", self.ValuesToUpdate["DebugMode"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "ShowOnHover", self.ValuesToUpdate["ShowOnHover"]
+        )
         # Save behavior settings
-        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Scroll", self.ValuesToUpdate["TabBar_Scroll"])
-        Parameters_Ribbon.Settings.SetIntSetting("Ribbon_Scroll", self.ValuesToUpdate["Ribbon_Scroll"])
-        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Click", self.ValuesToUpdate["TabBar_Click"])
-        Parameters_Ribbon.Settings.SetIntSetting("Ribbon_Click", self.ValuesToUpdate["Ribbon_Click"])
-        Parameters_Ribbon.Settings.SetStringSetting("Shortcut_Application", self.ValuesToUpdate["Shortcut_Application"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "TabBar_Scroll", self.ValuesToUpdate["TabBar_Scroll"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "Ribbon_Scroll", self.ValuesToUpdate["Ribbon_Scroll"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "TabBar_Click", self.ValuesToUpdate["TabBar_Click"]
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "Ribbon_Click", self.ValuesToUpdate["Ribbon_Click"]
+        )
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "Shortcut_Application", self.ValuesToUpdate["Shortcut_Application"]
+        )
         # Save the preferred toolbars
-        Parameters_Ribbon.Settings.SetIntSetting("Preferred_view", self.ValuesToUpdate["Preferred_view"])
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "Preferred_view", self.ValuesToUpdate["Preferred_view"]
+        )
         # Set the use of the tools panel
-        Parameters_Ribbon.Settings.SetBoolSetting("UseToolsPanel", self.ValuesToUpdate["UseToolsPanel"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "UseToolsPanel", self.ValuesToUpdate["UseToolsPanel"]
+        )
         # Set the use of FreeCAD's overlay function
-        Parameters_Ribbon.Settings.SetBoolSetting("UseOverlay", self.ValuesToUpdate["UseOverlay"])
-        Parameters_Ribbon.Settings.SetBoolSetting("UseFCOverlay", self.ValuesToUpdate["UseFCOverlay"])
-        Parameters_Ribbon.Settings.SetBoolSetting("UseButtonBackGround", self.ValuesToUpdate["UseButtonBackGround"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "UseOverlay", self.ValuesToUpdate["UseOverlay"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "UseFCOverlay", self.ValuesToUpdate["UseFCOverlay"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "UseButtonBackGround", self.ValuesToUpdate["UseButtonBackGround"]
+        )
         # Set the use of custom icons
-        Parameters_Ribbon.Settings.SetBoolSetting("CustomIcons", self.ValuesToUpdate["CustomIcons"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "CustomIcons", self.ValuesToUpdate["CustomIcons"]
+        )
         # Set the use of custom colors
-        Parameters_Ribbon.Settings.SetBoolSetting("CustomColors", self.ValuesToUpdate["CustomColors"])
-        Parameters_Ribbon.Settings.SetBoolSetting("BorderTransparant", self.ValuesToUpdate["BorderTransparant"])
-        Parameters_Ribbon.Settings.SetStringSetting("Color_Borders", self.ValuesToUpdate["Color_Borders"])
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "CustomColors", self.ValuesToUpdate["CustomColors"]
+        )
+        Parameters_Ribbon.Settings.SetBoolSetting(
+            "BorderTransparant", self.ValuesToUpdate["BorderTransparant"]
+        )
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "Color_Borders", self.ValuesToUpdate["Color_Borders"]
+        )
         # Parameters_Ribbon.Settings.SetStringSetting("Color_Background", self.ValuesToUpdate["Color_Background"])
         Parameters_Ribbon.Settings.SetStringSetting(
             "Color_Background_Hover", self.ValuesToUpdate["Color_Background_Hover"]
         )
-        Parameters_Ribbon.Settings.SetStringSetting("Color_Background_App", self.ValuesToUpdate["Color_Background_App"])
+        Parameters_Ribbon.Settings.SetStringSetting(
+            "Color_Background_App", self.ValuesToUpdate["Color_Background_App"]
+        )
 
         # Set the size of the window to the previous state
-        Parameters_Ribbon.Settings.SetIntSetting("SettingsDialog_Height", self.form.height())
-        Parameters_Ribbon.Settings.SetIntSetting("SettingsDialog_Width", self.form.width())
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "SettingsDialog_Height", self.form.height()
+        )
+        Parameters_Ribbon.Settings.SetIntSetting(
+            "SettingsDialog_Width", self.form.width()
+        )
 
         # Close the form
         self.form.close()
@@ -1185,9 +1440,15 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.IconSize_Small.setValue(DefaultSettings["IconSize_Small"])
         self.form.IconSize_Medium.setValue(DefaultSettings["IconSize_Medium"])
         self.form.IconSize_Large.setValue(DefaultSettings["IconSize_Large"])
-        self.form.IconSize_ApplicationButton.setValue(DefaultSettings["ApplicationButtonSize"])
-        self.form.IconSize_QuickAccessButton.setValue(DefaultSettings["QuickAccessButtonSize"])
-        self.form.IconSize_rightToolbarButton.setValue(DefaultSettings["RightToolbarButtonSize"])
+        self.form.IconSize_ApplicationButton.setValue(
+            DefaultSettings["ApplicationButtonSize"]
+        )
+        self.form.IconSize_QuickAccessButton.setValue(
+            DefaultSettings["QuickAccessButtonSize"]
+        )
+        self.form.IconSize_rightToolbarButton.setValue(
+            DefaultSettings["RightToolbarButtonSize"]
+        )
         self.form.TabbarHeight.setValue(DefaultSettings["TabBarSize"])
         self.form.label_7.setText(DefaultSettings["Stylesheet"])
         if DefaultSettings["ShowIconText_Small"] is True:
@@ -1248,7 +1509,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         # Set the color and icon buttons
         self.form.CustomIcons.setCheckState(Qt.CheckState.Unchecked)
 
-        self.form.Tab_Scroll_Left.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab", False))
+        self.form.Tab_Scroll_Left.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab", False)
+        )
         self.form.Tab_Scroll_Left.setIconSize(
             QSize(
                 self.form.Tab_Scroll_Left.width() - 6,
@@ -1256,7 +1519,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Tab_Scroll_Right.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab", False))
+        self.form.Tab_Scroll_Right.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab", False)
+        )
         self.form.Tab_Scroll_Right.setIconSize(
             QSize(
                 self.form.Tab_Scroll_Right.width() - 6,
@@ -1264,7 +1529,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Ribbon_Scroll_Left.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category", False))
+        self.form.Ribbon_Scroll_Left.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category", False)
+        )
         self.form.Ribbon_Scroll_Left.setIconSize(
             QSize(
                 self.form.Ribbon_Scroll_Left.width() - 6,
@@ -1272,7 +1539,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Ribbon_Scroll_Right.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category", False))
+        self.form.Ribbon_Scroll_Right.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category", False)
+        )
         self.form.Ribbon_Scroll_Right.setIconSize(
             QSize(
                 self.form.Ribbon_Scroll_Right.width() - 6,
@@ -1280,12 +1549,18 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.MoreCommands.setIcon(StyleMapping_Ribbon.ReturnStyleItem("OptionButton", False))
+        self.form.MoreCommands.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("OptionButton", False)
+        )
         self.form.MoreCommands.setIconSize(
-            QSize(self.form.MoreCommands.width() - 6, self.form.MoreCommands.height() - 6)
+            QSize(
+                self.form.MoreCommands.width() - 6, self.form.MoreCommands.height() - 6
+            )
         )
 
-        self.form.pinButton_open.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_open", False))
+        self.form.pinButton_open.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("PinButton_open", False)
+        )
         self.form.pinButton_open.setIconSize(
             QSize(
                 self.form.pinButton_open.width() - 6,
@@ -1293,7 +1568,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.pinButton_closed.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed", False))
+        self.form.pinButton_closed.setIcon(
+            StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed", False)
+        )
         self.form.pinButton_closed.setIconSize(
             QSize(
                 self.form.pinButton_closed.width() - 6,
@@ -1301,7 +1578,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Color_Borders.setProperty("color", QColor(StyleMapping_Ribbon.ReturnStyleItem("Color_Borders")))
+        self.form.Color_Borders.setProperty(
+            "color", QColor(StyleMapping_Ribbon.ReturnStyleItem("Color_Borders"))
+        )
         # self.form.Color_Background.setProperty("color", QColor(StyleMapping.ReturnStyleItem("Color_Background")))
         self.form.Color_Background_Hover.setProperty(
             "color",

--- a/LoadSettings_Ribbon.py
+++ b/LoadSettings_Ribbon.py
@@ -184,14 +184,10 @@ class LoadDialog(Settings_ui.Ui_Settings):
         # Set the size of the window to the previous state
         #
         # Get the previous values
-        LayoutDialog_Height = Parameters_Ribbon.Settings.GetIntSetting(
-            "SettingsDialog_Height"
-        )
+        LayoutDialog_Height = Parameters_Ribbon.Settings.GetIntSetting("SettingsDialog_Height")
         if LayoutDialog_Height == 0 or LayoutDialog_Height is None:
             LayoutDialog_Height = 730
-        LayoutDialog_Width = Parameters_Ribbon.Settings.GetIntSetting(
-            "SettingsDialog_Width"
-        )
+        LayoutDialog_Width = Parameters_Ribbon.Settings.GetIntSetting("SettingsDialog_Width")
         if LayoutDialog_Width == 0 or LayoutDialog_Height is None:
             LayoutDialog_Width = 800
         # set a fixed size to force the form in to shape
@@ -202,9 +198,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.setMinimumSize(600, 600)
         self.form.setMaximumSize(120000, 120000)
         # change the sizepolicy to preferred, to allow stretching
-        self.form.setSizePolicy(
-            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred
-        )
+        self.form.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
 
         # Disable and hide the controls for the old application button
         self.form.label_5.setDisabled(True)
@@ -246,10 +240,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.label_4.setText(Parameters_Ribbon.BACKUP_LOCATION)
         self.form.TabbarStyle.setCurrentIndex(Parameters_Ribbon.TABBAR_STYLE)
         self.form.ToolbarPositions.setCurrentIndex(Parameters_Ribbon.TOOLBAR_POSITION)
-        if (
-            Parameters_Ribbon.HIDE_TITLEBAR_FC is True
-            or Parameters_Ribbon.HIDE_TITLEBAR_FC is None
-        ):
+        if Parameters_Ribbon.HIDE_TITLEBAR_FC is True or Parameters_Ribbon.HIDE_TITLEBAR_FC is None:
             self.form.HideTitleBarFC.setCheckState(Qt.CheckState.Checked)
         else:
             self.form.HideTitleBarFC.setCheckState(Qt.CheckState.Unchecked)
@@ -259,9 +250,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.IconSize_Large.setValue(Parameters_Ribbon.ICON_SIZE_LARGE)
         self.form.IconSize_ApplicationButton.setValue(Parameters_Ribbon.APP_ICON_SIZE)
         self.form.IconSize_QuickAccessButton.setValue(Parameters_Ribbon.QUICK_ICON_SIZE)
-        self.form.IconSize_rightToolbarButton.setValue(
-            Parameters_Ribbon.RIGHT_ICON_SIZE
-        )
+        self.form.IconSize_rightToolbarButton.setValue(Parameters_Ribbon.RIGHT_ICON_SIZE)
         self.form.TabbarHeight.setValue(Parameters_Ribbon.TABBAR_SIZE)
 
         self.form.TextSize_Menus.setValue(Parameters_Ribbon.FONTSIZE_MENUS)
@@ -346,9 +335,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         else:
             self.form.CustomIcons.setCheckState(Qt.CheckState.Unchecked)
 
-        self.form.Tab_Scroll_Left.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab", True)
-        )
+        self.form.Tab_Scroll_Left.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab", True))
         self.form.Tab_Scroll_Left.setIconSize(
             QSize(
                 self.form.Tab_Scroll_Left.width() - 6,
@@ -356,9 +343,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Tab_Scroll_Right.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab", True)
-        )
+        self.form.Tab_Scroll_Right.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab", True))
         self.form.Tab_Scroll_Right.setIconSize(
             QSize(
                 self.form.Tab_Scroll_Right.width() - 6,
@@ -366,9 +351,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Ribbon_Scroll_Left.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category", True)
-        )
+        self.form.Ribbon_Scroll_Left.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category", True))
         self.form.Ribbon_Scroll_Left.setIconSize(
             QSize(
                 self.form.Ribbon_Scroll_Left.width() - 6,
@@ -376,9 +359,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Ribbon_Scroll_Right.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category", True)
-        )
+        self.form.Ribbon_Scroll_Right.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category", True))
         self.form.Ribbon_Scroll_Right.setIconSize(
             QSize(
                 self.form.Ribbon_Scroll_Right.width() - 6,
@@ -386,18 +367,12 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.MoreCommands.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("OptionButton", True)
-        )
+        self.form.MoreCommands.setIcon(StyleMapping_Ribbon.ReturnStyleItem("OptionButton", True))
         self.form.MoreCommands.setIconSize(
-            QSize(
-                self.form.MoreCommands.width() - 6, self.form.MoreCommands.height() - 6
-            )
+            QSize(self.form.MoreCommands.width() - 6, self.form.MoreCommands.height() - 6)
         )
 
-        self.form.pinButton_open.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("PinButton_open", True)
-        )
+        self.form.pinButton_open.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_open", True))
         self.form.pinButton_open.setIconSize(
             QSize(
                 self.form.pinButton_open.width() - 6,
@@ -405,9 +380,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.pinButton_closed.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed", True)
-        )
+        self.form.pinButton_closed.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed", True))
         self.form.pinButton_closed.setIconSize(
             QSize(
                 self.form.pinButton_closed.width() - 6,
@@ -425,13 +398,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         else:
             self.form.BorderTransparant.setCheckState(Qt.CheckState.Unchecked)
 
-        self.form.Color_Borders.setProperty(
-            "color", QColor(Parameters_Ribbon.COLOR_BORDERS)
-        )
+        self.form.Color_Borders.setProperty("color", QColor(Parameters_Ribbon.COLOR_BORDERS))
         # self.form.Color_Background.setProperty("color", QColor(Parameters_Ribbon.COLOR_BACKGROUND))
-        self.form.Color_Background_Hover.setProperty(
-            "color", QColor(Parameters_Ribbon.COLOR_BACKGROUND_HOVER)
-        )
+        self.form.Color_Background_Hover.setProperty("color", QColor(Parameters_Ribbon.COLOR_BACKGROUND_HOVER))
         self.form.Color_Background_App.setProperty(
             "color", QColor(Parameters_Ribbon.COLOR_APPLICATION_BUTTON_BACKGROUND)
         )
@@ -443,7 +412,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
 
         if helpIcon is not None:
             self.form.HelpButton.setIcon(helpIcon)
-        self.form.HelpButton.setMinimumHeight(self.form.Close.minimumHeight())
+        self.form.HelpButton.setMinimumHeight(self.form.GenerateJsonExit.minimumHeight())
 
         # region - connect controls with functions----------------------------------------------------
         #
@@ -451,28 +420,16 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.EnableBackup.clicked.connect(self.on_EnableBackup_clicked)
         self.form.BackUpLocation.clicked.connect(self.on_BackUpLocation_clicked)
         # Connect the tabbar style
-        self.form.TabbarStyle.currentIndexChanged.connect(
-            self.on_TabbarStyle_currentIndexChanged
-        )
-        self.form.ToolbarPositions.currentIndexChanged.connect(
-            self.on_ToolbarPositions_currentIndexChanged
-        )
+        self.form.TabbarStyle.currentIndexChanged.connect(self.on_TabbarStyle_currentIndexChanged)
+        self.form.ToolbarPositions.currentIndexChanged.connect(self.on_ToolbarPositions_currentIndexChanged)
         self.form.HideTitleBarFC.clicked.connect(self.on_HideTitleBarFC_clicked)
         # Connect icon sizes
         self.form.IconSize_Small.textChanged.connect(self.on_IconSize_Small_TextChanged)
-        self.form.IconSize_Medium.textChanged.connect(
-            self.on_IconSize_Medium_TextChanged
-        )
+        self.form.IconSize_Medium.textChanged.connect(self.on_IconSize_Medium_TextChanged)
         self.form.IconSize_Large.textChanged.connect(self.on_IconSize_Large_TextChanged)
-        self.form.IconSize_ApplicationButton.textChanged.connect(
-            self.on_IconSize_ApplicationButton_TextChanged
-        )
-        self.form.IconSize_QuickAccessButton.textChanged.connect(
-            self.on_IconSize_QuickAccessButton_TextChanged
-        )
-        self.form.IconSize_rightToolbarButton.textChanged.connect(
-            self.on_IconSize_rightToolbarButton_TextChanged
-        )
+        self.form.IconSize_ApplicationButton.textChanged.connect(self.on_IconSize_ApplicationButton_TextChanged)
+        self.form.IconSize_QuickAccessButton.textChanged.connect(self.on_IconSize_QuickAccessButton_TextChanged)
+        self.form.IconSize_rightToolbarButton.textChanged.connect(self.on_IconSize_rightToolbarButton_TextChanged)
         self.form.TabbarHeight.textChanged.connect(self.on_TabbarHeight_TextChanged)
         # Connect stylesheet
         self.form.StyleSheetLocation.clicked.connect(self.on_StyleSheetLocation_clicked)
@@ -484,13 +441,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.EnableWrap_Large.clicked.connect(self.on_EnableWrap_Large_clicked)
         # Connect text sizes
         self.form.TextSize_Menus.textChanged.connect(self.on_TextSize_Menus_TextChanged)
-        self.form.TextSize_Buttons.textChanged.connect(
-            self.on_TextSize_Buttons_TextChanged
-        )
+        self.form.TextSize_Buttons.textChanged.connect(self.on_TextSize_Buttons_TextChanged)
         self.form.TextSize_Tabs.textChanged.connect(self.on_TextSize_Tabs_TextChanged)
-        self.form.TextSize_Panels.textChanged.connect(
-            self.on_TextSize_Panels_TextChanged
-        )
+        self.form.TextSize_Panels.textChanged.connect(self.on_TextSize_Panels_TextChanged)
 
         # Connect column width
         self.form.MaxPanelColumn.textChanged.connect(self.on_MaxPanelColumn_TextChanged)
@@ -513,9 +466,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         def GenerateJsonExit():
             self.on_Close_clicked(self)
 
-        self.form.GenerateJsonExit.connect(
-            self.form.GenerateJsonExit, SIGNAL("clicked()"), GenerateJsonExit
-        )
+        self.form.GenerateJsonExit.connect(self.form.GenerateJsonExit, SIGNAL("clicked()"), GenerateJsonExit)
 
         # Connect the reset button
         def Reset():
@@ -525,31 +476,19 @@ class LoadDialog(Settings_ui.Ui_Settings):
 
         # Connect the behavior settings
         self.form.EnableEnterEvent.clicked.connect(self.on_EnableEnterEvent_clicked)
-        self.form.ScrollSpeed_TabBar.valueChanged.connect(
-            self.on_ScrollSpeed_TabBar_valueCHanged
-        )
-        self.form.ScrollSpeed_Ribbon.valueChanged.connect(
-            self.on_ScrollSpeed_Ribbon_valueCHanged
-        )
-        self.form.ScrollClicks_TabBar.textChanged.connect(
-            self.on_ScrollClicks_TabBar_valueCHanged
-        )
-        self.form.ScrollClicks_Ribbon.textChanged.connect(
-            self.on_ScrollClicks_Ribbon_valueCHanged
-        )
+        self.form.ScrollSpeed_TabBar.valueChanged.connect(self.on_ScrollSpeed_TabBar_valueCHanged)
+        self.form.ScrollSpeed_Ribbon.valueChanged.connect(self.on_ScrollSpeed_Ribbon_valueCHanged)
+        self.form.ScrollClicks_TabBar.textChanged.connect(self.on_ScrollClicks_TabBar_valueCHanged)
+        self.form.ScrollClicks_Ribbon.textChanged.connect(self.on_ScrollClicks_Ribbon_valueCHanged)
 
         # Connect the preferred panel settings
-        self.form.PreferedViewPanel.currentIndexChanged.connect(
-            self.on_PreferedViewPanel_currentIndexChanged
-        )
+        self.form.PreferedViewPanel.currentIndexChanged.connect(self.on_PreferedViewPanel_currentIndexChanged)
         # Connect the EnableTools checkbox:
         self.form.EnableToolsPanel.clicked.connect(self.on_EnableToolsPanel_clicked)
         # Connect the overlay setting:
         self.form.EnableOverlay.clicked.connect(self.on_OverlayEnabled_clicked)
         self.form.FCOverlayEnabled.clicked.connect(self.on_FCOverlayEnabled_clicked)
-        self.form.UseButtonBackGround.clicked.connect(
-            self.on_UseButtonBackGround_clicked
-        )
+        self.form.UseButtonBackGround.clicked.connect(self.on_UseButtonBackGround_clicked)
 
         # endregion
 
@@ -560,67 +499,49 @@ class LoadDialog(Settings_ui.Ui_Settings):
         def TabScrollLeft():
             self.on_Tab_Scroll_Left_clicked()
 
-        self.form.Tab_Scroll_Left.connect(
-            self.form.Tab_Scroll_Left, SIGNAL("clicked()"), TabScrollLeft
-        )
+        self.form.Tab_Scroll_Left.connect(self.form.Tab_Scroll_Left, SIGNAL("clicked()"), TabScrollLeft)
 
         #
         def TabScrollRight():
             self.on_Tab_Scroll_Right_clicked()
 
-        self.form.Tab_Scroll_Right.connect(
-            self.form.Tab_Scroll_Right, SIGNAL("clicked()"), TabScrollRight
-        )
+        self.form.Tab_Scroll_Right.connect(self.form.Tab_Scroll_Right, SIGNAL("clicked()"), TabScrollRight)
 
         #
         def CategoryScrollLeft():
             self.on_Ribbon_Scroll_Left_clicked()
 
-        self.form.Ribbon_Scroll_Left.connect(
-            self.form.Ribbon_Scroll_Left, SIGNAL("clicked()"), CategoryScrollLeft
-        )
+        self.form.Ribbon_Scroll_Left.connect(self.form.Ribbon_Scroll_Left, SIGNAL("clicked()"), CategoryScrollLeft)
 
         #
         def CategoryScrollRight():
             self.on_Ribbon_Scroll_Right_clicked()
 
-        self.form.Ribbon_Scroll_Right.connect(
-            self.form.Ribbon_Scroll_Right, SIGNAL("clicked()"), CategoryScrollRight
-        )
+        self.form.Ribbon_Scroll_Right.connect(self.form.Ribbon_Scroll_Right, SIGNAL("clicked()"), CategoryScrollRight)
 
         #
         def MoreCommands():
             self.on_MoreCommands_clicked()
 
-        self.form.MoreCommands.connect(
-            self.form.MoreCommands, SIGNAL("clicked()"), MoreCommands
-        )
+        self.form.MoreCommands.connect(self.form.MoreCommands, SIGNAL("clicked()"), MoreCommands)
 
         #
         def PinButtonOpen():
             self.on_pinButton_open_clicked()
 
-        self.form.pinButton_open.connect(
-            self.form.pinButton_open, SIGNAL("clicked()"), PinButtonOpen
-        )
+        self.form.pinButton_open.connect(self.form.pinButton_open, SIGNAL("clicked()"), PinButtonOpen)
 
         #
         def PinButtonClosed():
             self.on_pinButton_closed_clicked()
 
-        self.form.pinButton_closed.connect(
-            self.form.pinButton_closed, SIGNAL("clicked()"), PinButtonClosed
-        )
+        self.form.pinButton_closed.connect(self.form.pinButton_closed, SIGNAL("clicked()"), PinButtonClosed)
         self.form.CustomColors.clicked.connect(self.on_CustomColors_clicked)
         self.form.BorderTransparant.clicked.connect(self.on_BorderTransparant_clicked)
         self.form.Color_Borders.clicked.connect(self.on_Color_Borders_clicked)
         # self.form.Color_Background.clicked.connect(self.on_Color_Background_clicked)
-        self.form.Color_Background_Hover.clicked.connect(
-            self.on_Color_Background_Hover_clicked
-        )
-        self.form.Color_Background_App.clicked.connect(
-            self.on_Color_Background_App_clicked
-        )
+        self.form.Color_Background_Hover.clicked.connect(self.on_Color_Background_Hover_clicked)
+        self.form.Color_Background_App.clicked.connect(self.on_Color_Background_App_clicked)
         # endregion
 
         # Set the first tab active
@@ -643,9 +564,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
 
     def on_BackUpLocation_clicked(self):
         BackupFolder = ""
-        BackupFolder = StandardFunctions.GetFolder(
-            parent=self.form, DefaultPath=Parameters_Ribbon.BACKUP_LOCATION
-        )
+        BackupFolder = StandardFunctions.GetFolder(parent=self.form, DefaultPath=Parameters_Ribbon.BACKUP_LOCATION)
         if BackupFolder != "":
             self.pathBackup = BackupFolder
             self.form.label_4.setText(BackupFolder)
@@ -659,9 +578,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         return
 
     def on_ToolbarPositions_currentIndexChanged(self):
-        self.ValuesToUpdate["Toolbar_Position"] = (
-            self.form.ToolbarPositions.currentIndex()
-        )
+        self.ValuesToUpdate["Toolbar_Position"] = self.form.ToolbarPositions.currentIndex()
         self.settingChanged = True
         return
 
@@ -688,23 +605,17 @@ class LoadDialog(Settings_ui.Ui_Settings):
         return
 
     def on_IconSize_ApplicationButton_TextChanged(self):
-        self.ValuesToUpdate["ApplicationButtonSize"] = int(
-            self.form.IconSize_ApplicationButton.text()
-        )
+        self.ValuesToUpdate["ApplicationButtonSize"] = int(self.form.IconSize_ApplicationButton.text())
         self.settingChanged = True
         return
 
     def on_IconSize_QuickAccessButton_TextChanged(self):
-        self.ValuesToUpdate["QuickAccessButtonSize"] = int(
-            self.form.IconSize_QuickAccessButton.text()
-        )
+        self.ValuesToUpdate["QuickAccessButtonSize"] = int(self.form.IconSize_QuickAccessButton.text())
         self.settingChanged = True
         return
 
     def on_IconSize_rightToolbarButton_TextChanged(self):
-        self.ValuesToUpdate["RightToolbarButtonSize"] = int(
-            self.form.IconSize_rightToolbarButton.text()
-        )
+        self.ValuesToUpdate["RightToolbarButtonSize"] = int(self.form.IconSize_rightToolbarButton.text())
         self.settingChanged = True
         return
 
@@ -823,9 +734,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.settingChanged = True
 
     def on_PreferedViewPanel_currentIndexChanged(self):
-        self.ValuesToUpdate["Preferred_view"] = (
-            self.form.PreferedViewPanel.currentIndex()
-        )
+        self.ValuesToUpdate["Preferred_view"] = self.form.PreferedViewPanel.currentIndex()
         self.settingChanged = True
         return
 
@@ -954,9 +863,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         )
         # if File is not nothing, set the icon in settings and on the button
         if File is not None and File != "" and os.path.isfile(File):
-            Parameters_Ribbon.Settings.SetStringSetting(
-                "ScrollLeftButton_Category", File
-            )
+            Parameters_Ribbon.Settings.SetStringSetting("ScrollLeftButton_Category", File)
             self.form.Ribbon_Scroll_Left.setIcon(QIcon(QPixmap(File)))
             self.form.Ribbon_Scroll_Left.setIconSize(
                 QSize(
@@ -981,9 +888,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         )
         # if File is not nothing, set the icon in settings and on the button
         if File is not None and File != "" and os.path.isfile(File):
-            Parameters_Ribbon.Settings.SetStringSetting(
-                "ScrollRightButton_Category", File
-            )
+            Parameters_Ribbon.Settings.SetStringSetting("ScrollRightButton_Category", File)
             self.form.Ribbon_Scroll_Right.setIcon(QIcon(QPixmap(File)))
             self.form.Ribbon_Scroll_Right.setIconSize(
                 QSize(
@@ -1078,9 +983,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         return
 
     def on_Color_Borders_clicked(self):
-        Color = QColor(
-            self.form.Color_Borders.property("color")
-        ).toTuple()  # RGBA tupple
+        Color = QColor(self.form.Color_Borders.property("color")).toTuple()  # RGBA tupple
         HexColor = StandardFunctions.ColorConvertor(Color, Color[3] / 255, True, False)
         self.ValuesToUpdate["Color_Borders"] = HexColor
         self.settingChanged = True
@@ -1094,18 +997,14 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.settingChanged = True
 
     def on_Color_Background_Hover_clicked(self):
-        Color = QColor(
-            self.form.Color_Background_Hover.property("color")
-        ).toTuple()  # RGBA tupple
+        Color = QColor(self.form.Color_Background_Hover.property("color")).toTuple()  # RGBA tupple
         HexColor = StandardFunctions.ColorConvertor(Color, Color[3] / 255, True, False)
         self.ValuesToUpdate["Color_Background_Hover"] = HexColor
         self.settingChanged = True
         return
 
     def on_Color_Background_App_clicked(self):
-        Color = QColor(
-            self.form.Color_Background_App.property("color")
-        ).toTuple()  # RGBA tupple
+        Color = QColor(self.form.Color_Background_App.property("color")).toTuple()  # RGBA tupple
         HexColor = StandardFunctions.ColorConvertor(Color, Color[3] / 255, True, False)
         self.ValuesToUpdate["Color_Background_App"] = HexColor
         self.settingChanged = True
@@ -1116,144 +1015,68 @@ class LoadDialog(Settings_ui.Ui_Settings):
     @staticmethod
     def on_Cancel_clicked(self):
         # Save backup settings
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "BackupEnabled", self.OriginalValues["BackupEnabled"]
-        )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "BackupFolder", self.OriginalValues["BackupFolder"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("BackupEnabled", self.OriginalValues["BackupEnabled"])
+        Parameters_Ribbon.Settings.SetStringSetting("BackupFolder", self.OriginalValues["BackupFolder"])
         # Save tabBar style
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "TabBar_Style", self.OriginalValues["TabBar_Style"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "Toolbar_Position", self.OriginalValues["Toolbar_Position"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "Hide_Titlebar_FC", self.OriginalValues["Hide_Titlebar_FC"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Style", self.OriginalValues["TabBar_Style"])
+        Parameters_Ribbon.Settings.SetIntSetting("Toolbar_Position", self.OriginalValues["Toolbar_Position"])
+        Parameters_Ribbon.Settings.SetBoolSetting("Hide_Titlebar_FC", self.OriginalValues["Hide_Titlebar_FC"])
         # Save icon sizes
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "IconSize_Small", int(self.OriginalValues["IconSize_Small"])
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "IconSize_Medium", int(self.OriginalValues["IconSize_Medium"])
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "IconSize_Large", int(self.OriginalValues["IconSize_Large"])
-        )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "Stylesheet", self.OriginalValues["Stylesheet"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Small", int(self.OriginalValues["IconSize_Small"]))
+        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Medium", int(self.OriginalValues["IconSize_Medium"]))
+        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Large", int(self.OriginalValues["IconSize_Large"]))
+        Parameters_Ribbon.Settings.SetStringSetting("Stylesheet", self.OriginalValues["Stylesheet"])
         Parameters_Ribbon.Settings.SetIntSetting(
             "ApplicationButtonSize", int(self.OriginalValues["ApplicationButtonSize"])
         )
         Parameters_Ribbon.Settings.SetIntSetting(
             "QuickAccessButtonSize", int(self.OriginalValues["QuickAccessButtonSize"])
         )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "TabBarSize", int(self.OriginalValues["TabBarSize"])
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("TabBarSize", int(self.OriginalValues["TabBarSize"]))
         Parameters_Ribbon.Settings.SetIntSetting(
             "RightToolbarButtonSize", int(self.OriginalValues["RightToolbarButtonSize"])
         )
         # Save text settings
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "ShowIconText_Small", self.OriginalValues["ShowIconText_Small"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "ShowIconText_Medium", self.OriginalValues["ShowIconText_Medium"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "ShowIconText_Large", self.OriginalValues["ShowIconText_Large"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "WrapText_Medium", self.OriginalValues["WrapText_Medium"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "WrapText_Large", self.OriginalValues["WrapText_Large"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "FontSize_Menus", self.OriginalValues["FontSize_Menus"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "FontSize_Buttons", self.OriginalValues["FontSize_Buttons"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "FontSize_Tabs", self.OriginalValues["FontSize_Tabs"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "FontSize_Panels", self.OriginalValues["FontSize_Panels"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Small", self.OriginalValues["ShowIconText_Small"])
+        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Medium", self.OriginalValues["ShowIconText_Medium"])
+        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Large", self.OriginalValues["ShowIconText_Large"])
+        Parameters_Ribbon.Settings.SetBoolSetting("WrapText_Medium", self.OriginalValues["WrapText_Medium"])
+        Parameters_Ribbon.Settings.SetBoolSetting("WrapText_Large", self.OriginalValues["WrapText_Large"])
+        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Menus", self.OriginalValues["FontSize_Menus"])
+        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Buttons", self.OriginalValues["FontSize_Buttons"])
+        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Tabs", self.OriginalValues["FontSize_Tabs"])
+        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Panels", self.OriginalValues["FontSize_Panels"])
         # Save No of columns
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "MaxColumnsPerPanel", int(self.OriginalValues["MaxColumnsPerPanel"])
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "DebugMode", self.OriginalValues["DebugMode"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "ShowOnHover", self.OriginalValues["ShowOnHover"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("MaxColumnsPerPanel", int(self.OriginalValues["MaxColumnsPerPanel"]))
+        Parameters_Ribbon.Settings.SetBoolSetting("DebugMode", self.OriginalValues["DebugMode"])
+        Parameters_Ribbon.Settings.SetBoolSetting("ShowOnHover", self.OriginalValues["ShowOnHover"])
         # Save behavior settings
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "TabBar_Scroll", self.OriginalValues["TabBar_Scroll"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "Ribbon_Scroll", self.OriginalValues["Ribbon_Scroll"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "TabBar_Click", self.OriginalValues["TabBar_Click"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "Ribbon_Click", self.OriginalValues["Ribbon_Click"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Scroll", self.OriginalValues["TabBar_Scroll"])
+        Parameters_Ribbon.Settings.SetIntSetting("Ribbon_Scroll", self.OriginalValues["Ribbon_Scroll"])
+        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Click", self.OriginalValues["TabBar_Click"])
+        Parameters_Ribbon.Settings.SetIntSetting("Ribbon_Click", self.OriginalValues["Ribbon_Click"])
         # Save the preferred toolbars
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "Preferred_view", self.OriginalValues["Preferred_view"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("Preferred_view", self.OriginalValues["Preferred_view"])
         # Set the use of the tools panel
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "UseToolsPanel", self.OriginalValues["UseToolsPanel"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("UseToolsPanel", self.OriginalValues["UseToolsPanel"])
         # Set the use of FreeCAD's overlay function
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "UseOverlay", self.OriginalValues["UseOverlay"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "UseFCOverlay", self.OriginalValues["UseFCOverlay"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "UseButtonBackGround", self.OriginalValues["UseButtonBackGround"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("UseOverlay", self.OriginalValues["UseOverlay"])
+        Parameters_Ribbon.Settings.SetBoolSetting("UseFCOverlay", self.OriginalValues["UseFCOverlay"])
+        Parameters_Ribbon.Settings.SetBoolSetting("UseButtonBackGround", self.OriginalValues["UseButtonBackGround"])
         # Set the use of custom icons
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "CustomIcons", self.OriginalValues["CustomIcons"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("CustomIcons", self.OriginalValues["CustomIcons"])
         # Set the use of custom colors
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "CustomColors", self.OriginalValues["CustomColors"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "BorderTransparant", self.OriginalValues["BorderTransparant"]
-        )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "Color_Borders", self.OriginalValues["Color_Borders"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("CustomColors", self.OriginalValues["CustomColors"])
+        Parameters_Ribbon.Settings.SetBoolSetting("BorderTransparant", self.OriginalValues["BorderTransparant"])
+        Parameters_Ribbon.Settings.SetStringSetting("Color_Borders", self.OriginalValues["Color_Borders"])
         Parameters_Ribbon.Settings.SetStringSetting(
             "Color_Background_Hover", self.OriginalValues["Color_Background_Hover"]
         )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "Color_Background_App", self.OriginalValues["Color_Background_App"]
-        )
+        Parameters_Ribbon.Settings.SetStringSetting("Color_Background_App", self.OriginalValues["Color_Background_App"])
 
         # Set the size of the window to the previous state
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "SettingsDialog_Height", self.form.height()
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "SettingsDialog_Width", self.form.width()
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("SettingsDialog_Height", self.form.height())
+        Parameters_Ribbon.Settings.SetIntSetting("SettingsDialog_Width", self.form.width())
 
         # Close the form
         self.form.close()
@@ -1262,148 +1085,70 @@ class LoadDialog(Settings_ui.Ui_Settings):
     @staticmethod
     def on_Close_clicked(self):
         # Save backup settings
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "BackupEnabled", self.ValuesToUpdate["BackupEnabled"]
-        )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "BackupFolder", self.ValuesToUpdate["BackupFolder"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("BackupEnabled", self.ValuesToUpdate["BackupEnabled"])
+        Parameters_Ribbon.Settings.SetStringSetting("BackupFolder", self.ValuesToUpdate["BackupFolder"])
         # Save tabBar style
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "TabBar_Style", self.ValuesToUpdate["TabBar_Style"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "Toolbar_Position", self.ValuesToUpdate["Toolbar_Position"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "Hide_Titlebar_FC", self.ValuesToUpdate["Hide_Titlebar_FC"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Style", self.ValuesToUpdate["TabBar_Style"])
+        Parameters_Ribbon.Settings.SetIntSetting("Toolbar_Position", self.ValuesToUpdate["Toolbar_Position"])
+        Parameters_Ribbon.Settings.SetBoolSetting("Hide_Titlebar_FC", self.ValuesToUpdate["Hide_Titlebar_FC"])
         # Save icon sizes
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "IconSize_Small", int(self.ValuesToUpdate["IconSize_Small"])
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "IconSize_Medium", int(self.ValuesToUpdate["IconSize_Medium"])
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "IconSize_Large", int(self.ValuesToUpdate["IconSize_Large"])
-        )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "Stylesheet", self.ValuesToUpdate["Stylesheet"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Small", int(self.ValuesToUpdate["IconSize_Small"]))
+        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Medium", int(self.ValuesToUpdate["IconSize_Medium"]))
+        Parameters_Ribbon.Settings.SetIntSetting("IconSize_Large", int(self.ValuesToUpdate["IconSize_Large"]))
+        Parameters_Ribbon.Settings.SetStringSetting("Stylesheet", self.ValuesToUpdate["Stylesheet"])
         Parameters_Ribbon.Settings.SetIntSetting(
             "ApplicationButtonSize", int(self.ValuesToUpdate["ApplicationButtonSize"])
         )
         Parameters_Ribbon.Settings.SetIntSetting(
             "QuickAccessButtonSize", int(self.ValuesToUpdate["QuickAccessButtonSize"])
         )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "TabBarSize", int(self.ValuesToUpdate["TabBarSize"])
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("TabBarSize", int(self.ValuesToUpdate["TabBarSize"]))
         Parameters_Ribbon.Settings.SetIntSetting(
             "RightToolbarButtonSize", int(self.ValuesToUpdate["RightToolbarButtonSize"])
         )
         # Save text settings
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "ShowIconText_Small", self.ValuesToUpdate["ShowIconText_Small"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "ShowIconText_Medium", self.ValuesToUpdate["ShowIconText_Medium"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "ShowIconText_Large", self.ValuesToUpdate["ShowIconText_Large"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "WrapText_Medium", self.ValuesToUpdate["WrapText_Medium"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "WrapText_Large", self.ValuesToUpdate["WrapText_Large"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "FontSize_Menus", self.ValuesToUpdate["FontSize_Menus"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "FontSize_Buttons", self.ValuesToUpdate["FontSize_Buttons"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "FontSize_Tabs", self.ValuesToUpdate["FontSize_Tabs"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "FontSize_Panels", self.ValuesToUpdate["FontSize_Panels"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Small", self.ValuesToUpdate["ShowIconText_Small"])
+        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Medium", self.ValuesToUpdate["ShowIconText_Medium"])
+        Parameters_Ribbon.Settings.SetBoolSetting("ShowIconText_Large", self.ValuesToUpdate["ShowIconText_Large"])
+        Parameters_Ribbon.Settings.SetBoolSetting("WrapText_Medium", self.ValuesToUpdate["WrapText_Medium"])
+        Parameters_Ribbon.Settings.SetBoolSetting("WrapText_Large", self.ValuesToUpdate["WrapText_Large"])
+        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Menus", self.ValuesToUpdate["FontSize_Menus"])
+        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Buttons", self.ValuesToUpdate["FontSize_Buttons"])
+        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Tabs", self.ValuesToUpdate["FontSize_Tabs"])
+        Parameters_Ribbon.Settings.SetIntSetting("FontSize_Panels", self.ValuesToUpdate["FontSize_Panels"])
         # Save No of columns
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "MaxColumnsPerPanel", int(self.ValuesToUpdate["MaxColumnsPerPanel"])
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "DebugMode", self.ValuesToUpdate["DebugMode"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "ShowOnHover", self.ValuesToUpdate["ShowOnHover"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("MaxColumnsPerPanel", int(self.ValuesToUpdate["MaxColumnsPerPanel"]))
+        Parameters_Ribbon.Settings.SetBoolSetting("DebugMode", self.ValuesToUpdate["DebugMode"])
+        Parameters_Ribbon.Settings.SetBoolSetting("ShowOnHover", self.ValuesToUpdate["ShowOnHover"])
         # Save behavior settings
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "TabBar_Scroll", self.ValuesToUpdate["TabBar_Scroll"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "Ribbon_Scroll", self.ValuesToUpdate["Ribbon_Scroll"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "TabBar_Click", self.ValuesToUpdate["TabBar_Click"]
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "Ribbon_Click", self.ValuesToUpdate["Ribbon_Click"]
-        )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "Shortcut_Application", self.ValuesToUpdate["Shortcut_Application"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Scroll", self.ValuesToUpdate["TabBar_Scroll"])
+        Parameters_Ribbon.Settings.SetIntSetting("Ribbon_Scroll", self.ValuesToUpdate["Ribbon_Scroll"])
+        Parameters_Ribbon.Settings.SetIntSetting("TabBar_Click", self.ValuesToUpdate["TabBar_Click"])
+        Parameters_Ribbon.Settings.SetIntSetting("Ribbon_Click", self.ValuesToUpdate["Ribbon_Click"])
+        Parameters_Ribbon.Settings.SetStringSetting("Shortcut_Application", self.ValuesToUpdate["Shortcut_Application"])
         # Save the preferred toolbars
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "Preferred_view", self.ValuesToUpdate["Preferred_view"]
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("Preferred_view", self.ValuesToUpdate["Preferred_view"])
         # Set the use of the tools panel
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "UseToolsPanel", self.ValuesToUpdate["UseToolsPanel"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("UseToolsPanel", self.ValuesToUpdate["UseToolsPanel"])
         # Set the use of FreeCAD's overlay function
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "UseOverlay", self.ValuesToUpdate["UseOverlay"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "UseFCOverlay", self.ValuesToUpdate["UseFCOverlay"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "UseButtonBackGround", self.ValuesToUpdate["UseButtonBackGround"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("UseOverlay", self.ValuesToUpdate["UseOverlay"])
+        Parameters_Ribbon.Settings.SetBoolSetting("UseFCOverlay", self.ValuesToUpdate["UseFCOverlay"])
+        Parameters_Ribbon.Settings.SetBoolSetting("UseButtonBackGround", self.ValuesToUpdate["UseButtonBackGround"])
         # Set the use of custom icons
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "CustomIcons", self.ValuesToUpdate["CustomIcons"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("CustomIcons", self.ValuesToUpdate["CustomIcons"])
         # Set the use of custom colors
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "CustomColors", self.ValuesToUpdate["CustomColors"]
-        )
-        Parameters_Ribbon.Settings.SetBoolSetting(
-            "BorderTransparant", self.ValuesToUpdate["BorderTransparant"]
-        )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "Color_Borders", self.ValuesToUpdate["Color_Borders"]
-        )
+        Parameters_Ribbon.Settings.SetBoolSetting("CustomColors", self.ValuesToUpdate["CustomColors"])
+        Parameters_Ribbon.Settings.SetBoolSetting("BorderTransparant", self.ValuesToUpdate["BorderTransparant"])
+        Parameters_Ribbon.Settings.SetStringSetting("Color_Borders", self.ValuesToUpdate["Color_Borders"])
         # Parameters_Ribbon.Settings.SetStringSetting("Color_Background", self.ValuesToUpdate["Color_Background"])
         Parameters_Ribbon.Settings.SetStringSetting(
             "Color_Background_Hover", self.ValuesToUpdate["Color_Background_Hover"]
         )
-        Parameters_Ribbon.Settings.SetStringSetting(
-            "Color_Background_App", self.ValuesToUpdate["Color_Background_App"]
-        )
+        Parameters_Ribbon.Settings.SetStringSetting("Color_Background_App", self.ValuesToUpdate["Color_Background_App"])
 
         # Set the size of the window to the previous state
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "SettingsDialog_Height", self.form.height()
-        )
-        Parameters_Ribbon.Settings.SetIntSetting(
-            "SettingsDialog_Width", self.form.width()
-        )
+        Parameters_Ribbon.Settings.SetIntSetting("SettingsDialog_Height", self.form.height())
+        Parameters_Ribbon.Settings.SetIntSetting("SettingsDialog_Width", self.form.width())
 
         # Close the form
         self.form.close()
@@ -1440,15 +1185,9 @@ class LoadDialog(Settings_ui.Ui_Settings):
         self.form.IconSize_Small.setValue(DefaultSettings["IconSize_Small"])
         self.form.IconSize_Medium.setValue(DefaultSettings["IconSize_Medium"])
         self.form.IconSize_Large.setValue(DefaultSettings["IconSize_Large"])
-        self.form.IconSize_ApplicationButton.setValue(
-            DefaultSettings["ApplicationButtonSize"]
-        )
-        self.form.IconSize_QuickAccessButton.setValue(
-            DefaultSettings["QuickAccessButtonSize"]
-        )
-        self.form.IconSize_rightToolbarButton.setValue(
-            DefaultSettings["RightToolbarButtonSize"]
-        )
+        self.form.IconSize_ApplicationButton.setValue(DefaultSettings["ApplicationButtonSize"])
+        self.form.IconSize_QuickAccessButton.setValue(DefaultSettings["QuickAccessButtonSize"])
+        self.form.IconSize_rightToolbarButton.setValue(DefaultSettings["RightToolbarButtonSize"])
         self.form.TabbarHeight.setValue(DefaultSettings["TabBarSize"])
         self.form.label_7.setText(DefaultSettings["Stylesheet"])
         if DefaultSettings["ShowIconText_Small"] is True:
@@ -1509,9 +1248,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
         # Set the color and icon buttons
         self.form.CustomIcons.setCheckState(Qt.CheckState.Unchecked)
 
-        self.form.Tab_Scroll_Left.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab", False)
-        )
+        self.form.Tab_Scroll_Left.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Tab", False))
         self.form.Tab_Scroll_Left.setIconSize(
             QSize(
                 self.form.Tab_Scroll_Left.width() - 6,
@@ -1519,9 +1256,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Tab_Scroll_Right.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab", False)
-        )
+        self.form.Tab_Scroll_Right.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Tab", False))
         self.form.Tab_Scroll_Right.setIconSize(
             QSize(
                 self.form.Tab_Scroll_Right.width() - 6,
@@ -1529,9 +1264,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Ribbon_Scroll_Left.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category", False)
-        )
+        self.form.Ribbon_Scroll_Left.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollLeftButton_Category", False))
         self.form.Ribbon_Scroll_Left.setIconSize(
             QSize(
                 self.form.Ribbon_Scroll_Left.width() - 6,
@@ -1539,9 +1272,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Ribbon_Scroll_Right.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category", False)
-        )
+        self.form.Ribbon_Scroll_Right.setIcon(StyleMapping_Ribbon.ReturnStyleItem("ScrollRightButton_Category", False))
         self.form.Ribbon_Scroll_Right.setIconSize(
             QSize(
                 self.form.Ribbon_Scroll_Right.width() - 6,
@@ -1549,18 +1280,12 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.MoreCommands.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("OptionButton", False)
-        )
+        self.form.MoreCommands.setIcon(StyleMapping_Ribbon.ReturnStyleItem("OptionButton", False))
         self.form.MoreCommands.setIconSize(
-            QSize(
-                self.form.MoreCommands.width() - 6, self.form.MoreCommands.height() - 6
-            )
+            QSize(self.form.MoreCommands.width() - 6, self.form.MoreCommands.height() - 6)
         )
 
-        self.form.pinButton_open.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("PinButton_open", False)
-        )
+        self.form.pinButton_open.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_open", False))
         self.form.pinButton_open.setIconSize(
             QSize(
                 self.form.pinButton_open.width() - 6,
@@ -1568,9 +1293,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.pinButton_closed.setIcon(
-            StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed", False)
-        )
+        self.form.pinButton_closed.setIcon(StyleMapping_Ribbon.ReturnStyleItem("PinButton_closed", False))
         self.form.pinButton_closed.setIconSize(
             QSize(
                 self.form.pinButton_closed.width() - 6,
@@ -1578,9 +1301,7 @@ class LoadDialog(Settings_ui.Ui_Settings):
             )
         )
 
-        self.form.Color_Borders.setProperty(
-            "color", QColor(StyleMapping_Ribbon.ReturnStyleItem("Color_Borders"))
-        )
+        self.form.Color_Borders.setProperty("color", QColor(StyleMapping_Ribbon.ReturnStyleItem("Color_Borders")))
         # self.form.Color_Background.setProperty("color", QColor(StyleMapping.ReturnStyleItem("Color_Background")))
         self.form.Color_Background_Hover.setProperty(
             "color",

--- a/Resources/stylesheets/debug.qss
+++ b/Resources/stylesheets/debug.qss
@@ -65,46 +65,112 @@ RibbonPanelItemWidget {
 }
 
 QTabBar {
-    background-color: transparent;
-}
+  margin: 0px;
+  padding-bottom: 0px;
+  padding-top: 0px;}
+  QTabBar::tab {
+  	background: transparent;
+	margin-top: 4px;
+	margin-bottom: 4px;
+	padding-top: 4px;
+	padding-bottom: 4px;
+	spacing: 0px;}
+  QTabBar::scroller {
+    min-width: 40px;}
 
-QTabBar QToolButton {
-    background-color: transparent;
-}
+QDockWidget {
+	margin: 0px;
+	padding-bottom: 0px;
+	padding-top: 0px;}
+	QDockWidget::title {
+		margin: 0px;
+		padding: 0px;
+		text-align: center; }
 
-QTabBar::tab {
-	color: gray;
+QDockWidget::title QToolButton, QDockWidget::title QWidget#Selector > QToolButton {
+	margin: 1px; }
+
+RibbonApplicationButton::menu-indicator {
+    image: none;
 	border: none;
-	background: transparent;
+}
+
+QTabBar, QDockWidget QTabBar {
+  qproperty-drawBase: 0;
+}
+
+RibbonBar {
+	padding-top: 0px;
+	padding-bottom: 0px;
 	margin-top: 0px;
 	margin-right: 0px;
-	margin-left: 6px;
+	margin-left: 0px;
 	margin-bottom: 0px;
-	min-width: 100px;
-	max-width: 250px;
-	min-height: 25px;
-	max-height: 25px;
-	padding-left: 10px;
-	padding-right: 10px;
-	padding-top: 10px;
-	padding-bottom: 2px;
+	spacing: 0px;
 }
 
-QTabBar::tab:selected, QTabBar::tab:hover {
-	border-top-left-radius: 0px;
-	border-top-right-radius: 0px;
+RibbonCategory {
+	padding-top: 0px;
+	padding-bottom: 0px;
+	margin-top: 0px;
+	margin-right: 3px;
+	margin-left: 3px;
+	margin-bottom: 0px;
+	spacing: 0px;
 }
 
-QTabBar::tab:selected {
-	color: blue;
-	background: transparent;
-	border-bottom: 3px solid blue;
+RibbonCategoryScrollArea {
+    background-color: transparent;
+	padding-top: 0px;
+	padding-bottom: 0px;
+	margin-top: 0px;
+	margin-right: 0px;
+	margin-left: 0px;
+	margin-bottom: 0px;
+	spacing: 0px;
 }
 
-QToolButton::menu-button {
-	border: 2px solid transparent;
-	border-top-right-radius: 6px;
-	border-bottom-right-radius: 6px;
-	/* 16px width + 4px for border = 20px allocated above */
-	width: 16px;
+RibbonCategoryScrollAreaContents {
+    background-color: transparent;
+	padding-top: 0px;
+	padding-bottom: 0px;
+	margin-top: 0px;
+	margin-right: 0px;
+	margin-left: 0px;
+	margin-bottom: 0px;
+	spacing: 0px;
+}
+
+RibbonPanel {
+	padding-top: 0px;
+	padding-bottom: 0px;
+	margin-top: 0px;
+	margin-right: 0px;
+	margin-left: 0px;
+	margin-bottom: 0px;
+	spacing: 0px;
+}
+
+RibbonPanelTitle {
+	padding-top: 0px;
+	padding-bottom: 0px;
+	margin-top: 0px;
+	margin-right: 0px;
+	margin-left: 0px;
+	margin-bottom: 0px;
+	spacing: 0px;
+}
+
+RibbonPanelItemWidget {
+    padding-top: 0px;
+	padding-bottom: 0px;
+	margin-top: 0px;
+	margin-right: 0px;
+	margin-left: 0px;
+	margin-bottom: 0px;
+	spacing: 0px;
+}
+
+QTabBar {
+    background-color: transparent;
 }

--- a/Resources/ui/Settings.ui
+++ b/Resources/ui/Settings.ui
@@ -31,52 +31,8 @@
   <property name="autoFillBackground">
    <bool>false</bool>
   </property>
-  <layout class="QGridLayout" name="gridLayout_40">
-   <item row="1" column="0">
-    <layout class="QGridLayout" name="gridLayout_7">
-     <item row="0" column="0">
-      <widget class="QPushButton" name="Reset">
-       <property name="text">
-        <string>Reset</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="0" column="2">
-      <widget class="QPushButton" name="GenerateJsonExit">
-       <property name="text">
-        <string>Close</string>
-       </property>
-       <property name="shortcut">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="3">
-      <widget class="QPushButton" name="Cancel">
-       <property name="text">
-        <string>Cancel</string>
-       </property>
-       <property name="shortcut">
-        <string>Esc</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="0" column="0" colspan="2">
+  <layout class="QGridLayout" name="gridLayout_36">
+   <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout_6">
      <item row="0" column="0" colspan="3">
       <widget class="QScrollArea" name="scrollArea">
@@ -2245,6 +2201,73 @@ Uncheck this when there are issues with the overlay function and the FreeCAD Rib
          </item>
         </layout>
        </widget>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <layout class="QGridLayout" name="gridLayout_7">
+     <item row="0" column="3">
+      <widget class="QPushButton" name="Cancel">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+       <property name="shortcut">
+        <string>Esc</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="4">
+      <spacer name="horizontalSpacer_11">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Policy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>10</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="0">
+      <widget class="QPushButton" name="Reset">
+       <property name="text">
+        <string>Reset</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QPushButton" name="GenerateJsonExit">
+       <property name="text">
+        <string>Close</string>
+       </property>
+       <property name="shortcut">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5">
+      <widget class="QToolButton" name="HelpButton">
+       <property name="text">
+        <string>...</string>
+       </property>
       </widget>
      </item>
     </layout>

--- a/Resources/ui/Settings_ui.py
+++ b/Resources/ui/Settings_ui.py
@@ -68,7 +68,9 @@ class Ui_Settings(object):
             Settings.setObjectName("Settings")
         Settings.setWindowModality(Qt.WindowModality.WindowModal)
         Settings.resize(736, 801)
-        sizePolicy = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Preferred)
+        sizePolicy = QSizePolicy(
+            QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Preferred
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(Settings.sizePolicy().hasHeightForWidth())
@@ -81,7 +83,9 @@ class Ui_Settings(object):
         self.gridLayout_6.setObjectName("gridLayout_6")
         self.scrollArea = QScrollArea(Settings)
         self.scrollArea.setObjectName("scrollArea")
-        sizePolicy1 = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding)
+        sizePolicy1 = QSizePolicy(
+            QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding
+        )
         sizePolicy1.setHorizontalStretch(0)
         sizePolicy1.setVerticalStretch(0)
         sizePolicy1.setHeightForWidth(self.scrollArea.sizePolicy().hasHeightForWidth())
@@ -95,7 +99,9 @@ class Ui_Settings(object):
         self.gridLayout_28.setObjectName("gridLayout_28")
         self.tabWidget = QTabWidget(self.scrollAreaWidgetContents)
         self.tabWidget.setObjectName("tabWidget")
-        sizePolicy2 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        sizePolicy2 = QSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
         sizePolicy2.setHorizontalStretch(0)
         sizePolicy2.setVerticalStretch(0)
         sizePolicy2.setHeightForWidth(self.tabWidget.sizePolicy().hasHeightForWidth())
@@ -130,10 +136,14 @@ class Ui_Settings(object):
         self.groupBox_Backup = QGroupBox(self.groupBox)
         self.groupBox_Backup.setObjectName("groupBox_Backup")
         self.groupBox_Backup.setEnabled(False)
-        sizePolicy3 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        sizePolicy3 = QSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed
+        )
         sizePolicy3.setHorizontalStretch(0)
         sizePolicy3.setVerticalStretch(0)
-        sizePolicy3.setHeightForWidth(self.groupBox_Backup.sizePolicy().hasHeightForWidth())
+        sizePolicy3.setHeightForWidth(
+            self.groupBox_Backup.sizePolicy().hasHeightForWidth()
+        )
         self.groupBox_Backup.setSizePolicy(sizePolicy3)
         self.groupBox_Backup.setMinimumSize(QSize(0, 50))
         self.groupBox_Backup.setFont(font1)
@@ -141,7 +151,9 @@ class Ui_Settings(object):
         self.gridLayout_13.setObjectName("gridLayout_13")
         self.label_4 = QLabel(self.groupBox_Backup)
         self.label_4.setObjectName("label_4")
-        sizePolicy4 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+        sizePolicy4 = QSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred
+        )
         sizePolicy4.setHorizontalStretch(0)
         sizePolicy4.setVerticalStretch(0)
         sizePolicy4.setHeightForWidth(self.label_4.sizePolicy().hasHeightForWidth())
@@ -150,7 +162,9 @@ class Ui_Settings(object):
         self.label_4.setFrameShape(QFrame.Shape.Box)
         self.label_4.setScaledContents(True)
         self.label_4.setAlignment(
-            Qt.AlignmentFlag.AlignLeading | Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
+            Qt.AlignmentFlag.AlignLeading
+            | Qt.AlignmentFlag.AlignLeft
+            | Qt.AlignmentFlag.AlignVCenter
         )
 
         self.gridLayout_13.addWidget(self.label_4, 0, 0, 1, 1)
@@ -160,7 +174,9 @@ class Ui_Settings(object):
         sizePolicy5 = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         sizePolicy5.setHorizontalStretch(20)
         sizePolicy5.setVerticalStretch(0)
-        sizePolicy5.setHeightForWidth(self.BackUpLocation.sizePolicy().hasHeightForWidth())
+        sizePolicy5.setHeightForWidth(
+            self.BackUpLocation.sizePolicy().hasHeightForWidth()
+        )
         self.BackUpLocation.setSizePolicy(sizePolicy5)
         self.BackUpLocation.setMinimumSize(QSize(20, 0))
 
@@ -190,7 +206,9 @@ class Ui_Settings(object):
         sizePolicy6 = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         sizePolicy6.setHorizontalStretch(0)
         sizePolicy6.setVerticalStretch(0)
-        sizePolicy6.setHeightForWidth(self.ShowText_Medium.sizePolicy().hasHeightForWidth())
+        sizePolicy6.setHeightForWidth(
+            self.ShowText_Medium.sizePolicy().hasHeightForWidth()
+        )
         self.ShowText_Medium.setSizePolicy(sizePolicy6)
         self.ShowText_Medium.setMinimumSize(QSize(100, 0))
         self.ShowText_Medium.setFont(font1)
@@ -206,7 +224,9 @@ class Ui_Settings(object):
 
         self.ShowText_Large = QCheckBox(self.groupBox_3)
         self.ShowText_Large.setObjectName("ShowText_Large")
-        sizePolicy6.setHeightForWidth(self.ShowText_Large.sizePolicy().hasHeightForWidth())
+        sizePolicy6.setHeightForWidth(
+            self.ShowText_Large.sizePolicy().hasHeightForWidth()
+        )
         self.ShowText_Large.setSizePolicy(sizePolicy6)
         self.ShowText_Large.setMinimumSize(QSize(100, 0))
         self.ShowText_Large.setFont(font1)
@@ -216,14 +236,18 @@ class Ui_Settings(object):
 
         self.ShowText_Small = QCheckBox(self.groupBox_3)
         self.ShowText_Small.setObjectName("ShowText_Small")
-        sizePolicy6.setHeightForWidth(self.ShowText_Small.sizePolicy().hasHeightForWidth())
+        sizePolicy6.setHeightForWidth(
+            self.ShowText_Small.sizePolicy().hasHeightForWidth()
+        )
         self.ShowText_Small.setSizePolicy(sizePolicy6)
         self.ShowText_Small.setMinimumSize(QSize(100, 0))
         self.ShowText_Small.setFont(font1)
 
         self.gridLayout_26.addWidget(self.ShowText_Small, 0, 0, 1, 1)
 
-        self.horizontalSpacer_9 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_9 = QSpacerItem(
+            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
+        )
 
         self.gridLayout_26.addItem(self.horizontalSpacer_9, 0, 2, 1, 1)
 
@@ -240,7 +264,9 @@ class Ui_Settings(object):
 
         self.groupBox_10 = QGroupBox(self.groupBox1)
         self.groupBox_10.setObjectName("groupBox_10")
-        sizePolicy7 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Minimum)
+        sizePolicy7 = QSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Minimum
+        )
         sizePolicy7.setHorizontalStretch(0)
         sizePolicy7.setVerticalStretch(0)
         sizePolicy7.setHeightForWidth(self.groupBox_10.sizePolicy().hasHeightForWidth())
@@ -291,7 +317,9 @@ class Ui_Settings(object):
 
         self.gridLayout_25.addLayout(self.gridLayout_24, 0, 0, 1, 1)
 
-        self.horizontalSpacer_7 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_7 = QSpacerItem(
+            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
+        )
 
         self.gridLayout_25.addItem(self.horizontalSpacer_7, 0, 1, 1, 1)
 
@@ -311,16 +339,22 @@ class Ui_Settings(object):
 
         self.IconSize_Medium = QSpinBox(self.groupBox_4)
         self.IconSize_Medium.setObjectName("IconSize_Medium")
-        sizePolicy8 = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Preferred)
+        sizePolicy8 = QSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Preferred
+        )
         sizePolicy8.setHorizontalStretch(0)
         sizePolicy8.setVerticalStretch(0)
-        sizePolicy8.setHeightForWidth(self.IconSize_Medium.sizePolicy().hasHeightForWidth())
+        sizePolicy8.setHeightForWidth(
+            self.IconSize_Medium.sizePolicy().hasHeightForWidth()
+        )
         self.IconSize_Medium.setSizePolicy(sizePolicy8)
         self.IconSize_Medium.setMinimumSize(QSize(50, 20))
         self.IconSize_Medium.setBaseSize(QSize(0, 0))
         self.IconSize_Medium.setFont(font1)
         self.IconSize_Medium.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.IconSize_Medium.setCorrectionMode(QAbstractSpinBox.CorrectionMode.CorrectToNearestValue)
+        self.IconSize_Medium.setCorrectionMode(
+            QAbstractSpinBox.CorrectionMode.CorrectToNearestValue
+        )
         self.IconSize_Medium.setMinimum(16)
         self.IconSize_Medium.setMaximum(48)
         self.IconSize_Medium.setValue(44)
@@ -409,7 +443,9 @@ class Ui_Settings(object):
 
         self.IconSize_Small = QSpinBox(self.groupBox_4)
         self.IconSize_Small.setObjectName("IconSize_Small")
-        sizePolicy8.setHeightForWidth(self.IconSize_Small.sizePolicy().hasHeightForWidth())
+        sizePolicy8.setHeightForWidth(
+            self.IconSize_Small.sizePolicy().hasHeightForWidth()
+        )
         self.IconSize_Small.setSizePolicy(sizePolicy8)
         self.IconSize_Small.setMinimumSize(QSize(50, 20))
         self.IconSize_Small.setSizeIncrement(QSize(0, 0))
@@ -418,7 +454,9 @@ class Ui_Settings(object):
         self.IconSize_Small.setFocusPolicy(Qt.FocusPolicy.WheelFocus)
         self.IconSize_Small.setFrame(True)
         self.IconSize_Small.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.IconSize_Small.setCorrectionMode(QAbstractSpinBox.CorrectionMode.CorrectToNearestValue)
+        self.IconSize_Small.setCorrectionMode(
+            QAbstractSpinBox.CorrectionMode.CorrectToNearestValue
+        )
         self.IconSize_Small.setProperty("showGroupSeparator", False)
         self.IconSize_Small.setMinimum(16)
         self.IconSize_Small.setMaximum(36)
@@ -428,7 +466,9 @@ class Ui_Settings(object):
 
         self.gridLayout_5.addLayout(self.gridLayout, 1, 0, 1, 1)
 
-        self.horizontalSpacer_3 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_3 = QSpacerItem(
+            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
+        )
 
         self.gridLayout_5.addItem(self.horizontalSpacer_3, 1, 1, 1, 1)
 
@@ -446,7 +486,9 @@ class Ui_Settings(object):
         self.gridLayout_10.setObjectName("gridLayout_10")
         self.MaxPanelColumn = QSpinBox(self.groupBox_5)
         self.MaxPanelColumn.setObjectName("MaxPanelColumn")
-        sizePolicy6.setHeightForWidth(self.MaxPanelColumn.sizePolicy().hasHeightForWidth())
+        sizePolicy6.setHeightForWidth(
+            self.MaxPanelColumn.sizePolicy().hasHeightForWidth()
+        )
         self.MaxPanelColumn.setSizePolicy(sizePolicy6)
         self.MaxPanelColumn.setMinimumSize(QSize(50, 20))
         self.MaxPanelColumn.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -461,7 +503,9 @@ class Ui_Settings(object):
 
         self.gridLayout_10.addWidget(self.label, 0, 0, 1, 1)
 
-        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer = QSpacerItem(
+            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
+        )
 
         self.gridLayout_10.addItem(self.horizontalSpacer, 0, 2, 1, 1)
 
@@ -495,7 +539,9 @@ class Ui_Settings(object):
 
         self.TextSize_Menus = QSpinBox(self.groupBox_14)
         self.TextSize_Menus.setObjectName("TextSize_Menus")
-        sizePolicy8.setHeightForWidth(self.TextSize_Menus.sizePolicy().hasHeightForWidth())
+        sizePolicy8.setHeightForWidth(
+            self.TextSize_Menus.sizePolicy().hasHeightForWidth()
+        )
         self.TextSize_Menus.setSizePolicy(sizePolicy8)
         self.TextSize_Menus.setMinimumSize(QSize(50, 20))
         self.TextSize_Menus.setSizeIncrement(QSize(0, 0))
@@ -504,7 +550,9 @@ class Ui_Settings(object):
         self.TextSize_Menus.setFocusPolicy(Qt.FocusPolicy.WheelFocus)
         self.TextSize_Menus.setFrame(True)
         self.TextSize_Menus.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.TextSize_Menus.setCorrectionMode(QAbstractSpinBox.CorrectionMode.CorrectToNearestValue)
+        self.TextSize_Menus.setCorrectionMode(
+            QAbstractSpinBox.CorrectionMode.CorrectToNearestValue
+        )
         self.TextSize_Menus.setProperty("showGroupSeparator", False)
         self.TextSize_Menus.setMinimum(8)
         self.TextSize_Menus.setMaximum(24)
@@ -527,7 +575,9 @@ class Ui_Settings(object):
         self.TextSize_Buttons.setObjectName("TextSize_Buttons")
         self.TextSize_Buttons.setFont(font1)
         self.TextSize_Buttons.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.TextSize_Buttons.setCorrectionMode(QAbstractSpinBox.CorrectionMode.CorrectToNearestValue)
+        self.TextSize_Buttons.setCorrectionMode(
+            QAbstractSpinBox.CorrectionMode.CorrectToNearestValue
+        )
         self.TextSize_Buttons.setMinimum(8)
         self.TextSize_Buttons.setMaximum(24)
         self.TextSize_Buttons.setValue(11)
@@ -556,7 +606,9 @@ class Ui_Settings(object):
 
         self.gridLayout_39.addLayout(self.gridLayout_38, 0, 0, 1, 1)
 
-        self.horizontalSpacer_12 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_12 = QSpacerItem(
+            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
+        )
 
         self.gridLayout_39.addItem(self.horizontalSpacer_12, 0, 1, 1, 1)
 
@@ -566,7 +618,9 @@ class Ui_Settings(object):
 
         self.groupBox_2 = QGroupBox(self.groupBox1)
         self.groupBox_2.setObjectName("groupBox_2")
-        sizePolicy9 = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Fixed)
+        sizePolicy9 = QSizePolicy(
+            QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Fixed
+        )
         sizePolicy9.setHorizontalStretch(0)
         sizePolicy9.setVerticalStretch(0)
         sizePolicy9.setHeightForWidth(self.groupBox_2.sizePolicy().hasHeightForWidth())
@@ -581,14 +635,18 @@ class Ui_Settings(object):
         self.label_7.setFrameShape(QFrame.Shape.Box)
         self.label_7.setScaledContents(True)
         self.label_7.setAlignment(
-            Qt.AlignmentFlag.AlignLeading | Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
+            Qt.AlignmentFlag.AlignLeading
+            | Qt.AlignmentFlag.AlignLeft
+            | Qt.AlignmentFlag.AlignVCenter
         )
 
         self.gridLayout_12.addWidget(self.label_7, 0, 0, 1, 1)
 
         self.StyleSheetLocation = QPushButton(self.groupBox_2)
         self.StyleSheetLocation.setObjectName("StyleSheetLocation")
-        sizePolicy5.setHeightForWidth(self.StyleSheetLocation.sizePolicy().hasHeightForWidth())
+        sizePolicy5.setHeightForWidth(
+            self.StyleSheetLocation.sizePolicy().hasHeightForWidth()
+        )
         self.StyleSheetLocation.setSizePolicy(sizePolicy5)
         self.StyleSheetLocation.setMinimumSize(QSize(20, 0))
 
@@ -622,7 +680,9 @@ class Ui_Settings(object):
 
         self.gridLayout_9.addLayout(self.verticalLayout_2, 6, 0, 1, 1)
 
-        self.verticalSpacer_7 = QSpacerItem(20, 10, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.verticalSpacer_7 = QSpacerItem(
+            20, 10, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding
+        )
 
         self.gridLayout_9.addItem(self.verticalSpacer_7, 5, 0, 1, 1)
 
@@ -631,7 +691,9 @@ class Ui_Settings(object):
         self.tab.setObjectName("tab")
         self.gridLayout_14 = QGridLayout(self.tab)
         self.gridLayout_14.setObjectName("gridLayout_14")
-        self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.verticalSpacer = QSpacerItem(
+            20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding
+        )
 
         self.gridLayout_14.addItem(self.verticalSpacer, 3, 0, 1, 1)
 
@@ -678,10 +740,14 @@ class Ui_Settings(object):
 
         self.ScrollSpeed_TabBar = QSlider(self.groupBox_6)
         self.ScrollSpeed_TabBar.setObjectName("ScrollSpeed_TabBar")
-        sizePolicy10 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        sizePolicy10 = QSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
         sizePolicy10.setHorizontalStretch(0)
         sizePolicy10.setVerticalStretch(0)
-        sizePolicy10.setHeightForWidth(self.ScrollSpeed_TabBar.sizePolicy().hasHeightForWidth())
+        sizePolicy10.setHeightForWidth(
+            self.ScrollSpeed_TabBar.sizePolicy().hasHeightForWidth()
+        )
         self.ScrollSpeed_TabBar.setSizePolicy(sizePolicy10)
         self.ScrollSpeed_TabBar.setMaximum(10)
         self.ScrollSpeed_TabBar.setSingleStep(1)
@@ -714,7 +780,9 @@ class Ui_Settings(object):
         self.gridLayout_17.setObjectName("gridLayout_17")
         self.ScrollClicks_TabBar = QSpinBox(self.groupBox_7)
         self.ScrollClicks_TabBar.setObjectName("ScrollClicks_TabBar")
-        sizePolicy8.setHeightForWidth(self.ScrollClicks_TabBar.sizePolicy().hasHeightForWidth())
+        sizePolicy8.setHeightForWidth(
+            self.ScrollClicks_TabBar.sizePolicy().hasHeightForWidth()
+        )
         self.ScrollClicks_TabBar.setSizePolicy(sizePolicy8)
         self.ScrollClicks_TabBar.setMinimumSize(QSize(50, 0))
         self.ScrollClicks_TabBar.setSizeIncrement(QSize(0, 0))
@@ -722,7 +790,9 @@ class Ui_Settings(object):
         self.ScrollClicks_TabBar.setFont(font1)
         self.ScrollClicks_TabBar.setFrame(True)
         self.ScrollClicks_TabBar.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.ScrollClicks_TabBar.setCorrectionMode(QAbstractSpinBox.CorrectionMode.CorrectToNearestValue)
+        self.ScrollClicks_TabBar.setCorrectionMode(
+            QAbstractSpinBox.CorrectionMode.CorrectToNearestValue
+        )
         self.ScrollClicks_TabBar.setProperty("showGroupSeparator", False)
         self.ScrollClicks_TabBar.setMinimum(0)
         self.ScrollClicks_TabBar.setMaximum(10)
@@ -742,13 +812,17 @@ class Ui_Settings(object):
 
         self.ScrollClicks_Ribbon = QSpinBox(self.groupBox_7)
         self.ScrollClicks_Ribbon.setObjectName("ScrollClicks_Ribbon")
-        sizePolicy8.setHeightForWidth(self.ScrollClicks_Ribbon.sizePolicy().hasHeightForWidth())
+        sizePolicy8.setHeightForWidth(
+            self.ScrollClicks_Ribbon.sizePolicy().hasHeightForWidth()
+        )
         self.ScrollClicks_Ribbon.setSizePolicy(sizePolicy8)
         self.ScrollClicks_Ribbon.setMinimumSize(QSize(50, 0))
         self.ScrollClicks_Ribbon.setBaseSize(QSize(0, 0))
         self.ScrollClicks_Ribbon.setFont(font1)
         self.ScrollClicks_Ribbon.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.ScrollClicks_Ribbon.setCorrectionMode(QAbstractSpinBox.CorrectionMode.CorrectToNearestValue)
+        self.ScrollClicks_Ribbon.setCorrectionMode(
+            QAbstractSpinBox.CorrectionMode.CorrectToNearestValue
+        )
         self.ScrollClicks_Ribbon.setMaximum(10)
         self.ScrollClicks_Ribbon.setValue(1)
         self.ScrollClicks_Ribbon.setDisplayIntegerBase(10)
@@ -766,7 +840,9 @@ class Ui_Settings(object):
 
         self.gridLayout_18.addLayout(self.gridLayout_17, 0, 0, 1, 1)
 
-        self.horizontalSpacer_4 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_4 = QSpacerItem(
+            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
+        )
 
         self.gridLayout_18.addItem(self.horizontalSpacer_4, 0, 1, 1, 1)
 
@@ -786,7 +862,9 @@ class Ui_Settings(object):
 
         self.gridLayout_23.addWidget(self.CustomIcons, 0, 0, 1, 1)
 
-        self.horizontalSpacer_6 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_6 = QSpacerItem(
+            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
+        )
 
         self.gridLayout_23.addItem(self.horizontalSpacer_6, 1, 1, 1, 1)
 
@@ -804,7 +882,9 @@ class Ui_Settings(object):
 
         self.Tab_Scroll_Left = QPushButton(self.IconS)
         self.Tab_Scroll_Left.setObjectName("Tab_Scroll_Left")
-        sizePolicy6.setHeightForWidth(self.Tab_Scroll_Left.sizePolicy().hasHeightForWidth())
+        sizePolicy6.setHeightForWidth(
+            self.Tab_Scroll_Left.sizePolicy().hasHeightForWidth()
+        )
         self.Tab_Scroll_Left.setSizePolicy(sizePolicy6)
         self.Tab_Scroll_Left.setMinimumSize(QSize(10, 20))
         self.Tab_Scroll_Left.setMaximumSize(QSize(20, 20))
@@ -819,7 +899,9 @@ class Ui_Settings(object):
 
         self.Tab_Scroll_Right = QPushButton(self.IconS)
         self.Tab_Scroll_Right.setObjectName("Tab_Scroll_Right")
-        sizePolicy6.setHeightForWidth(self.Tab_Scroll_Right.sizePolicy().hasHeightForWidth())
+        sizePolicy6.setHeightForWidth(
+            self.Tab_Scroll_Right.sizePolicy().hasHeightForWidth()
+        )
         self.Tab_Scroll_Right.setSizePolicy(sizePolicy6)
         self.Tab_Scroll_Right.setMinimumSize(QSize(10, 20))
         self.Tab_Scroll_Right.setMaximumSize(QSize(20, 20))
@@ -834,7 +916,9 @@ class Ui_Settings(object):
 
         self.Ribbon_Scroll_Left = QPushButton(self.IconS)
         self.Ribbon_Scroll_Left.setObjectName("Ribbon_Scroll_Left")
-        sizePolicy6.setHeightForWidth(self.Ribbon_Scroll_Left.sizePolicy().hasHeightForWidth())
+        sizePolicy6.setHeightForWidth(
+            self.Ribbon_Scroll_Left.sizePolicy().hasHeightForWidth()
+        )
         self.Ribbon_Scroll_Left.setSizePolicy(sizePolicy6)
         self.Ribbon_Scroll_Left.setMinimumSize(QSize(20, 60))
         self.Ribbon_Scroll_Left.setMaximumSize(QSize(20, 60))
@@ -848,7 +932,9 @@ class Ui_Settings(object):
 
         self.Ribbon_Scroll_Right = QPushButton(self.IconS)
         self.Ribbon_Scroll_Right.setObjectName("Ribbon_Scroll_Right")
-        sizePolicy6.setHeightForWidth(self.Ribbon_Scroll_Right.sizePolicy().hasHeightForWidth())
+        sizePolicy6.setHeightForWidth(
+            self.Ribbon_Scroll_Right.sizePolicy().hasHeightForWidth()
+        )
         self.Ribbon_Scroll_Right.setSizePolicy(sizePolicy6)
         self.Ribbon_Scroll_Right.setMinimumSize(QSize(20, 60))
         self.Ribbon_Scroll_Right.setMaximumSize(QSize(20, 60))
@@ -862,7 +948,9 @@ class Ui_Settings(object):
 
         self.MoreCommands = QPushButton(self.IconS)
         self.MoreCommands.setObjectName("MoreCommands")
-        sizePolicy6.setHeightForWidth(self.MoreCommands.sizePolicy().hasHeightForWidth())
+        sizePolicy6.setHeightForWidth(
+            self.MoreCommands.sizePolicy().hasHeightForWidth()
+        )
         self.MoreCommands.setSizePolicy(sizePolicy6)
         self.MoreCommands.setMinimumSize(QSize(30, 20))
         self.MoreCommands.setMaximumSize(QSize(30, 20))
@@ -877,7 +965,9 @@ class Ui_Settings(object):
 
         self.pinButton_open = QPushButton(self.IconS)
         self.pinButton_open.setObjectName("pinButton_open")
-        sizePolicy6.setHeightForWidth(self.pinButton_open.sizePolicy().hasHeightForWidth())
+        sizePolicy6.setHeightForWidth(
+            self.pinButton_open.sizePolicy().hasHeightForWidth()
+        )
         self.pinButton_open.setSizePolicy(sizePolicy6)
         self.pinButton_open.setMinimumSize(QSize(30, 30))
         self.pinButton_open.setMaximumSize(QSize(30, 30))
@@ -891,7 +981,9 @@ class Ui_Settings(object):
 
         self.pinButton_closed = QPushButton(self.IconS)
         self.pinButton_closed.setObjectName("pinButton_closed")
-        sizePolicy6.setHeightForWidth(self.pinButton_closed.sizePolicy().hasHeightForWidth())
+        sizePolicy6.setHeightForWidth(
+            self.pinButton_closed.sizePolicy().hasHeightForWidth()
+        )
         self.pinButton_closed.setSizePolicy(sizePolicy6)
         self.pinButton_closed.setMinimumSize(QSize(30, 30))
         self.pinButton_closed.setMaximumSize(QSize(30, 30))
@@ -905,7 +997,9 @@ class Ui_Settings(object):
 
         self.gridLayout_19.addWidget(self.groupBox_9, 1, 0, 1, 1)
 
-        self.verticalSpacer_2 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.verticalSpacer_2 = QSpacerItem(
+            20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding
+        )
 
         self.gridLayout_19.addItem(self.verticalSpacer_2, 2, 0, 1, 1)
 
@@ -967,13 +1061,17 @@ class Ui_Settings(object):
 
         self.gridLayout_35.addLayout(self.gridLayout_20, 0, 0, 1, 1)
 
-        self.horizontalSpacer_5 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_5 = QSpacerItem(
+            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
+        )
 
         self.gridLayout_35.addItem(self.horizontalSpacer_5, 0, 2, 1, 1)
 
         self.gridLayout_21.addWidget(self.ColorS, 2, 0, 1, 1)
 
-        self.verticalSpacer_4 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.verticalSpacer_4 = QSpacerItem(
+            20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding
+        )
 
         self.gridLayout_21.addItem(self.verticalSpacer_4, 2, 1, 1, 1)
 
@@ -991,7 +1089,9 @@ class Ui_Settings(object):
         self.gridLayout_34.setObjectName("gridLayout_34")
         self.EnableOverlay = QGroupBox(self.tab_3)
         self.EnableOverlay.setObjectName("EnableOverlay")
-        sizePolicy4.setHeightForWidth(self.EnableOverlay.sizePolicy().hasHeightForWidth())
+        sizePolicy4.setHeightForWidth(
+            self.EnableOverlay.sizePolicy().hasHeightForWidth()
+        )
         self.EnableOverlay.setSizePolicy(sizePolicy4)
         self.EnableOverlay.setCheckable(True)
         self.gridLayout_32 = QGridLayout(self.EnableOverlay)
@@ -1013,7 +1113,9 @@ class Ui_Settings(object):
         self.label_26 = QLabel(self.EnableOverlay)
         self.label_26.setObjectName("label_26")
         self.label_26.setEnabled(False)
-        sizePolicy11 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding)
+        sizePolicy11 = QSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding
+        )
         sizePolicy11.setHorizontalStretch(0)
         sizePolicy11.setVerticalStretch(0)
         sizePolicy11.setHeightForWidth(self.label_26.sizePolicy().hasHeightForWidth())
@@ -1024,7 +1126,9 @@ class Ui_Settings(object):
 
         self.gridLayout_32.addLayout(self.gridLayout_30, 0, 0, 2, 2)
 
-        self.horizontalSpacer_10 = QSpacerItem(80, 20, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_10 = QSpacerItem(
+            80, 20, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum
+        )
 
         self.gridLayout_32.addItem(self.horizontalSpacer_10, 0, 2, 1, 1)
 
@@ -1034,7 +1138,9 @@ class Ui_Settings(object):
         self.groupBox_11.setObjectName("groupBox_11")
         self.gridLayout_29 = QGridLayout(self.groupBox_11)
         self.gridLayout_29.setObjectName("gridLayout_29")
-        self.horizontalSpacer_8 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_8 = QSpacerItem(
+            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
+        )
 
         self.gridLayout_29.addItem(self.horizontalSpacer_8, 0, 1, 1, 1)
 
@@ -1069,7 +1175,9 @@ class Ui_Settings(object):
 
         self.gridLayout_34.addWidget(self.groupBox_11, 0, 0, 1, 1)
 
-        self.verticalSpacer_3 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.verticalSpacer_3 = QSpacerItem(
+            20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding
+        )
 
         self.gridLayout_34.addItem(self.verticalSpacer_3, 3, 0, 1, 1)
 
@@ -1090,11 +1198,15 @@ class Ui_Settings(object):
 
         self.gridLayout_7.addWidget(self.Cancel, 0, 3, 1, 1)
 
-        self.horizontalSpacer_2 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_2 = QSpacerItem(
+            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
+        )
 
         self.gridLayout_7.addItem(self.horizontalSpacer_2, 0, 1, 1, 1)
 
-        self.horizontalSpacer_11 = QSpacerItem(10, 20, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_11 = QSpacerItem(
+            10, 20, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum
+        )
 
         self.gridLayout_7.addItem(self.horizontalSpacer_11, 0, 4, 1, 1)
 
@@ -1131,54 +1243,121 @@ class Ui_Settings(object):
     # setupUi
 
     def retranslateUi(self, Settings):
-        Settings.setWindowTitle(QCoreApplication.translate("Settings", "Preferences", None))
-        self.groupBox.setTitle(QCoreApplication.translate("Settings", "Backup settings", None))
-        self.EnableBackup.setText(QCoreApplication.translate("Settings", "Create backup", None))
-        self.groupBox_Backup.setTitle(QCoreApplication.translate("Settings", "Backup location", None))
+        Settings.setWindowTitle(
+            QCoreApplication.translate("Settings", "Preferences", None)
+        )
+        self.groupBox.setTitle(
+            QCoreApplication.translate("Settings", "Backup settings", None)
+        )
+        self.EnableBackup.setText(
+            QCoreApplication.translate("Settings", "Create backup", None)
+        )
+        self.groupBox_Backup.setTitle(
+            QCoreApplication.translate("Settings", "Backup location", None)
+        )
         self.label_4.setText(QCoreApplication.translate("Settings", "...\\", None))
-        self.BackUpLocation.setText(QCoreApplication.translate("Settings", "Browse...", None))
-        self.groupBox1.setTitle(QCoreApplication.translate("Settings", "Ribbon settings", None))
-        self.groupBox_3.setTitle(QCoreApplication.translate("Settings", "Show text", None))
-        self.ShowText_Medium.setText(QCoreApplication.translate("Settings", "Medium buttons", None))
-        self.EnableWrap_Large.setText(QCoreApplication.translate("Settings", "Enable text wrap", None))
-        self.ShowText_Large.setText(QCoreApplication.translate("Settings", "Large buttons", None))
-        self.ShowText_Small.setText(QCoreApplication.translate("Settings", "Small buttons", None))
-        self.EnableWrap_Medium.setText(QCoreApplication.translate("Settings", "Enable text wrap", None))
-        self.groupBox_10.setTitle(QCoreApplication.translate("Settings", "Tab style", None))
-        self.TabbarStyle.setItemText(0, QCoreApplication.translate("Settings", "Icon + text", None))
-        self.TabbarStyle.setItemText(1, QCoreApplication.translate("Settings", "Icon only", None))
-        self.TabbarStyle.setItemText(2, QCoreApplication.translate("Settings", "Text only", None))
-
-        self.TabbarStyle.setCurrentText(QCoreApplication.translate("Settings", "Icon + text", None))
-        self.ToolbarPositions.setItemText(0, QCoreApplication.translate("Settings", "Toolbars above tabbar", None))
-        self.ToolbarPositions.setItemText(
-            1, QCoreApplication.translate("Settings", "Toolbars inline with tabbar", None)
+        self.BackUpLocation.setText(
+            QCoreApplication.translate("Settings", "Browse...", None)
+        )
+        self.groupBox1.setTitle(
+            QCoreApplication.translate("Settings", "Ribbon settings", None)
+        )
+        self.groupBox_3.setTitle(
+            QCoreApplication.translate("Settings", "Show text", None)
+        )
+        self.ShowText_Medium.setText(
+            QCoreApplication.translate("Settings", "Medium buttons", None)
+        )
+        self.EnableWrap_Large.setText(
+            QCoreApplication.translate("Settings", "Enable text wrap", None)
+        )
+        self.ShowText_Large.setText(
+            QCoreApplication.translate("Settings", "Large buttons", None)
+        )
+        self.ShowText_Small.setText(
+            QCoreApplication.translate("Settings", "Small buttons", None)
+        )
+        self.EnableWrap_Medium.setText(
+            QCoreApplication.translate("Settings", "Enable text wrap", None)
+        )
+        self.groupBox_10.setTitle(
+            QCoreApplication.translate("Settings", "Tab style", None)
+        )
+        self.TabbarStyle.setItemText(
+            0, QCoreApplication.translate("Settings", "Icon + text", None)
+        )
+        self.TabbarStyle.setItemText(
+            1, QCoreApplication.translate("Settings", "Icon only", None)
+        )
+        self.TabbarStyle.setItemText(
+            2, QCoreApplication.translate("Settings", "Text only", None)
         )
 
-        self.ToolbarPositions.setCurrentText(QCoreApplication.translate("Settings", "Toolbars above tabbar", None))
+        self.TabbarStyle.setCurrentText(
+            QCoreApplication.translate("Settings", "Icon + text", None)
+        )
+        self.ToolbarPositions.setItemText(
+            0, QCoreApplication.translate("Settings", "Toolbars above tabbar", None)
+        )
+        self.ToolbarPositions.setItemText(
+            1,
+            QCoreApplication.translate("Settings", "Toolbars inline with tabbar", None),
+        )
+
+        self.ToolbarPositions.setCurrentText(
+            QCoreApplication.translate("Settings", "Toolbars above tabbar", None)
+        )
         self.label_24.setText(
-            QCoreApplication.translate("Settings", "<html><head/><body><p>Set the tab style: </p></body></html>", None)
+            QCoreApplication.translate(
+                "Settings",
+                "<html><head/><body><p>Set the tab style: </p></body></html>",
+                None,
+            )
         )
         self.label_36.setText(
             QCoreApplication.translate(
-                "Settings", "<html><head/><body><p>Set the toolbar positions: </p></body></html>", None
+                "Settings",
+                "<html><head/><body><p>Set the toolbar positions: </p></body></html>",
+                None,
             )
         )
-        self.HideTitleBarFC.setText(QCoreApplication.translate("Settings", "Hide the titlebar of FreeCAD", None))
-        self.groupBox_4.setTitle(QCoreApplication.translate("Settings", "Button size", None))
-        self.label_23.setText(QCoreApplication.translate("Settings", "Size of tabbar tabs:", None))
-        self.label_22.setText(QCoreApplication.translate("Settings", "Size of right toolbar buttons:", None))
-        self.label_5.setText(QCoreApplication.translate("Settings", "Size of application button:", None))
-        self.label_10.setText(QCoreApplication.translate("Settings", "Size of small buttons:", None))
+        self.HideTitleBarFC.setText(
+            QCoreApplication.translate("Settings", "Hide the titlebar of FreeCAD", None)
+        )
+        self.groupBox_4.setTitle(
+            QCoreApplication.translate("Settings", "Button size", None)
+        )
+        self.label_23.setText(
+            QCoreApplication.translate("Settings", "Size of tabbar tabs:", None)
+        )
+        self.label_22.setText(
+            QCoreApplication.translate(
+                "Settings", "Size of right toolbar buttons:", None
+            )
+        )
+        self.label_5.setText(
+            QCoreApplication.translate("Settings", "Size of application button:", None)
+        )
+        self.label_10.setText(
+            QCoreApplication.translate("Settings", "Size of small buttons:", None)
+        )
         self.label_21.setText(
             QCoreApplication.translate(
-                "Settings", "<html><head/><body><p>Size of quick access toolbar buttons:</p></body></html>", None
+                "Settings",
+                "<html><head/><body><p>Size of quick access toolbar buttons:</p></body></html>",
+                None,
             )
         )
-        self.label_11.setText(QCoreApplication.translate("Settings", "Size of medium buttons:", None))
-        self.label_25.setText(QCoreApplication.translate("Settings", "Size of large buttons:", None))
+        self.label_11.setText(
+            QCoreApplication.translate("Settings", "Size of medium buttons:", None)
+        )
+        self.label_25.setText(
+            QCoreApplication.translate("Settings", "Size of large buttons:", None)
+        )
         self.groupBox_5.setTitle(QCoreApplication.translate("Settings", "Panels", None))
-        self.label.setText(QCoreApplication.translate("Settings", "No. of columns per panel:", None))
+        self.label.setText(
+            QCoreApplication.translate("Settings", "No. of columns per panel:", None)
+        )
         self.label_2.setText(
             QCoreApplication.translate(
                 "Settings",
@@ -1186,15 +1365,31 @@ class Ui_Settings(object):
                 None,
             )
         )
-        self.groupBox_14.setTitle(QCoreApplication.translate("Settings", "Text size", None))
-        self.label_32.setText(QCoreApplication.translate("Settings", "Text size of menus", None))
-        self.label_34.setText(QCoreApplication.translate("Settings", "Text size of tabs", None))
-        self.label_35.setText(QCoreApplication.translate("Settings", "Text size of panel titles", None))
-        self.label_33.setText(QCoreApplication.translate("Settings", "Text size of buttons", None))
-        self.groupBox_2.setTitle(QCoreApplication.translate("Settings", "Select stylesheet", None))
+        self.groupBox_14.setTitle(
+            QCoreApplication.translate("Settings", "Text size", None)
+        )
+        self.label_32.setText(
+            QCoreApplication.translate("Settings", "Text size of menus", None)
+        )
+        self.label_34.setText(
+            QCoreApplication.translate("Settings", "Text size of tabs", None)
+        )
+        self.label_35.setText(
+            QCoreApplication.translate("Settings", "Text size of panel titles", None)
+        )
+        self.label_33.setText(
+            QCoreApplication.translate("Settings", "Text size of buttons", None)
+        )
+        self.groupBox_2.setTitle(
+            QCoreApplication.translate("Settings", "Select stylesheet", None)
+        )
         self.label_7.setText(QCoreApplication.translate("Settings", "...\\", None))
-        self.StyleSheetLocation.setText(QCoreApplication.translate("Settings", "Browse...", None))
-        self.DebugMode.setText(QCoreApplication.translate("Settings", "Debug mode", None))
+        self.StyleSheetLocation.setText(
+            QCoreApplication.translate("Settings", "Browse...", None)
+        )
+        self.DebugMode.setText(
+            QCoreApplication.translate("Settings", "Debug mode", None)
+        )
         self.label_3.setText(
             QCoreApplication.translate(
                 "Settings",
@@ -1203,18 +1398,27 @@ class Ui_Settings(object):
             )
         )
         self.tabWidget.setTabText(
-            self.tabWidget.indexOf(self.General), QCoreApplication.translate("Settings", "General", None)
+            self.tabWidget.indexOf(self.General),
+            QCoreApplication.translate("Settings", "General", None),
         )
-        self.groupBox_6.setTitle(QCoreApplication.translate("Settings", "Mouse settings", None))
-        self.EnableEnterEvent.setText(QCoreApplication.translate("Settings", "Show ribbon on hover. ", None))
+        self.groupBox_6.setTitle(
+            QCoreApplication.translate("Settings", "Mouse settings", None)
+        )
+        self.EnableEnterEvent.setText(
+            QCoreApplication.translate("Settings", "Show ribbon on hover. ", None)
+        )
         self.label_12.setText(
             QCoreApplication.translate(
-                "Settings", "<html><head/><body><p>Scroll speed for ribbon:</p></body></html>", None
+                "Settings",
+                "<html><head/><body><p>Scroll speed for ribbon:</p></body></html>",
+                None,
             )
         )
         self.label_13.setText(
             QCoreApplication.translate(
-                "Settings", "<html><head/><body><p>Scroll speed for tab bar:</p></body></html>", None
+                "Settings",
+                "<html><head/><body><p>Scroll speed for tab bar:</p></body></html>",
+                None,
             )
         )
         self.label_41.setText(
@@ -1224,64 +1428,104 @@ class Ui_Settings(object):
                 None,
             )
         )
-        self.groupBox_7.setTitle(QCoreApplication.translate("Settings", "Scroll buttons", None))
+        self.groupBox_7.setTitle(
+            QCoreApplication.translate("Settings", "Scroll buttons", None)
+        )
         self.label_14.setText(
             QCoreApplication.translate(
-                "Settings", "<html><head/><body><p>Scroll steps per click for ribbon:</p></body></html>", None
+                "Settings",
+                "<html><head/><body><p>Scroll steps per click for ribbon:</p></body></html>",
+                None,
             )
         )
         self.label_15.setText(
             QCoreApplication.translate(
-                "Settings", "<html><head/><body><p>Scroll steps per click for tab bar:</p></body></html>", None
+                "Settings",
+                "<html><head/><body><p>Scroll steps per click for tab bar:</p></body></html>",
+                None,
             )
         )
         self.tabWidget.setTabText(
-            self.tabWidget.indexOf(self.tab), QCoreApplication.translate("Settings", "Navigation", None)
+            self.tabWidget.indexOf(self.tab),
+            QCoreApplication.translate("Settings", "Navigation", None),
         )
         self.groupBox_9.setTitle(QCoreApplication.translate("Settings", "Icons", None))
-        self.CustomIcons.setText(QCoreApplication.translate("Settings", "Enable custom icons", None))
+        self.CustomIcons.setText(
+            QCoreApplication.translate("Settings", "Enable custom icons", None)
+        )
         self.label_16.setText(
-            QCoreApplication.translate("Settings", "<html><head/><body><p>Tab bar scroll left:</p></body></html>", None)
+            QCoreApplication.translate(
+                "Settings",
+                "<html><head/><body><p>Tab bar scroll left:</p></body></html>",
+                None,
+            )
         )
         self.Tab_Scroll_Left.setText("")
-        self.label_17.setText(QCoreApplication.translate("Settings", "Tab bar scroll right:", None))
+        self.label_17.setText(
+            QCoreApplication.translate("Settings", "Tab bar scroll right:", None)
+        )
         self.Tab_Scroll_Right.setText("")
-        self.label_18.setText(QCoreApplication.translate("Settings", "Ribbon bar scroll left:", None))
+        self.label_18.setText(
+            QCoreApplication.translate("Settings", "Ribbon bar scroll left:", None)
+        )
         self.Ribbon_Scroll_Left.setText("")
         self.label_19.setText(
             QCoreApplication.translate(
-                "Settings", "<html><head/><body><p>Ribbon bar scroll right:</p></body></html>", None
+                "Settings",
+                "<html><head/><body><p>Ribbon bar scroll right:</p></body></html>",
+                None,
             )
         )
         self.Ribbon_Scroll_Right.setText("")
         self.label_20.setText(
             QCoreApplication.translate(
-                "Settings", "<html><head/><body><p>More commands button:</p></body></html>", None
+                "Settings",
+                "<html><head/><body><p>More commands button:</p></body></html>",
+                None,
             )
         )
         self.MoreCommands.setText("")
-        self.label_28.setText(QCoreApplication.translate("Settings", "Pin button - unpinned:", None))
+        self.label_28.setText(
+            QCoreApplication.translate("Settings", "Pin button - unpinned:", None)
+        )
         self.pinButton_open.setText("")
-        self.label_29.setText(QCoreApplication.translate("Settings", "Pin button - pinned:", None))
+        self.label_29.setText(
+            QCoreApplication.translate("Settings", "Pin button - pinned:", None)
+        )
         self.pinButton_closed.setText("")
         self.groupBox_8.setTitle(QCoreApplication.translate("Settings", "Colors", None))
-        self.CustomColors.setText(QCoreApplication.translate("Settings", "Enable custom colors", None))
+        self.CustomColors.setText(
+            QCoreApplication.translate("Settings", "Enable custom colors", None)
+        )
         self.label_30.setText(
-            QCoreApplication.translate("Settings", "Set the color for buttons when hovering over them", None)
+            QCoreApplication.translate(
+                "Settings", "Set the color for buttons when hovering over them", None
+            )
         )
         self.label_6.setText(
-            QCoreApplication.translate("Settings", "Set the color for control borders when hovering over them:", None)
+            QCoreApplication.translate(
+                "Settings",
+                "Set the color for control borders when hovering over them:",
+                None,
+            )
         )
         self.label_9.setText(
-            QCoreApplication.translate("Settings", "Set the background color for the application button:", None)
+            QCoreApplication.translate(
+                "Settings", "Set the background color for the application button:", None
+            )
         )
         self.BorderTransparant.setText(
-            QCoreApplication.translate("Settings", "Set border invisible for ribbon buttons", None)
+            QCoreApplication.translate(
+                "Settings", "Set border invisible for ribbon buttons", None
+            )
         )
         self.tabWidget.setTabText(
-            self.tabWidget.indexOf(self.tab_2), QCoreApplication.translate("Settings", "Colors and icons", None)
+            self.tabWidget.indexOf(self.tab_2),
+            QCoreApplication.translate("Settings", "Colors and icons", None),
         )
-        self.EnableOverlay.setTitle(QCoreApplication.translate("Settings", "Enable overlay", None))
+        self.EnableOverlay.setTitle(
+            QCoreApplication.translate("Settings", "Enable overlay", None)
+        )
         # if QT_CONFIG(tooltip)
         self.FCOverlayEnabled.setToolTip(
             QCoreApplication.translate(
@@ -1292,8 +1536,14 @@ class Ui_Settings(object):
             )
         )
         # endif // QT_CONFIG(tooltip)
-        self.FCOverlayEnabled.setText(QCoreApplication.translate("Settings", "Use FreeCAD's overlay function.", None))
-        self.UseButtonBackGround.setText(QCoreApplication.translate("Settings", "Use background on buttons", None))
+        self.FCOverlayEnabled.setText(
+            QCoreApplication.translate(
+                "Settings", "Use FreeCAD's overlay function.", None
+            )
+        )
+        self.UseButtonBackGround.setText(
+            QCoreApplication.translate("Settings", "Use background on buttons", None)
+        )
         self.label_26.setText(
             QCoreApplication.translate(
                 "Settings",
@@ -1301,23 +1551,42 @@ class Ui_Settings(object):
                 None,
             )
         )
-        self.groupBox_11.setTitle(QCoreApplication.translate("Settings", "Standard panels preference", None))
-        self.label_27.setText(QCoreApplication.translate("Settings", "Select preferred standard view panel: ", None))
-        self.PreferedViewPanel.setItemText(0, QCoreApplication.translate("Settings", "Individual views - Native", None))
-        self.PreferedViewPanel.setItemText(1, QCoreApplication.translate("Settings", "Views - Native", None))
-        self.PreferedViewPanel.setItemText(2, QCoreApplication.translate("Settings", "Views - Ribbon", None))
-        self.PreferedViewPanel.setItemText(3, QCoreApplication.translate("Settings", "None", None))
+        self.groupBox_11.setTitle(
+            QCoreApplication.translate("Settings", "Standard panels preference", None)
+        )
+        self.label_27.setText(
+            QCoreApplication.translate(
+                "Settings", "Select preferred standard view panel: ", None
+            )
+        )
+        self.PreferedViewPanel.setItemText(
+            0, QCoreApplication.translate("Settings", "Individual views - Native", None)
+        )
+        self.PreferedViewPanel.setItemText(
+            1, QCoreApplication.translate("Settings", "Views - Native", None)
+        )
+        self.PreferedViewPanel.setItemText(
+            2, QCoreApplication.translate("Settings", "Views - Ribbon", None)
+        )
+        self.PreferedViewPanel.setItemText(
+            3, QCoreApplication.translate("Settings", "None", None)
+        )
 
-        self.EnableToolsPanel.setText(QCoreApplication.translate("Settings", "Use standard Tools panel", None))
+        self.EnableToolsPanel.setText(
+            QCoreApplication.translate("Settings", "Use standard Tools panel", None)
+        )
         self.tabWidget.setTabText(
-            self.tabWidget.indexOf(self.tab_3), QCoreApplication.translate("Settings", "Miscellaneous", None)
+            self.tabWidget.indexOf(self.tab_3),
+            QCoreApplication.translate("Settings", "Miscellaneous", None),
         )
         self.Cancel.setText(QCoreApplication.translate("Settings", "Cancel", None))
         # if QT_CONFIG(shortcut)
         self.Cancel.setShortcut(QCoreApplication.translate("Settings", "Esc", None))
         # endif // QT_CONFIG(shortcut)
         self.Reset.setText(QCoreApplication.translate("Settings", "Reset", None))
-        self.GenerateJsonExit.setText(QCoreApplication.translate("Settings", "Close", None))
+        self.GenerateJsonExit.setText(
+            QCoreApplication.translate("Settings", "Close", None)
+        )
         # if QT_CONFIG(shortcut)
         self.GenerateJsonExit.setShortcut("")
         # endif // QT_CONFIG(shortcut)

--- a/Resources/ui/Settings_ui.py
+++ b/Resources/ui/Settings_ui.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 ################################################################################
-## Form generated from reading UI file 'SettingsnMsOlI.ui'
+## Form generated from reading UI file 'SettingsAxImyX.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.8.1
+## Created by: Qt User Interface Compiler version 6.8.3
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -56,6 +56,7 @@ from PySide.QtWidgets import (
     QSpacerItem,
     QSpinBox,
     QTabWidget,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
@@ -67,49 +68,20 @@ class Ui_Settings(object):
             Settings.setObjectName("Settings")
         Settings.setWindowModality(Qt.WindowModality.WindowModal)
         Settings.resize(736, 801)
-        sizePolicy = QSizePolicy(
-            QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Preferred
-        )
+        sizePolicy = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(Settings.sizePolicy().hasHeightForWidth())
         Settings.setSizePolicy(sizePolicy)
         Settings.setMinimumSize(QSize(600, 600))
         Settings.setAutoFillBackground(False)
-        self.gridLayout_40 = QGridLayout(Settings)
-        self.gridLayout_40.setObjectName("gridLayout_40")
-        self.gridLayout_7 = QGridLayout()
-        self.gridLayout_7.setObjectName("gridLayout_7")
-        self.Reset = QPushButton(Settings)
-        self.Reset.setObjectName("Reset")
-
-        self.gridLayout_7.addWidget(self.Reset, 0, 0, 1, 1)
-
-        self.horizontalSpacer_2 = QSpacerItem(
-            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
-        )
-
-        self.gridLayout_7.addItem(self.horizontalSpacer_2, 0, 1, 1, 1)
-
-        self.GenerateJsonExit = QPushButton(Settings)
-        self.GenerateJsonExit.setObjectName("GenerateJsonExit")
-
-        self.gridLayout_7.addWidget(self.GenerateJsonExit, 0, 2, 1, 1)
-
-        self.Cancel = QPushButton(Settings)
-        self.Cancel.setObjectName("Cancel")
-
-        self.gridLayout_7.addWidget(self.Cancel, 0, 3, 1, 1)
-
-        self.gridLayout_40.addLayout(self.gridLayout_7, 1, 0, 1, 1)
-
+        self.gridLayout_36 = QGridLayout(Settings)
+        self.gridLayout_36.setObjectName("gridLayout_36")
         self.gridLayout_6 = QGridLayout()
         self.gridLayout_6.setObjectName("gridLayout_6")
         self.scrollArea = QScrollArea(Settings)
         self.scrollArea.setObjectName("scrollArea")
-        sizePolicy1 = QSizePolicy(
-            QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding
-        )
+        sizePolicy1 = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding)
         sizePolicy1.setHorizontalStretch(0)
         sizePolicy1.setVerticalStretch(0)
         sizePolicy1.setHeightForWidth(self.scrollArea.sizePolicy().hasHeightForWidth())
@@ -123,9 +95,7 @@ class Ui_Settings(object):
         self.gridLayout_28.setObjectName("gridLayout_28")
         self.tabWidget = QTabWidget(self.scrollAreaWidgetContents)
         self.tabWidget.setObjectName("tabWidget")
-        sizePolicy2 = QSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
-        )
+        sizePolicy2 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         sizePolicy2.setHorizontalStretch(0)
         sizePolicy2.setVerticalStretch(0)
         sizePolicy2.setHeightForWidth(self.tabWidget.sizePolicy().hasHeightForWidth())
@@ -160,14 +130,10 @@ class Ui_Settings(object):
         self.groupBox_Backup = QGroupBox(self.groupBox)
         self.groupBox_Backup.setObjectName("groupBox_Backup")
         self.groupBox_Backup.setEnabled(False)
-        sizePolicy3 = QSizePolicy(
-            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed
-        )
+        sizePolicy3 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
         sizePolicy3.setHorizontalStretch(0)
         sizePolicy3.setVerticalStretch(0)
-        sizePolicy3.setHeightForWidth(
-            self.groupBox_Backup.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy3.setHeightForWidth(self.groupBox_Backup.sizePolicy().hasHeightForWidth())
         self.groupBox_Backup.setSizePolicy(sizePolicy3)
         self.groupBox_Backup.setMinimumSize(QSize(0, 50))
         self.groupBox_Backup.setFont(font1)
@@ -175,9 +141,7 @@ class Ui_Settings(object):
         self.gridLayout_13.setObjectName("gridLayout_13")
         self.label_4 = QLabel(self.groupBox_Backup)
         self.label_4.setObjectName("label_4")
-        sizePolicy4 = QSizePolicy(
-            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred
-        )
+        sizePolicy4 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
         sizePolicy4.setHorizontalStretch(0)
         sizePolicy4.setVerticalStretch(0)
         sizePolicy4.setHeightForWidth(self.label_4.sizePolicy().hasHeightForWidth())
@@ -186,9 +150,7 @@ class Ui_Settings(object):
         self.label_4.setFrameShape(QFrame.Shape.Box)
         self.label_4.setScaledContents(True)
         self.label_4.setAlignment(
-            Qt.AlignmentFlag.AlignLeading
-            | Qt.AlignmentFlag.AlignLeft
-            | Qt.AlignmentFlag.AlignVCenter
+            Qt.AlignmentFlag.AlignLeading | Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
         )
 
         self.gridLayout_13.addWidget(self.label_4, 0, 0, 1, 1)
@@ -198,9 +160,7 @@ class Ui_Settings(object):
         sizePolicy5 = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         sizePolicy5.setHorizontalStretch(20)
         sizePolicy5.setVerticalStretch(0)
-        sizePolicy5.setHeightForWidth(
-            self.BackUpLocation.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy5.setHeightForWidth(self.BackUpLocation.sizePolicy().hasHeightForWidth())
         self.BackUpLocation.setSizePolicy(sizePolicy5)
         self.BackUpLocation.setMinimumSize(QSize(20, 0))
 
@@ -230,9 +190,7 @@ class Ui_Settings(object):
         sizePolicy6 = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         sizePolicy6.setHorizontalStretch(0)
         sizePolicy6.setVerticalStretch(0)
-        sizePolicy6.setHeightForWidth(
-            self.ShowText_Medium.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy6.setHeightForWidth(self.ShowText_Medium.sizePolicy().hasHeightForWidth())
         self.ShowText_Medium.setSizePolicy(sizePolicy6)
         self.ShowText_Medium.setMinimumSize(QSize(100, 0))
         self.ShowText_Medium.setFont(font1)
@@ -248,9 +206,7 @@ class Ui_Settings(object):
 
         self.ShowText_Large = QCheckBox(self.groupBox_3)
         self.ShowText_Large.setObjectName("ShowText_Large")
-        sizePolicy6.setHeightForWidth(
-            self.ShowText_Large.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy6.setHeightForWidth(self.ShowText_Large.sizePolicy().hasHeightForWidth())
         self.ShowText_Large.setSizePolicy(sizePolicy6)
         self.ShowText_Large.setMinimumSize(QSize(100, 0))
         self.ShowText_Large.setFont(font1)
@@ -260,18 +216,14 @@ class Ui_Settings(object):
 
         self.ShowText_Small = QCheckBox(self.groupBox_3)
         self.ShowText_Small.setObjectName("ShowText_Small")
-        sizePolicy6.setHeightForWidth(
-            self.ShowText_Small.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy6.setHeightForWidth(self.ShowText_Small.sizePolicy().hasHeightForWidth())
         self.ShowText_Small.setSizePolicy(sizePolicy6)
         self.ShowText_Small.setMinimumSize(QSize(100, 0))
         self.ShowText_Small.setFont(font1)
 
         self.gridLayout_26.addWidget(self.ShowText_Small, 0, 0, 1, 1)
 
-        self.horizontalSpacer_9 = QSpacerItem(
-            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
-        )
+        self.horizontalSpacer_9 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_26.addItem(self.horizontalSpacer_9, 0, 2, 1, 1)
 
@@ -288,9 +240,7 @@ class Ui_Settings(object):
 
         self.groupBox_10 = QGroupBox(self.groupBox1)
         self.groupBox_10.setObjectName("groupBox_10")
-        sizePolicy7 = QSizePolicy(
-            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Minimum
-        )
+        sizePolicy7 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Minimum)
         sizePolicy7.setHorizontalStretch(0)
         sizePolicy7.setVerticalStretch(0)
         sizePolicy7.setHeightForWidth(self.groupBox_10.sizePolicy().hasHeightForWidth())
@@ -341,9 +291,7 @@ class Ui_Settings(object):
 
         self.gridLayout_25.addLayout(self.gridLayout_24, 0, 0, 1, 1)
 
-        self.horizontalSpacer_7 = QSpacerItem(
-            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
-        )
+        self.horizontalSpacer_7 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_25.addItem(self.horizontalSpacer_7, 0, 1, 1, 1)
 
@@ -363,22 +311,16 @@ class Ui_Settings(object):
 
         self.IconSize_Medium = QSpinBox(self.groupBox_4)
         self.IconSize_Medium.setObjectName("IconSize_Medium")
-        sizePolicy8 = QSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Preferred
-        )
+        sizePolicy8 = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Preferred)
         sizePolicy8.setHorizontalStretch(0)
         sizePolicy8.setVerticalStretch(0)
-        sizePolicy8.setHeightForWidth(
-            self.IconSize_Medium.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy8.setHeightForWidth(self.IconSize_Medium.sizePolicy().hasHeightForWidth())
         self.IconSize_Medium.setSizePolicy(sizePolicy8)
         self.IconSize_Medium.setMinimumSize(QSize(50, 20))
         self.IconSize_Medium.setBaseSize(QSize(0, 0))
         self.IconSize_Medium.setFont(font1)
         self.IconSize_Medium.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.IconSize_Medium.setCorrectionMode(
-            QAbstractSpinBox.CorrectionMode.CorrectToNearestValue
-        )
+        self.IconSize_Medium.setCorrectionMode(QAbstractSpinBox.CorrectionMode.CorrectToNearestValue)
         self.IconSize_Medium.setMinimum(16)
         self.IconSize_Medium.setMaximum(48)
         self.IconSize_Medium.setValue(44)
@@ -467,9 +409,7 @@ class Ui_Settings(object):
 
         self.IconSize_Small = QSpinBox(self.groupBox_4)
         self.IconSize_Small.setObjectName("IconSize_Small")
-        sizePolicy8.setHeightForWidth(
-            self.IconSize_Small.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy8.setHeightForWidth(self.IconSize_Small.sizePolicy().hasHeightForWidth())
         self.IconSize_Small.setSizePolicy(sizePolicy8)
         self.IconSize_Small.setMinimumSize(QSize(50, 20))
         self.IconSize_Small.setSizeIncrement(QSize(0, 0))
@@ -478,9 +418,7 @@ class Ui_Settings(object):
         self.IconSize_Small.setFocusPolicy(Qt.FocusPolicy.WheelFocus)
         self.IconSize_Small.setFrame(True)
         self.IconSize_Small.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.IconSize_Small.setCorrectionMode(
-            QAbstractSpinBox.CorrectionMode.CorrectToNearestValue
-        )
+        self.IconSize_Small.setCorrectionMode(QAbstractSpinBox.CorrectionMode.CorrectToNearestValue)
         self.IconSize_Small.setProperty("showGroupSeparator", False)
         self.IconSize_Small.setMinimum(16)
         self.IconSize_Small.setMaximum(36)
@@ -490,9 +428,7 @@ class Ui_Settings(object):
 
         self.gridLayout_5.addLayout(self.gridLayout, 1, 0, 1, 1)
 
-        self.horizontalSpacer_3 = QSpacerItem(
-            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
-        )
+        self.horizontalSpacer_3 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_5.addItem(self.horizontalSpacer_3, 1, 1, 1, 1)
 
@@ -510,9 +446,7 @@ class Ui_Settings(object):
         self.gridLayout_10.setObjectName("gridLayout_10")
         self.MaxPanelColumn = QSpinBox(self.groupBox_5)
         self.MaxPanelColumn.setObjectName("MaxPanelColumn")
-        sizePolicy6.setHeightForWidth(
-            self.MaxPanelColumn.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy6.setHeightForWidth(self.MaxPanelColumn.sizePolicy().hasHeightForWidth())
         self.MaxPanelColumn.setSizePolicy(sizePolicy6)
         self.MaxPanelColumn.setMinimumSize(QSize(50, 20))
         self.MaxPanelColumn.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -527,9 +461,7 @@ class Ui_Settings(object):
 
         self.gridLayout_10.addWidget(self.label, 0, 0, 1, 1)
 
-        self.horizontalSpacer = QSpacerItem(
-            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
-        )
+        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_10.addItem(self.horizontalSpacer, 0, 2, 1, 1)
 
@@ -563,9 +495,7 @@ class Ui_Settings(object):
 
         self.TextSize_Menus = QSpinBox(self.groupBox_14)
         self.TextSize_Menus.setObjectName("TextSize_Menus")
-        sizePolicy8.setHeightForWidth(
-            self.TextSize_Menus.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy8.setHeightForWidth(self.TextSize_Menus.sizePolicy().hasHeightForWidth())
         self.TextSize_Menus.setSizePolicy(sizePolicy8)
         self.TextSize_Menus.setMinimumSize(QSize(50, 20))
         self.TextSize_Menus.setSizeIncrement(QSize(0, 0))
@@ -574,9 +504,7 @@ class Ui_Settings(object):
         self.TextSize_Menus.setFocusPolicy(Qt.FocusPolicy.WheelFocus)
         self.TextSize_Menus.setFrame(True)
         self.TextSize_Menus.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.TextSize_Menus.setCorrectionMode(
-            QAbstractSpinBox.CorrectionMode.CorrectToNearestValue
-        )
+        self.TextSize_Menus.setCorrectionMode(QAbstractSpinBox.CorrectionMode.CorrectToNearestValue)
         self.TextSize_Menus.setProperty("showGroupSeparator", False)
         self.TextSize_Menus.setMinimum(8)
         self.TextSize_Menus.setMaximum(24)
@@ -599,9 +527,7 @@ class Ui_Settings(object):
         self.TextSize_Buttons.setObjectName("TextSize_Buttons")
         self.TextSize_Buttons.setFont(font1)
         self.TextSize_Buttons.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.TextSize_Buttons.setCorrectionMode(
-            QAbstractSpinBox.CorrectionMode.CorrectToNearestValue
-        )
+        self.TextSize_Buttons.setCorrectionMode(QAbstractSpinBox.CorrectionMode.CorrectToNearestValue)
         self.TextSize_Buttons.setMinimum(8)
         self.TextSize_Buttons.setMaximum(24)
         self.TextSize_Buttons.setValue(11)
@@ -630,9 +556,7 @@ class Ui_Settings(object):
 
         self.gridLayout_39.addLayout(self.gridLayout_38, 0, 0, 1, 1)
 
-        self.horizontalSpacer_12 = QSpacerItem(
-            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
-        )
+        self.horizontalSpacer_12 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_39.addItem(self.horizontalSpacer_12, 0, 1, 1, 1)
 
@@ -642,9 +566,7 @@ class Ui_Settings(object):
 
         self.groupBox_2 = QGroupBox(self.groupBox1)
         self.groupBox_2.setObjectName("groupBox_2")
-        sizePolicy9 = QSizePolicy(
-            QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Fixed
-        )
+        sizePolicy9 = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Fixed)
         sizePolicy9.setHorizontalStretch(0)
         sizePolicy9.setVerticalStretch(0)
         sizePolicy9.setHeightForWidth(self.groupBox_2.sizePolicy().hasHeightForWidth())
@@ -659,18 +581,14 @@ class Ui_Settings(object):
         self.label_7.setFrameShape(QFrame.Shape.Box)
         self.label_7.setScaledContents(True)
         self.label_7.setAlignment(
-            Qt.AlignmentFlag.AlignLeading
-            | Qt.AlignmentFlag.AlignLeft
-            | Qt.AlignmentFlag.AlignVCenter
+            Qt.AlignmentFlag.AlignLeading | Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
         )
 
         self.gridLayout_12.addWidget(self.label_7, 0, 0, 1, 1)
 
         self.StyleSheetLocation = QPushButton(self.groupBox_2)
         self.StyleSheetLocation.setObjectName("StyleSheetLocation")
-        sizePolicy5.setHeightForWidth(
-            self.StyleSheetLocation.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy5.setHeightForWidth(self.StyleSheetLocation.sizePolicy().hasHeightForWidth())
         self.StyleSheetLocation.setSizePolicy(sizePolicy5)
         self.StyleSheetLocation.setMinimumSize(QSize(20, 0))
 
@@ -704,9 +622,7 @@ class Ui_Settings(object):
 
         self.gridLayout_9.addLayout(self.verticalLayout_2, 6, 0, 1, 1)
 
-        self.verticalSpacer_7 = QSpacerItem(
-            20, 10, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding
-        )
+        self.verticalSpacer_7 = QSpacerItem(20, 10, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.gridLayout_9.addItem(self.verticalSpacer_7, 5, 0, 1, 1)
 
@@ -715,9 +631,7 @@ class Ui_Settings(object):
         self.tab.setObjectName("tab")
         self.gridLayout_14 = QGridLayout(self.tab)
         self.gridLayout_14.setObjectName("gridLayout_14")
-        self.verticalSpacer = QSpacerItem(
-            20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding
-        )
+        self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.gridLayout_14.addItem(self.verticalSpacer, 3, 0, 1, 1)
 
@@ -764,14 +678,10 @@ class Ui_Settings(object):
 
         self.ScrollSpeed_TabBar = QSlider(self.groupBox_6)
         self.ScrollSpeed_TabBar.setObjectName("ScrollSpeed_TabBar")
-        sizePolicy10 = QSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
-        )
+        sizePolicy10 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         sizePolicy10.setHorizontalStretch(0)
         sizePolicy10.setVerticalStretch(0)
-        sizePolicy10.setHeightForWidth(
-            self.ScrollSpeed_TabBar.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy10.setHeightForWidth(self.ScrollSpeed_TabBar.sizePolicy().hasHeightForWidth())
         self.ScrollSpeed_TabBar.setSizePolicy(sizePolicy10)
         self.ScrollSpeed_TabBar.setMaximum(10)
         self.ScrollSpeed_TabBar.setSingleStep(1)
@@ -804,9 +714,7 @@ class Ui_Settings(object):
         self.gridLayout_17.setObjectName("gridLayout_17")
         self.ScrollClicks_TabBar = QSpinBox(self.groupBox_7)
         self.ScrollClicks_TabBar.setObjectName("ScrollClicks_TabBar")
-        sizePolicy8.setHeightForWidth(
-            self.ScrollClicks_TabBar.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy8.setHeightForWidth(self.ScrollClicks_TabBar.sizePolicy().hasHeightForWidth())
         self.ScrollClicks_TabBar.setSizePolicy(sizePolicy8)
         self.ScrollClicks_TabBar.setMinimumSize(QSize(50, 0))
         self.ScrollClicks_TabBar.setSizeIncrement(QSize(0, 0))
@@ -814,9 +722,7 @@ class Ui_Settings(object):
         self.ScrollClicks_TabBar.setFont(font1)
         self.ScrollClicks_TabBar.setFrame(True)
         self.ScrollClicks_TabBar.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.ScrollClicks_TabBar.setCorrectionMode(
-            QAbstractSpinBox.CorrectionMode.CorrectToNearestValue
-        )
+        self.ScrollClicks_TabBar.setCorrectionMode(QAbstractSpinBox.CorrectionMode.CorrectToNearestValue)
         self.ScrollClicks_TabBar.setProperty("showGroupSeparator", False)
         self.ScrollClicks_TabBar.setMinimum(0)
         self.ScrollClicks_TabBar.setMaximum(10)
@@ -836,17 +742,13 @@ class Ui_Settings(object):
 
         self.ScrollClicks_Ribbon = QSpinBox(self.groupBox_7)
         self.ScrollClicks_Ribbon.setObjectName("ScrollClicks_Ribbon")
-        sizePolicy8.setHeightForWidth(
-            self.ScrollClicks_Ribbon.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy8.setHeightForWidth(self.ScrollClicks_Ribbon.sizePolicy().hasHeightForWidth())
         self.ScrollClicks_Ribbon.setSizePolicy(sizePolicy8)
         self.ScrollClicks_Ribbon.setMinimumSize(QSize(50, 0))
         self.ScrollClicks_Ribbon.setBaseSize(QSize(0, 0))
         self.ScrollClicks_Ribbon.setFont(font1)
         self.ScrollClicks_Ribbon.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.ScrollClicks_Ribbon.setCorrectionMode(
-            QAbstractSpinBox.CorrectionMode.CorrectToNearestValue
-        )
+        self.ScrollClicks_Ribbon.setCorrectionMode(QAbstractSpinBox.CorrectionMode.CorrectToNearestValue)
         self.ScrollClicks_Ribbon.setMaximum(10)
         self.ScrollClicks_Ribbon.setValue(1)
         self.ScrollClicks_Ribbon.setDisplayIntegerBase(10)
@@ -864,9 +766,7 @@ class Ui_Settings(object):
 
         self.gridLayout_18.addLayout(self.gridLayout_17, 0, 0, 1, 1)
 
-        self.horizontalSpacer_4 = QSpacerItem(
-            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
-        )
+        self.horizontalSpacer_4 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_18.addItem(self.horizontalSpacer_4, 0, 1, 1, 1)
 
@@ -886,9 +786,7 @@ class Ui_Settings(object):
 
         self.gridLayout_23.addWidget(self.CustomIcons, 0, 0, 1, 1)
 
-        self.horizontalSpacer_6 = QSpacerItem(
-            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
-        )
+        self.horizontalSpacer_6 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_23.addItem(self.horizontalSpacer_6, 1, 1, 1, 1)
 
@@ -906,9 +804,7 @@ class Ui_Settings(object):
 
         self.Tab_Scroll_Left = QPushButton(self.IconS)
         self.Tab_Scroll_Left.setObjectName("Tab_Scroll_Left")
-        sizePolicy6.setHeightForWidth(
-            self.Tab_Scroll_Left.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy6.setHeightForWidth(self.Tab_Scroll_Left.sizePolicy().hasHeightForWidth())
         self.Tab_Scroll_Left.setSizePolicy(sizePolicy6)
         self.Tab_Scroll_Left.setMinimumSize(QSize(10, 20))
         self.Tab_Scroll_Left.setMaximumSize(QSize(20, 20))
@@ -923,9 +819,7 @@ class Ui_Settings(object):
 
         self.Tab_Scroll_Right = QPushButton(self.IconS)
         self.Tab_Scroll_Right.setObjectName("Tab_Scroll_Right")
-        sizePolicy6.setHeightForWidth(
-            self.Tab_Scroll_Right.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy6.setHeightForWidth(self.Tab_Scroll_Right.sizePolicy().hasHeightForWidth())
         self.Tab_Scroll_Right.setSizePolicy(sizePolicy6)
         self.Tab_Scroll_Right.setMinimumSize(QSize(10, 20))
         self.Tab_Scroll_Right.setMaximumSize(QSize(20, 20))
@@ -940,9 +834,7 @@ class Ui_Settings(object):
 
         self.Ribbon_Scroll_Left = QPushButton(self.IconS)
         self.Ribbon_Scroll_Left.setObjectName("Ribbon_Scroll_Left")
-        sizePolicy6.setHeightForWidth(
-            self.Ribbon_Scroll_Left.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy6.setHeightForWidth(self.Ribbon_Scroll_Left.sizePolicy().hasHeightForWidth())
         self.Ribbon_Scroll_Left.setSizePolicy(sizePolicy6)
         self.Ribbon_Scroll_Left.setMinimumSize(QSize(20, 60))
         self.Ribbon_Scroll_Left.setMaximumSize(QSize(20, 60))
@@ -956,9 +848,7 @@ class Ui_Settings(object):
 
         self.Ribbon_Scroll_Right = QPushButton(self.IconS)
         self.Ribbon_Scroll_Right.setObjectName("Ribbon_Scroll_Right")
-        sizePolicy6.setHeightForWidth(
-            self.Ribbon_Scroll_Right.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy6.setHeightForWidth(self.Ribbon_Scroll_Right.sizePolicy().hasHeightForWidth())
         self.Ribbon_Scroll_Right.setSizePolicy(sizePolicy6)
         self.Ribbon_Scroll_Right.setMinimumSize(QSize(20, 60))
         self.Ribbon_Scroll_Right.setMaximumSize(QSize(20, 60))
@@ -972,9 +862,7 @@ class Ui_Settings(object):
 
         self.MoreCommands = QPushButton(self.IconS)
         self.MoreCommands.setObjectName("MoreCommands")
-        sizePolicy6.setHeightForWidth(
-            self.MoreCommands.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy6.setHeightForWidth(self.MoreCommands.sizePolicy().hasHeightForWidth())
         self.MoreCommands.setSizePolicy(sizePolicy6)
         self.MoreCommands.setMinimumSize(QSize(30, 20))
         self.MoreCommands.setMaximumSize(QSize(30, 20))
@@ -989,9 +877,7 @@ class Ui_Settings(object):
 
         self.pinButton_open = QPushButton(self.IconS)
         self.pinButton_open.setObjectName("pinButton_open")
-        sizePolicy6.setHeightForWidth(
-            self.pinButton_open.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy6.setHeightForWidth(self.pinButton_open.sizePolicy().hasHeightForWidth())
         self.pinButton_open.setSizePolicy(sizePolicy6)
         self.pinButton_open.setMinimumSize(QSize(30, 30))
         self.pinButton_open.setMaximumSize(QSize(30, 30))
@@ -1005,9 +891,7 @@ class Ui_Settings(object):
 
         self.pinButton_closed = QPushButton(self.IconS)
         self.pinButton_closed.setObjectName("pinButton_closed")
-        sizePolicy6.setHeightForWidth(
-            self.pinButton_closed.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy6.setHeightForWidth(self.pinButton_closed.sizePolicy().hasHeightForWidth())
         self.pinButton_closed.setSizePolicy(sizePolicy6)
         self.pinButton_closed.setMinimumSize(QSize(30, 30))
         self.pinButton_closed.setMaximumSize(QSize(30, 30))
@@ -1021,9 +905,7 @@ class Ui_Settings(object):
 
         self.gridLayout_19.addWidget(self.groupBox_9, 1, 0, 1, 1)
 
-        self.verticalSpacer_2 = QSpacerItem(
-            20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding
-        )
+        self.verticalSpacer_2 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.gridLayout_19.addItem(self.verticalSpacer_2, 2, 0, 1, 1)
 
@@ -1085,17 +967,13 @@ class Ui_Settings(object):
 
         self.gridLayout_35.addLayout(self.gridLayout_20, 0, 0, 1, 1)
 
-        self.horizontalSpacer_5 = QSpacerItem(
-            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
-        )
+        self.horizontalSpacer_5 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_35.addItem(self.horizontalSpacer_5, 0, 2, 1, 1)
 
         self.gridLayout_21.addWidget(self.ColorS, 2, 0, 1, 1)
 
-        self.verticalSpacer_4 = QSpacerItem(
-            20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding
-        )
+        self.verticalSpacer_4 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.gridLayout_21.addItem(self.verticalSpacer_4, 2, 1, 1, 1)
 
@@ -1113,9 +991,7 @@ class Ui_Settings(object):
         self.gridLayout_34.setObjectName("gridLayout_34")
         self.EnableOverlay = QGroupBox(self.tab_3)
         self.EnableOverlay.setObjectName("EnableOverlay")
-        sizePolicy4.setHeightForWidth(
-            self.EnableOverlay.sizePolicy().hasHeightForWidth()
-        )
+        sizePolicy4.setHeightForWidth(self.EnableOverlay.sizePolicy().hasHeightForWidth())
         self.EnableOverlay.setSizePolicy(sizePolicy4)
         self.EnableOverlay.setCheckable(True)
         self.gridLayout_32 = QGridLayout(self.EnableOverlay)
@@ -1137,9 +1013,7 @@ class Ui_Settings(object):
         self.label_26 = QLabel(self.EnableOverlay)
         self.label_26.setObjectName("label_26")
         self.label_26.setEnabled(False)
-        sizePolicy11 = QSizePolicy(
-            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding
-        )
+        sizePolicy11 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding)
         sizePolicy11.setHorizontalStretch(0)
         sizePolicy11.setVerticalStretch(0)
         sizePolicy11.setHeightForWidth(self.label_26.sizePolicy().hasHeightForWidth())
@@ -1150,9 +1024,7 @@ class Ui_Settings(object):
 
         self.gridLayout_32.addLayout(self.gridLayout_30, 0, 0, 2, 2)
 
-        self.horizontalSpacer_10 = QSpacerItem(
-            80, 20, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum
-        )
+        self.horizontalSpacer_10 = QSpacerItem(80, 20, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_32.addItem(self.horizontalSpacer_10, 0, 2, 1, 1)
 
@@ -1162,9 +1034,7 @@ class Ui_Settings(object):
         self.groupBox_11.setObjectName("groupBox_11")
         self.gridLayout_29 = QGridLayout(self.groupBox_11)
         self.gridLayout_29.setObjectName("gridLayout_29")
-        self.horizontalSpacer_8 = QSpacerItem(
-            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
-        )
+        self.horizontalSpacer_8 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_29.addItem(self.horizontalSpacer_8, 0, 1, 1, 1)
 
@@ -1199,9 +1069,7 @@ class Ui_Settings(object):
 
         self.gridLayout_34.addWidget(self.groupBox_11, 0, 0, 1, 1)
 
-        self.verticalSpacer_3 = QSpacerItem(
-            20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding
-        )
+        self.verticalSpacer_3 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.gridLayout_34.addItem(self.verticalSpacer_3, 3, 0, 1, 1)
 
@@ -1213,7 +1081,39 @@ class Ui_Settings(object):
 
         self.gridLayout_6.addWidget(self.scrollArea, 0, 0, 1, 3)
 
-        self.gridLayout_40.addLayout(self.gridLayout_6, 0, 0, 1, 2)
+        self.gridLayout_36.addLayout(self.gridLayout_6, 0, 0, 1, 1)
+
+        self.gridLayout_7 = QGridLayout()
+        self.gridLayout_7.setObjectName("gridLayout_7")
+        self.Cancel = QPushButton(Settings)
+        self.Cancel.setObjectName("Cancel")
+
+        self.gridLayout_7.addWidget(self.Cancel, 0, 3, 1, 1)
+
+        self.horizontalSpacer_2 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.gridLayout_7.addItem(self.horizontalSpacer_2, 0, 1, 1, 1)
+
+        self.horizontalSpacer_11 = QSpacerItem(10, 20, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum)
+
+        self.gridLayout_7.addItem(self.horizontalSpacer_11, 0, 4, 1, 1)
+
+        self.Reset = QPushButton(Settings)
+        self.Reset.setObjectName("Reset")
+
+        self.gridLayout_7.addWidget(self.Reset, 0, 0, 1, 1)
+
+        self.GenerateJsonExit = QPushButton(Settings)
+        self.GenerateJsonExit.setObjectName("GenerateJsonExit")
+
+        self.gridLayout_7.addWidget(self.GenerateJsonExit, 0, 2, 1, 1)
+
+        self.HelpButton = QToolButton(Settings)
+        self.HelpButton.setObjectName("HelpButton")
+
+        self.gridLayout_7.addWidget(self.HelpButton, 0, 5, 1, 1)
+
+        self.gridLayout_36.addLayout(self.gridLayout_7, 1, 0, 1, 1)
 
         self.retranslateUi(Settings)
         self.EnableBackup.toggled.connect(self.groupBox_Backup.setEnabled)
@@ -1231,132 +1131,54 @@ class Ui_Settings(object):
     # setupUi
 
     def retranslateUi(self, Settings):
-        Settings.setWindowTitle(
-            QCoreApplication.translate("Settings", "Preferences", None)
-        )
-        self.Reset.setText(QCoreApplication.translate("Settings", "Reset", None))
-        self.GenerateJsonExit.setText(
-            QCoreApplication.translate("Settings", "Close", None)
-        )
-        # if QT_CONFIG(shortcut)
-        self.GenerateJsonExit.setShortcut("")
-        # endif // QT_CONFIG(shortcut)
-        self.Cancel.setText(QCoreApplication.translate("Settings", "Cancel", None))
-        # if QT_CONFIG(shortcut)
-        self.Cancel.setShortcut(QCoreApplication.translate("Settings", "Esc", None))
-        # endif // QT_CONFIG(shortcut)
-        self.groupBox.setTitle(
-            QCoreApplication.translate("Settings", "Backup settings", None)
-        )
-        self.EnableBackup.setText(
-            QCoreApplication.translate("Settings", "Create backup", None)
-        )
-        self.groupBox_Backup.setTitle(
-            QCoreApplication.translate("Settings", "Backup location", None)
-        )
+        Settings.setWindowTitle(QCoreApplication.translate("Settings", "Preferences", None))
+        self.groupBox.setTitle(QCoreApplication.translate("Settings", "Backup settings", None))
+        self.EnableBackup.setText(QCoreApplication.translate("Settings", "Create backup", None))
+        self.groupBox_Backup.setTitle(QCoreApplication.translate("Settings", "Backup location", None))
         self.label_4.setText(QCoreApplication.translate("Settings", "...\\", None))
-        self.BackUpLocation.setText(
-            QCoreApplication.translate("Settings", "Browse...", None)
-        )
-        self.groupBox1.setTitle(
-            QCoreApplication.translate("Settings", "Ribbon settings", None)
-        )
-        self.groupBox_3.setTitle(
-            QCoreApplication.translate("Settings", "Show text", None)
-        )
-        self.ShowText_Medium.setText(
-            QCoreApplication.translate("Settings", "Medium buttons", None)
-        )
-        self.EnableWrap_Large.setText(
-            QCoreApplication.translate("Settings", "Enable text wrap", None)
-        )
-        self.ShowText_Large.setText(
-            QCoreApplication.translate("Settings", "Large buttons", None)
-        )
-        self.ShowText_Small.setText(
-            QCoreApplication.translate("Settings", "Small buttons", None)
-        )
-        self.EnableWrap_Medium.setText(
-            QCoreApplication.translate("Settings", "Enable text wrap", None)
-        )
-        self.groupBox_10.setTitle(
-            QCoreApplication.translate("Settings", "Tab style", None)
-        )
-        self.TabbarStyle.setItemText(
-            0, QCoreApplication.translate("Settings", "Icon + text", None)
-        )
-        self.TabbarStyle.setItemText(
-            1, QCoreApplication.translate("Settings", "Icon only", None)
-        )
-        self.TabbarStyle.setItemText(
-            2, QCoreApplication.translate("Settings", "Text only", None)
+        self.BackUpLocation.setText(QCoreApplication.translate("Settings", "Browse...", None))
+        self.groupBox1.setTitle(QCoreApplication.translate("Settings", "Ribbon settings", None))
+        self.groupBox_3.setTitle(QCoreApplication.translate("Settings", "Show text", None))
+        self.ShowText_Medium.setText(QCoreApplication.translate("Settings", "Medium buttons", None))
+        self.EnableWrap_Large.setText(QCoreApplication.translate("Settings", "Enable text wrap", None))
+        self.ShowText_Large.setText(QCoreApplication.translate("Settings", "Large buttons", None))
+        self.ShowText_Small.setText(QCoreApplication.translate("Settings", "Small buttons", None))
+        self.EnableWrap_Medium.setText(QCoreApplication.translate("Settings", "Enable text wrap", None))
+        self.groupBox_10.setTitle(QCoreApplication.translate("Settings", "Tab style", None))
+        self.TabbarStyle.setItemText(0, QCoreApplication.translate("Settings", "Icon + text", None))
+        self.TabbarStyle.setItemText(1, QCoreApplication.translate("Settings", "Icon only", None))
+        self.TabbarStyle.setItemText(2, QCoreApplication.translate("Settings", "Text only", None))
+
+        self.TabbarStyle.setCurrentText(QCoreApplication.translate("Settings", "Icon + text", None))
+        self.ToolbarPositions.setItemText(0, QCoreApplication.translate("Settings", "Toolbars above tabbar", None))
+        self.ToolbarPositions.setItemText(
+            1, QCoreApplication.translate("Settings", "Toolbars inline with tabbar", None)
         )
 
-        self.TabbarStyle.setCurrentText(
-            QCoreApplication.translate("Settings", "Icon + text", None)
-        )
-        self.ToolbarPositions.setItemText(
-            0, QCoreApplication.translate("Settings", "Toolbars above tabbar", None)
-        )
-        self.ToolbarPositions.setItemText(
-            1,
-            QCoreApplication.translate("Settings", "Toolbars inline with tabbar", None),
-        )
-
-        self.ToolbarPositions.setCurrentText(
-            QCoreApplication.translate("Settings", "Toolbars above tabbar", None)
-        )
+        self.ToolbarPositions.setCurrentText(QCoreApplication.translate("Settings", "Toolbars above tabbar", None))
         self.label_24.setText(
-            QCoreApplication.translate(
-                "Settings",
-                "<html><head/><body><p>Set the tab style: </p></body></html>",
-                None,
-            )
+            QCoreApplication.translate("Settings", "<html><head/><body><p>Set the tab style: </p></body></html>", None)
         )
         self.label_36.setText(
             QCoreApplication.translate(
-                "Settings",
-                "<html><head/><body><p>Set the toolbar positions: </p></body></html>",
-                None,
+                "Settings", "<html><head/><body><p>Set the toolbar positions: </p></body></html>", None
             )
         )
-        self.HideTitleBarFC.setText(
-            QCoreApplication.translate("Settings", "Hide the titlebar of FreeCAD", None)
-        )
-        self.groupBox_4.setTitle(
-            QCoreApplication.translate("Settings", "Button size", None)
-        )
-        self.label_23.setText(
-            QCoreApplication.translate("Settings", "Size of tabbar tabs:", None)
-        )
-        self.label_22.setText(
-            QCoreApplication.translate(
-                "Settings", "Size of right toolbar buttons:", None
-            )
-        )
-        self.label_5.setText(
-            QCoreApplication.translate("Settings", "Size of application button:", None)
-        )
-        self.label_10.setText(
-            QCoreApplication.translate("Settings", "Size of small buttons:", None)
-        )
+        self.HideTitleBarFC.setText(QCoreApplication.translate("Settings", "Hide the titlebar of FreeCAD", None))
+        self.groupBox_4.setTitle(QCoreApplication.translate("Settings", "Button size", None))
+        self.label_23.setText(QCoreApplication.translate("Settings", "Size of tabbar tabs:", None))
+        self.label_22.setText(QCoreApplication.translate("Settings", "Size of right toolbar buttons:", None))
+        self.label_5.setText(QCoreApplication.translate("Settings", "Size of application button:", None))
+        self.label_10.setText(QCoreApplication.translate("Settings", "Size of small buttons:", None))
         self.label_21.setText(
             QCoreApplication.translate(
-                "Settings",
-                "<html><head/><body><p>Size of quick access toolbar buttons:</p></body></html>",
-                None,
+                "Settings", "<html><head/><body><p>Size of quick access toolbar buttons:</p></body></html>", None
             )
         )
-        self.label_11.setText(
-            QCoreApplication.translate("Settings", "Size of medium buttons:", None)
-        )
-        self.label_25.setText(
-            QCoreApplication.translate("Settings", "Size of large buttons:", None)
-        )
+        self.label_11.setText(QCoreApplication.translate("Settings", "Size of medium buttons:", None))
+        self.label_25.setText(QCoreApplication.translate("Settings", "Size of large buttons:", None))
         self.groupBox_5.setTitle(QCoreApplication.translate("Settings", "Panels", None))
-        self.label.setText(
-            QCoreApplication.translate("Settings", "No. of columns per panel:", None)
-        )
+        self.label.setText(QCoreApplication.translate("Settings", "No. of columns per panel:", None))
         self.label_2.setText(
             QCoreApplication.translate(
                 "Settings",
@@ -1364,31 +1186,15 @@ class Ui_Settings(object):
                 None,
             )
         )
-        self.groupBox_14.setTitle(
-            QCoreApplication.translate("Settings", "Text size", None)
-        )
-        self.label_32.setText(
-            QCoreApplication.translate("Settings", "Text size of menus", None)
-        )
-        self.label_34.setText(
-            QCoreApplication.translate("Settings", "Text size of tabs", None)
-        )
-        self.label_35.setText(
-            QCoreApplication.translate("Settings", "Text size of panel titles", None)
-        )
-        self.label_33.setText(
-            QCoreApplication.translate("Settings", "Text size of buttons", None)
-        )
-        self.groupBox_2.setTitle(
-            QCoreApplication.translate("Settings", "Select stylesheet", None)
-        )
+        self.groupBox_14.setTitle(QCoreApplication.translate("Settings", "Text size", None))
+        self.label_32.setText(QCoreApplication.translate("Settings", "Text size of menus", None))
+        self.label_34.setText(QCoreApplication.translate("Settings", "Text size of tabs", None))
+        self.label_35.setText(QCoreApplication.translate("Settings", "Text size of panel titles", None))
+        self.label_33.setText(QCoreApplication.translate("Settings", "Text size of buttons", None))
+        self.groupBox_2.setTitle(QCoreApplication.translate("Settings", "Select stylesheet", None))
         self.label_7.setText(QCoreApplication.translate("Settings", "...\\", None))
-        self.StyleSheetLocation.setText(
-            QCoreApplication.translate("Settings", "Browse...", None)
-        )
-        self.DebugMode.setText(
-            QCoreApplication.translate("Settings", "Debug mode", None)
-        )
+        self.StyleSheetLocation.setText(QCoreApplication.translate("Settings", "Browse...", None))
+        self.DebugMode.setText(QCoreApplication.translate("Settings", "Debug mode", None))
         self.label_3.setText(
             QCoreApplication.translate(
                 "Settings",
@@ -1397,27 +1203,18 @@ class Ui_Settings(object):
             )
         )
         self.tabWidget.setTabText(
-            self.tabWidget.indexOf(self.General),
-            QCoreApplication.translate("Settings", "General", None),
+            self.tabWidget.indexOf(self.General), QCoreApplication.translate("Settings", "General", None)
         )
-        self.groupBox_6.setTitle(
-            QCoreApplication.translate("Settings", "Mouse settings", None)
-        )
-        self.EnableEnterEvent.setText(
-            QCoreApplication.translate("Settings", "Show ribbon on hover. ", None)
-        )
+        self.groupBox_6.setTitle(QCoreApplication.translate("Settings", "Mouse settings", None))
+        self.EnableEnterEvent.setText(QCoreApplication.translate("Settings", "Show ribbon on hover. ", None))
         self.label_12.setText(
             QCoreApplication.translate(
-                "Settings",
-                "<html><head/><body><p>Scroll speed for ribbon:</p></body></html>",
-                None,
+                "Settings", "<html><head/><body><p>Scroll speed for ribbon:</p></body></html>", None
             )
         )
         self.label_13.setText(
             QCoreApplication.translate(
-                "Settings",
-                "<html><head/><body><p>Scroll speed for tab bar:</p></body></html>",
-                None,
+                "Settings", "<html><head/><body><p>Scroll speed for tab bar:</p></body></html>", None
             )
         )
         self.label_41.setText(
@@ -1427,104 +1224,64 @@ class Ui_Settings(object):
                 None,
             )
         )
-        self.groupBox_7.setTitle(
-            QCoreApplication.translate("Settings", "Scroll buttons", None)
-        )
+        self.groupBox_7.setTitle(QCoreApplication.translate("Settings", "Scroll buttons", None))
         self.label_14.setText(
             QCoreApplication.translate(
-                "Settings",
-                "<html><head/><body><p>Scroll steps per click for ribbon:</p></body></html>",
-                None,
+                "Settings", "<html><head/><body><p>Scroll steps per click for ribbon:</p></body></html>", None
             )
         )
         self.label_15.setText(
             QCoreApplication.translate(
-                "Settings",
-                "<html><head/><body><p>Scroll steps per click for tab bar:</p></body></html>",
-                None,
+                "Settings", "<html><head/><body><p>Scroll steps per click for tab bar:</p></body></html>", None
             )
         )
         self.tabWidget.setTabText(
-            self.tabWidget.indexOf(self.tab),
-            QCoreApplication.translate("Settings", "Navigation", None),
+            self.tabWidget.indexOf(self.tab), QCoreApplication.translate("Settings", "Navigation", None)
         )
         self.groupBox_9.setTitle(QCoreApplication.translate("Settings", "Icons", None))
-        self.CustomIcons.setText(
-            QCoreApplication.translate("Settings", "Enable custom icons", None)
-        )
+        self.CustomIcons.setText(QCoreApplication.translate("Settings", "Enable custom icons", None))
         self.label_16.setText(
-            QCoreApplication.translate(
-                "Settings",
-                "<html><head/><body><p>Tab bar scroll left:</p></body></html>",
-                None,
-            )
+            QCoreApplication.translate("Settings", "<html><head/><body><p>Tab bar scroll left:</p></body></html>", None)
         )
         self.Tab_Scroll_Left.setText("")
-        self.label_17.setText(
-            QCoreApplication.translate("Settings", "Tab bar scroll right:", None)
-        )
+        self.label_17.setText(QCoreApplication.translate("Settings", "Tab bar scroll right:", None))
         self.Tab_Scroll_Right.setText("")
-        self.label_18.setText(
-            QCoreApplication.translate("Settings", "Ribbon bar scroll left:", None)
-        )
+        self.label_18.setText(QCoreApplication.translate("Settings", "Ribbon bar scroll left:", None))
         self.Ribbon_Scroll_Left.setText("")
         self.label_19.setText(
             QCoreApplication.translate(
-                "Settings",
-                "<html><head/><body><p>Ribbon bar scroll right:</p></body></html>",
-                None,
+                "Settings", "<html><head/><body><p>Ribbon bar scroll right:</p></body></html>", None
             )
         )
         self.Ribbon_Scroll_Right.setText("")
         self.label_20.setText(
             QCoreApplication.translate(
-                "Settings",
-                "<html><head/><body><p>More commands button:</p></body></html>",
-                None,
+                "Settings", "<html><head/><body><p>More commands button:</p></body></html>", None
             )
         )
         self.MoreCommands.setText("")
-        self.label_28.setText(
-            QCoreApplication.translate("Settings", "Pin button - unpinned:", None)
-        )
+        self.label_28.setText(QCoreApplication.translate("Settings", "Pin button - unpinned:", None))
         self.pinButton_open.setText("")
-        self.label_29.setText(
-            QCoreApplication.translate("Settings", "Pin button - pinned:", None)
-        )
+        self.label_29.setText(QCoreApplication.translate("Settings", "Pin button - pinned:", None))
         self.pinButton_closed.setText("")
         self.groupBox_8.setTitle(QCoreApplication.translate("Settings", "Colors", None))
-        self.CustomColors.setText(
-            QCoreApplication.translate("Settings", "Enable custom colors", None)
-        )
+        self.CustomColors.setText(QCoreApplication.translate("Settings", "Enable custom colors", None))
         self.label_30.setText(
-            QCoreApplication.translate(
-                "Settings", "Set the color for buttons when hovering over them", None
-            )
+            QCoreApplication.translate("Settings", "Set the color for buttons when hovering over them", None)
         )
         self.label_6.setText(
-            QCoreApplication.translate(
-                "Settings",
-                "Set the color for control borders when hovering over them:",
-                None,
-            )
+            QCoreApplication.translate("Settings", "Set the color for control borders when hovering over them:", None)
         )
         self.label_9.setText(
-            QCoreApplication.translate(
-                "Settings", "Set the background color for the application button:", None
-            )
+            QCoreApplication.translate("Settings", "Set the background color for the application button:", None)
         )
         self.BorderTransparant.setText(
-            QCoreApplication.translate(
-                "Settings", "Set border invisible for ribbon buttons", None
-            )
+            QCoreApplication.translate("Settings", "Set border invisible for ribbon buttons", None)
         )
         self.tabWidget.setTabText(
-            self.tabWidget.indexOf(self.tab_2),
-            QCoreApplication.translate("Settings", "Colors and icons", None),
+            self.tabWidget.indexOf(self.tab_2), QCoreApplication.translate("Settings", "Colors and icons", None)
         )
-        self.EnableOverlay.setTitle(
-            QCoreApplication.translate("Settings", "Enable overlay", None)
-        )
+        self.EnableOverlay.setTitle(QCoreApplication.translate("Settings", "Enable overlay", None))
         # if QT_CONFIG(tooltip)
         self.FCOverlayEnabled.setToolTip(
             QCoreApplication.translate(
@@ -1535,14 +1292,8 @@ class Ui_Settings(object):
             )
         )
         # endif // QT_CONFIG(tooltip)
-        self.FCOverlayEnabled.setText(
-            QCoreApplication.translate(
-                "Settings", "Use FreeCAD's overlay function.", None
-            )
-        )
-        self.UseButtonBackGround.setText(
-            QCoreApplication.translate("Settings", "Use background on buttons", None)
-        )
+        self.FCOverlayEnabled.setText(QCoreApplication.translate("Settings", "Use FreeCAD's overlay function.", None))
+        self.UseButtonBackGround.setText(QCoreApplication.translate("Settings", "Use background on buttons", None))
         self.label_26.setText(
             QCoreApplication.translate(
                 "Settings",
@@ -1550,33 +1301,26 @@ class Ui_Settings(object):
                 None,
             )
         )
-        self.groupBox_11.setTitle(
-            QCoreApplication.translate("Settings", "Standard panels preference", None)
-        )
-        self.label_27.setText(
-            QCoreApplication.translate(
-                "Settings", "Select preferred standard view panel: ", None
-            )
-        )
-        self.PreferedViewPanel.setItemText(
-            0, QCoreApplication.translate("Settings", "Individual views - Native", None)
-        )
-        self.PreferedViewPanel.setItemText(
-            1, QCoreApplication.translate("Settings", "Views - Native", None)
-        )
-        self.PreferedViewPanel.setItemText(
-            2, QCoreApplication.translate("Settings", "Views - Ribbon", None)
-        )
-        self.PreferedViewPanel.setItemText(
-            3, QCoreApplication.translate("Settings", "None", None)
-        )
+        self.groupBox_11.setTitle(QCoreApplication.translate("Settings", "Standard panels preference", None))
+        self.label_27.setText(QCoreApplication.translate("Settings", "Select preferred standard view panel: ", None))
+        self.PreferedViewPanel.setItemText(0, QCoreApplication.translate("Settings", "Individual views - Native", None))
+        self.PreferedViewPanel.setItemText(1, QCoreApplication.translate("Settings", "Views - Native", None))
+        self.PreferedViewPanel.setItemText(2, QCoreApplication.translate("Settings", "Views - Ribbon", None))
+        self.PreferedViewPanel.setItemText(3, QCoreApplication.translate("Settings", "None", None))
 
-        self.EnableToolsPanel.setText(
-            QCoreApplication.translate("Settings", "Use standard Tools panel", None)
-        )
+        self.EnableToolsPanel.setText(QCoreApplication.translate("Settings", "Use standard Tools panel", None))
         self.tabWidget.setTabText(
-            self.tabWidget.indexOf(self.tab_3),
-            QCoreApplication.translate("Settings", "Miscellaneous", None),
+            self.tabWidget.indexOf(self.tab_3), QCoreApplication.translate("Settings", "Miscellaneous", None)
         )
+        self.Cancel.setText(QCoreApplication.translate("Settings", "Cancel", None))
+        # if QT_CONFIG(shortcut)
+        self.Cancel.setShortcut(QCoreApplication.translate("Settings", "Esc", None))
+        # endif // QT_CONFIG(shortcut)
+        self.Reset.setText(QCoreApplication.translate("Settings", "Reset", None))
+        self.GenerateJsonExit.setText(QCoreApplication.translate("Settings", "Close", None))
+        # if QT_CONFIG(shortcut)
+        self.GenerateJsonExit.setShortcut("")
+        # endif // QT_CONFIG(shortcut)
+        self.HelpButton.setText(QCoreApplication.translate("Settings", "...", None))
 
     # retranslateUi

--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
 
   <description>A Ribbon interface for FreeCAD</description>
 
-  <version>1.8.1</version>
+  <version>1.9.x</version>
 
   <date>2024-07-28</date>
 

--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
 
   <description>A Ribbon interface for FreeCAD</description>
 
-  <version>1.9.x</version>
+  <version>1.9.0</version>
 
   <date>2024-07-28</date>
 

--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,7 @@
       <subdirectory>./</subdirectory>
       <!-- Optional install of 3rd-party SearchBar to streamline ability to Search and find commands -->
       <depend type="addon" optional="true">SearchBar</depend>
+      <depend type="addon" optional="true">SaveAndRestore</depend>
       <depend type="python" optional="true">git</depend>
       <depend type="python" optional="true">gitpython</depend>
     </workbench>


### PR DESCRIPTION
- The "Save and restore" add-on is added as an option to the install of this add-on.  
  This "Save and restore" add-on can be used to restore toolbars after disabling the ribbon
  ![image](https://github.com/user-attachments/assets/beb2701b-be5f-404a-a691-69e15f2dd6d4)  
  See [https://github.com/APEbbers/SaveAndRestore](url) for more details.
- It is now possible to set toolbars to the left, right and bottom.
- a helpbutton is added to the preferences dialog