### PR TITLE
Make text on tabs transparent when style is Icon only

### DIFF
--- a/FCBinding.py
+++ b/FCBinding.py
@@ -600,9 +600,7 @@ class ModernMenu(RibbonBar):
                 """QTabBar::tab:selected, QTabBar::tab:hover {
                 background: """
                 + StyleMapping_Ribbon.ReturnStyleItem("Background_Color_Hover")
-                + """;color: """
-                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color_Hover")
-                + """;}"""
+                + """;color: transparent;}"""
             )
         StyleSheet = StyleSheet_Addition_4 + StyleSheet
         self.setStyleSheet(StyleSheet)
@@ -2098,9 +2096,7 @@ class ModernMenu(RibbonBar):
             self.tabBar().setStyleSheet(
                 """QTabBar::tab {background: """
                 + StyleMapping_Ribbon.ReturnStyleItem("Background_Color", True, True)
-                + """;color: """
-                + StyleMapping_Ribbon.ReturnStyleItem("Background_Color", True, True)
-                + """;}"""
+                + """;color: transparent;}"""
                 + """QTabBar::tab:selected, QTabBar::tab:hover {
                 background: """
                 + StyleMapping_Ribbon.ReturnStyleItem("Background_Color_Hover")


### PR DESCRIPTION
Fix for issue #397.

When editing this, I have also noticed: On line 602, should there be `Background_Color` instead of `Background_Color_Hover`?